### PR TITLE
feat: add Slideover component with bits-ui Dialog integration

### DIFF
--- a/src/lib/Slideover/Slideover.svelte
+++ b/src/lib/Slideover/Slideover.svelte
@@ -1,0 +1,182 @@
+<script lang="ts" module>
+    import type { SlideoverProps } from './slideover.types.js'
+
+    export type Props = SlideoverProps
+</script>
+
+<script lang="ts">
+    import { Dialog } from 'bits-ui'
+    import { slideoverVariants, slideoverDefaults } from './slideover.variants.js'
+    import { getComponentConfig } from '../config.js'
+    import Button from '../Button/Button.svelte'
+
+    const config = getComponentConfig('slideover', slideoverDefaults)
+
+    let {
+        open = $bindable(false),
+        onOpenChange,
+        onOpenChangeComplete,
+        trapFocus = true,
+        preventScroll = true,
+        onOpenAutoFocus,
+        onCloseAutoFocus,
+        onEscapeKeydown,
+        onInteractOutside,
+        forceMount,
+        restoreScrollDelay,
+        title,
+        description,
+        side = config.defaultVariants.side ?? 'right',
+        overlay: showOverlay = config.defaultVariants.overlay ?? true,
+        transition = config.defaultVariants.transition ?? true,
+        inset = config.defaultVariants.inset ?? false,
+        portal = true,
+        close: closeProp = true,
+        dismissible = true,
+        ui,
+        class: className,
+        children,
+        content: contentSlot,
+        header: headerSlot,
+        titleSlot,
+        descriptionSlot,
+        body: bodySlot,
+        footer: footerSlot,
+        closeSlot
+    }: Props = $props()
+
+    const showClose = $derived(!!closeProp)
+    const closeProps = $derived(typeof closeProp === 'object' ? closeProp : {})
+
+    const hasTitle = $derived(!!title || !!titleSlot)
+    const hasDescription = $derived(!!description || !!descriptionSlot)
+    const hasHeading = $derived(hasTitle || hasDescription)
+    const hasHeader = $derived(!!headerSlot || hasHeading || showClose || !!closeSlot)
+
+    const variantSlots = $derived(slideoverVariants({ transition, side, inset, overlay: showOverlay }))
+
+    const classes = $derived({
+        overlay: variantSlots.overlay({ class: [config.slots.overlay, ui?.overlay] }),
+        content: variantSlots.content({ class: [config.slots.content, ui?.content] }),
+        header: variantSlots.header({ class: [config.slots.header, ui?.header] }),
+        wrapper: variantSlots.wrapper({ class: [config.slots.wrapper, ui?.wrapper] }),
+        title: variantSlots.title({ class: [config.slots.title, ui?.title] }),
+        description: variantSlots.description({ class: [config.slots.description, ui?.description] }),
+        body: variantSlots.body({ class: [config.slots.body, ui?.body] }),
+        footer: variantSlots.footer({ class: [config.slots.footer, ui?.footer] }),
+        close: variantSlots.close({ class: [config.slots.close, ui?.close] })
+    })
+
+    const contentProps = $derived.by(() => {
+        const behavior = dismissible ? 'close' as const : 'ignore' as const
+        return {
+            trapFocus,
+            preventScroll,
+            escapeKeydownBehavior: behavior,
+            interactOutsideBehavior: behavior,
+            onOpenAutoFocus,
+            onCloseAutoFocus,
+            onEscapeKeydown,
+            onInteractOutside,
+            forceMount,
+            restoreScrollDelay
+        }
+    })
+
+    function handleOpenChange(value: boolean) {
+        open = value
+        onOpenChange?.(value)
+    }
+</script>
+
+{#snippet titleEl()}
+    {#if titleSlot}{@render titleSlot()}{:else}{title}{/if}
+{/snippet}
+
+{#snippet descriptionEl()}
+    {#if descriptionSlot}{@render descriptionSlot()}{:else}{description}{/if}
+{/snippet}
+
+{#snippet slideoverContentInner()}
+    <Dialog.Content
+        {...contentProps}
+        class={[classes.content, !children ? className : undefined]}
+    >
+        {#if contentSlot}
+            {#if hasHeading}
+                <div class="sr-only">
+                    {#if hasTitle}<Dialog.Title>{@render titleEl()}</Dialog.Title>{/if}
+                    {#if hasDescription}<Dialog.Description>{@render descriptionEl()}</Dialog.Description>{/if}
+                </div>
+            {/if}
+            {@render contentSlot()}
+        {:else}
+            {#if hasHeader}
+                <div class={classes.header}>
+                    {#if headerSlot}
+                        {@render headerSlot()}
+                    {:else}
+                        <div class={classes.wrapper}>
+                            {#if hasTitle}
+                                <Dialog.Title class={classes.title}>{@render titleEl()}</Dialog.Title>
+                            {/if}
+                            {#if hasDescription}
+                                <Dialog.Description class={classes.description}>{@render descriptionEl()}</Dialog.Description>
+                            {/if}
+                        </div>
+
+                        {#if showClose || closeSlot}
+                            <Dialog.Close>
+                                {#snippet child({ props })}
+                                    {#if closeSlot}
+                                        <span {...props} class={classes.close}>{@render closeSlot()}</span>
+                                    {:else}
+                                        <Button
+                                            {...props}
+                                            leadingIcon={closeProps.icon ?? 'lucide:x'}
+                                            color={closeProps.color ?? 'surface'}
+                                            variant={closeProps.variant ?? 'ghost'}
+                                            size={closeProps.size ?? 'sm'}
+                                            square
+                                            aria-label="Close"
+                                            class={classes.close}
+                                        />
+                                    {/if}
+                                {/snippet}
+                            </Dialog.Close>
+                        {/if}
+                    {/if}
+                </div>
+            {/if}
+
+            {#if bodySlot}
+                <div class={classes.body}>{@render bodySlot()}</div>
+            {/if}
+
+            {#if footerSlot}
+                <div class={classes.footer}>{@render footerSlot()}</div>
+            {/if}
+        {/if}
+    </Dialog.Content>
+{/snippet}
+
+{#snippet slideoverPortalContent()}
+    {#if showOverlay}
+        <Dialog.Overlay class={classes.overlay} />
+    {/if}
+    {@render slideoverContentInner()}
+{/snippet}
+
+<Dialog.Root bind:open onOpenChange={handleOpenChange} {onOpenChangeComplete}>
+    {#if children}
+        <Dialog.Trigger class={className as string}>
+            {@render children()}
+        </Dialog.Trigger>
+    {/if}
+
+    {#if portal}
+        <Dialog.Portal>{@render slideoverPortalContent()}</Dialog.Portal>
+    {:else}
+        {@render slideoverPortalContent()}
+    {/if}
+</Dialog.Root>

--- a/src/lib/Slideover/Slideover.svelte.spec.ts
+++ b/src/lib/Slideover/Slideover.svelte.spec.ts
@@ -1,0 +1,503 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-svelte'
+import { page } from 'vitest/browser'
+import Slideover from './Slideover.svelte'
+
+describe('Slideover', () => {
+    const getOverlay = () => document.querySelector('[data-dialog-overlay]') as HTMLElement | null
+    const getContent = () => document.querySelector('[data-dialog-content]') as HTMLElement | null
+    const getClose = () => document.querySelector('[data-dialog-close]') as HTMLElement | null
+
+    // ==================== RENDERING ====================
+
+    describe('rendering', () => {
+        it('should render without crashing', () => {
+            const { container } = render(Slideover)
+            expect(container).not.toBeNull()
+        })
+
+        it('should not render content when closed', () => {
+            render(Slideover, { title: 'Test' })
+            expect(getContent()).toBeNull()
+        })
+
+        it('should render content when open', async () => {
+            render(Slideover, { open: true, title: 'Test' })
+            await expect.element(page.getByText('Test')).toBeVisible()
+        })
+
+        it('should render overlay when open', async () => {
+            render(Slideover, { open: true, title: 'Test' })
+            await vi.waitFor(() => {
+                expect(getOverlay()).not.toBeNull()
+            })
+        })
+
+        it('should render close button by default when open', async () => {
+            render(Slideover, { open: true, title: 'Test' })
+            await vi.waitFor(() => {
+                expect(getClose()).not.toBeNull()
+            })
+        })
+    })
+
+    // ==================== TITLE & DESCRIPTION ====================
+
+    describe('title and description', () => {
+        it('should render title text', async () => {
+            render(Slideover, { open: true, title: 'My Title' })
+            await expect.element(page.getByText('My Title')).toBeVisible()
+        })
+
+        it('should render description text', async () => {
+            render(Slideover, { open: true, title: 'Title', description: 'My Description' })
+            await expect.element(page.getByText('My Description')).toBeVisible()
+        })
+
+        it('should render both title and description', async () => {
+            render(Slideover, { open: true, title: 'Title', description: 'Desc' })
+            await expect.element(page.getByText('Title')).toBeVisible()
+            await expect.element(page.getByText('Desc')).toBeVisible()
+        })
+    })
+
+    // ==================== SIDE VARIANTS ====================
+
+    describe('side variants', () => {
+        it('should apply right side classes by default', async () => {
+            render(Slideover, { open: true, title: 'Test' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('right-0')
+                expect(content!.className).toContain('inset-y-0')
+            })
+        })
+
+        it('should apply left side classes', async () => {
+            render(Slideover, { open: true, title: 'Test', side: 'left' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('left-0')
+                expect(content!.className).toContain('inset-y-0')
+            })
+        })
+
+        it('should apply top side classes', async () => {
+            render(Slideover, { open: true, title: 'Test', side: 'top' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('top-0')
+                expect(content!.className).toContain('inset-x-0')
+            })
+        })
+
+        it('should apply bottom side classes', async () => {
+            render(Slideover, { open: true, title: 'Test', side: 'bottom' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('bottom-0')
+                expect(content!.className).toContain('inset-x-0')
+            })
+        })
+    })
+
+    // ==================== INSET MODE ====================
+
+    describe('inset mode', () => {
+        it('should not have rounded corners by default (non-inset)', async () => {
+            render(Slideover, { open: true, title: 'Test' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).not.toContain('rounded-xl')
+            })
+        })
+
+        it('should apply inset styling with rounded corners', async () => {
+            render(Slideover, { open: true, title: 'Test', inset: true })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('rounded-xl')
+                expect(content!.className).toContain('ring')
+            })
+        })
+
+        it('should apply inset margins for right side while keeping max-width', async () => {
+            render(Slideover, { open: true, title: 'Test', side: 'right', inset: true })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('right-4')
+                expect(content!.className).toContain('inset-y-4')
+                expect(content!.className).toContain('max-w-md')
+            })
+        })
+
+        it('should apply inset margins for left side while keeping max-width', async () => {
+            render(Slideover, { open: true, title: 'Test', side: 'left', inset: true })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('left-4')
+                expect(content!.className).toContain('inset-y-4')
+                expect(content!.className).toContain('max-w-md')
+            })
+        })
+
+        it('should apply inset margins for top side', async () => {
+            render(Slideover, { open: true, title: 'Test', side: 'top', inset: true })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('top-4')
+                expect(content!.className).toContain('inset-x-4')
+            })
+        })
+
+        it('should apply inset margins for bottom side', async () => {
+            render(Slideover, { open: true, title: 'Test', side: 'bottom', inset: true })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('bottom-4')
+                expect(content!.className).toContain('inset-x-4')
+            })
+        })
+    })
+
+    // ==================== TRANSITION ====================
+
+    describe('transition', () => {
+        it('should apply transition animation classes by default', async () => {
+            render(Slideover, { open: true, title: 'Test' })
+            await vi.waitFor(() => {
+                const overlay = getOverlay()
+                expect(overlay).not.toBeNull()
+                expect(overlay!.className).toMatch(/animate-/)
+            })
+        })
+
+        it('should not apply transition classes when transition is false', async () => {
+            render(Slideover, { open: true, title: 'Test', transition: false })
+            await vi.waitFor(() => {
+                const overlay = getOverlay()
+                expect(overlay).not.toBeNull()
+                expect(overlay!.className).not.toMatch(/animate-/)
+            })
+        })
+
+        it('should apply side-specific transition for right', async () => {
+            render(Slideover, { open: true, title: 'Test', side: 'right' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('slide-in-full-right')
+            })
+        })
+
+        it('should apply side-specific transition for left', async () => {
+            render(Slideover, { open: true, title: 'Test', side: 'left' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('slide-in-full-left')
+            })
+        })
+
+        it('should apply side-specific transition for top', async () => {
+            render(Slideover, { open: true, title: 'Test', side: 'top' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('slide-in-full-top')
+            })
+        })
+
+        it('should apply side-specific transition for bottom', async () => {
+            render(Slideover, { open: true, title: 'Test', side: 'bottom' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('slide-in-full-bottom')
+            })
+        })
+    })
+
+    // ==================== OVERLAY ====================
+
+    describe('overlay', () => {
+        it('should render overlay with bg class when overlay is true', async () => {
+            render(Slideover, { open: true, title: 'Test' })
+            await vi.waitFor(() => {
+                const overlay = getOverlay()
+                expect(overlay).not.toBeNull()
+                expect(overlay!.className).toContain('bg-on-surface/50')
+            })
+        })
+
+        it('should not render overlay when overlay is false', async () => {
+            render(Slideover, { open: true, title: 'Test', overlay: false })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+            })
+            expect(getOverlay()).toBeNull()
+        })
+    })
+
+    // ==================== CLOSE BUTTON ====================
+
+    describe('close button', () => {
+        it('should render close button by default', async () => {
+            render(Slideover, { open: true, title: 'Test' })
+            await vi.waitFor(() => {
+                expect(getClose()).not.toBeNull()
+            })
+        })
+
+        it('should hide close button when close is false', async () => {
+            render(Slideover, { open: true, title: 'Test', close: false })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+            })
+            expect(getClose()).toBeNull()
+        })
+    })
+
+    // ==================== DISMISSIBLE ====================
+
+    describe('dismissible', () => {
+        it('should render with default dismissible behavior', async () => {
+            render(Slideover, { open: true, title: 'Test' })
+            await vi.waitFor(() => {
+                expect(getContent()).not.toBeNull()
+            })
+        })
+
+        it('should render with non-dismissible behavior', async () => {
+            render(Slideover, { open: true, title: 'Test', dismissible: false })
+            await vi.waitFor(() => {
+                expect(getContent()).not.toBeNull()
+            })
+        })
+    })
+
+    // ==================== CALLBACKS ====================
+
+    describe('callbacks', () => {
+        it('should call onOpenChange when open state changes', async () => {
+            const onOpenChange = vi.fn()
+            render(Slideover, { open: true, title: 'Test', onOpenChange })
+            await vi.waitFor(() => {
+                expect(getContent()).not.toBeNull()
+            })
+            expect(onOpenChange).toBeTypeOf('function')
+        })
+    })
+
+    // ==================== CONTENT LAYOUT ====================
+
+    describe('content layout', () => {
+        it('should render header with title', async () => {
+            render(Slideover, { open: true, title: 'My Title' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.textContent).toContain('My Title')
+            })
+        })
+
+        it('should render header with title and description', async () => {
+            render(Slideover, { open: true, title: 'Title', description: 'Description' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.textContent).toContain('Title')
+                expect(content!.textContent).toContain('Description')
+            })
+        })
+    })
+
+    // ==================== VARIANT CLASSES ====================
+
+    describe('variant classes', () => {
+        it('should apply overlay base classes', async () => {
+            render(Slideover, { open: true, title: 'Test' })
+            await vi.waitFor(() => {
+                const overlay = getOverlay()
+                expect(overlay).not.toBeNull()
+                expect(overlay!.className).toContain('fixed')
+                expect(overlay!.className).toContain('inset-0')
+                expect(overlay!.className).toContain('z-50')
+            })
+        })
+
+        it('should apply content base classes', async () => {
+            render(Slideover, { open: true, title: 'Test' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('z-50')
+                expect(content!.className).toContain('bg-surface-container-low')
+            })
+        })
+    })
+
+    // ==================== UI SLOT OVERRIDES ====================
+
+    describe('ui slot overrides', () => {
+        it('should apply ui.overlay class', async () => {
+            render(Slideover, { open: true, title: 'Test', ui: { overlay: 'custom-overlay' } })
+            await vi.waitFor(() => {
+                const overlay = getOverlay()
+                expect(overlay).not.toBeNull()
+                expect(overlay!.className).toContain('custom-overlay')
+            })
+        })
+
+        it('should apply ui.content class', async () => {
+            render(Slideover, { open: true, title: 'Test', ui: { content: 'custom-content' } })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('custom-content')
+            })
+        })
+
+        it('should apply ui.header class', async () => {
+            render(Slideover, { open: true, title: 'Test', ui: { header: 'custom-header' } })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                const header = content!.querySelector('.custom-header')
+                expect(header).not.toBeNull()
+            })
+        })
+
+        it('should apply ui.title class', async () => {
+            render(Slideover, { open: true, title: 'Test Title', ui: { title: 'custom-title' } })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                const title = content!.querySelector('.custom-title')
+                expect(title).not.toBeNull()
+                expect(title!.textContent).toContain('Test Title')
+            })
+        })
+
+        it('should apply ui.description class', async () => {
+            render(Slideover, {
+                open: true,
+                title: 'Title',
+                description: 'Test Desc',
+                ui: { description: 'custom-desc' }
+            })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                const desc = content!.querySelector('.custom-desc')
+                expect(desc).not.toBeNull()
+                expect(desc!.textContent).toContain('Test Desc')
+            })
+        })
+    })
+
+    // ==================== PORTAL ====================
+
+    describe('portal', () => {
+        it('should render content in body when portal is true (default)', async () => {
+            const { container } = render(Slideover, { open: true, title: 'Test' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(container.contains(content)).toBe(false)
+                expect(document.body.contains(content)).toBe(true)
+            })
+        })
+    })
+
+    // ==================== COMBINED FEATURES ====================
+
+    describe('combined features', () => {
+        it('should render inset + no close button', async () => {
+            render(Slideover, {
+                open: true,
+                title: 'Inset Panel',
+                description: 'Inset slideover',
+                inset: true,
+                close: false
+            })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('rounded-xl')
+                expect(content!.textContent).toContain('Inset Panel')
+                expect(content!.textContent).toContain('Inset slideover')
+            })
+            expect(getClose()).toBeNull()
+        })
+
+        it('should render non-dismissible with no overlay', async () => {
+            render(Slideover, {
+                open: true,
+                title: 'Minimal',
+                overlay: false,
+                dismissible: false
+            })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.textContent).toContain('Minimal')
+            })
+            expect(getOverlay()).toBeNull()
+        })
+
+        it('should render left side with inset', async () => {
+            render(Slideover, {
+                open: true,
+                title: 'Left Inset',
+                side: 'left',
+                inset: true
+            })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('left-4')
+                expect(content!.className).toContain('rounded-xl')
+            })
+        })
+
+        it('should render with all ui overrides', async () => {
+            render(Slideover, {
+                open: true,
+                title: 'Full Override',
+                description: 'Override desc',
+                ui: {
+                    overlay: 'ov-custom',
+                    content: 'ct-custom',
+                    header: 'hd-custom',
+                    title: 'tt-custom',
+                    description: 'dc-custom'
+                }
+            })
+            await vi.waitFor(() => {
+                const overlay = getOverlay()
+                expect(overlay).not.toBeNull()
+                expect(overlay!.className).toContain('ov-custom')
+
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('ct-custom')
+                expect(content!.querySelector('.hd-custom')).not.toBeNull()
+                expect(content!.querySelector('.tt-custom')).not.toBeNull()
+                expect(content!.querySelector('.dc-custom')).not.toBeNull()
+            })
+        })
+    })
+})

--- a/src/lib/Slideover/index.ts
+++ b/src/lib/Slideover/index.ts
@@ -1,0 +1,3 @@
+export { default as Slideover } from './Slideover.svelte'
+export type { SlideoverProps, SlideoverCloseProps } from './slideover.types.js'
+export type { SlideoverSide } from './slideover.variants.js'

--- a/src/lib/Slideover/slideover.types.ts
+++ b/src/lib/Slideover/slideover.types.ts
@@ -1,0 +1,181 @@
+import type { Snippet } from 'svelte'
+import type { ClassNameValue } from 'tailwind-merge'
+import type { SlideoverSlots, SlideoverVariantProps } from './slideover.variants.js'
+import type {
+    DialogRootPropsWithoutHTML,
+    DialogContentPropsWithoutHTML
+} from 'bits-ui'
+import type { ButtonVariantProps } from '../Button/button.variants.js'
+
+/**
+ * Props inherited from bits-ui's Dialog root.
+ */
+type RootProps = Pick<
+    DialogRootPropsWithoutHTML,
+    | 'open'
+    | 'onOpenChange'
+    | 'onOpenChangeComplete'
+>
+
+/**
+ * Props inherited from bits-ui's Dialog content.
+ */
+type ContentProps = Pick<
+    DialogContentPropsWithoutHTML,
+    | 'trapFocus'
+    | 'preventScroll'
+    | 'onOpenAutoFocus'
+    | 'onCloseAutoFocus'
+    | 'onEscapeKeydown'
+    | 'onInteractOutside'
+    | 'forceMount'
+    | 'restoreScrollDelay'
+>
+
+/**
+ * Props for customizing the close button appearance.
+ */
+export interface SlideoverCloseProps {
+    /** Button color scheme. */
+    color?: NonNullable<ButtonVariantProps['color']>
+    /** Button visual style. */
+    variant?: NonNullable<ButtonVariantProps['variant']>
+    /** Button size. */
+    size?: NonNullable<ButtonVariantProps['size']>
+    /** Icon displayed inside the close button. Supports any Iconify icon name. */
+    icon?: string
+}
+
+export interface SlideoverProps extends RootProps, ContentProps {
+    // --- Content ---
+
+    /**
+     * Title text displayed in the slideover header.
+     * Rendered inside an accessible `Dialog.Title` element.
+     */
+    title?: string
+
+    /**
+     * Description text displayed below the title.
+     * Rendered inside an accessible `Dialog.Description` element.
+     */
+    description?: string
+
+    // --- Variants ---
+
+    /**
+     * The side of the screen the slideover appears from.
+     * @default 'right'
+     */
+    side?: SlideoverVariantProps['side']
+
+    /**
+     * Render a backdrop overlay behind the slideover.
+     * @default true
+     */
+    overlay?: SlideoverVariantProps['overlay']
+
+    /**
+     * Animate the slideover on open and close.
+     * @default true
+     */
+    transition?: SlideoverVariantProps['transition']
+
+    /**
+     * Display the slideover with inset margins and rounded corners.
+     * @default false
+     */
+    inset?: SlideoverVariantProps['inset']
+
+    // --- Behavior ---
+
+    /**
+     * Render the slideover content in a portal appended to `<body>`.
+     * @default true
+     */
+    portal?: boolean
+
+    /**
+     * Display a close button in the slideover header.
+     * Pass `true` for the default close button, or an object
+     * to customize the button appearance.
+     *
+     * @example
+     * ```svelte
+     * <!-- Default close button -->
+     * <Slideover close title="Title" />
+     *
+     * <!-- Customized close button -->
+     * <Slideover close={{ color: 'error', size: 'xs' }} title="Title" />
+     * ```
+     *
+     * @default true
+     */
+    close?: boolean | SlideoverCloseProps
+
+    /**
+     * Allow dismissing the slideover by clicking outside or pressing Escape.
+     * When `false`, only programmatic close or the close button can dismiss.
+     * @default true
+     */
+    dismissible?: boolean
+
+    // --- Styling ---
+
+    /**
+     * Override classes for specific slideover slots.
+     */
+    ui?: Partial<Record<SlideoverSlots, ClassNameValue>>
+
+    /**
+     * Additional CSS classes for the trigger element,
+     * or the content element when no trigger is provided.
+     */
+    class?: ClassNameValue
+
+    // --- Slots ---
+
+    /**
+     * Default slot content used as the trigger element.
+     * When provided, clicking this element opens the slideover.
+     */
+    children?: Snippet
+
+    /**
+     * Custom content slot that replaces the entire default layout
+     * (header, body, footer). Title and description are rendered
+     * in a screen-reader-only container for accessibility.
+     */
+    content?: Snippet
+
+    /**
+     * Custom header slot that replaces the default header
+     * containing title, description, and close button.
+     */
+    header?: Snippet
+
+    /**
+     * Custom title slot. Overrides the `title` prop when provided.
+     */
+    titleSlot?: Snippet
+
+    /**
+     * Custom description slot. Overrides the `description` prop when provided.
+     */
+    descriptionSlot?: Snippet
+
+    /**
+     * Body content rendered between the header and footer.
+     */
+    body?: Snippet
+
+    /**
+     * Footer content rendered at the bottom of the slideover.
+     */
+    footer?: Snippet
+
+    /**
+     * Custom close button slot. Overrides the default close button entirely.
+     */
+    closeSlot?: Snippet
+}

--- a/src/lib/Slideover/slideover.variants.ts
+++ b/src/lib/Slideover/slideover.variants.ts
@@ -1,0 +1,149 @@
+import { tv, type VariantProps } from 'tailwind-variants'
+
+export const slideoverVariants = tv({
+    slots: {
+        overlay: 'fixed inset-0 z-50',
+        content: 'z-50 bg-surface-container-low divide-y divide-outline-variant flex flex-col focus:outline-none',
+        header: 'flex items-center gap-1.5 p-4 sm:px-6 min-h-16',
+        wrapper: '',
+        body: 'flex-1 overflow-y-auto p-4 sm:p-6',
+        footer: 'flex items-center gap-1.5 p-4 sm:px-6',
+        title: 'text-on-surface font-semibold',
+        description: 'mt-1 text-on-surface-variant text-sm',
+        close: 'absolute top-4 end-4'
+    },
+    variants: {
+        transition: {
+            true: {
+                overlay: 'data-[state=open]:animate-[fade-in_200ms_ease-out] data-[state=closed]:animate-[fade-out_150ms_ease-in]'
+            }
+        },
+        side: {
+            top: {
+                content: 'fixed top-0 inset-x-0 max-h-[90dvh]'
+            },
+            right: {
+                content: 'fixed right-0 inset-y-0 w-full max-w-md'
+            },
+            bottom: {
+                content: 'fixed bottom-0 inset-x-0 max-h-[90dvh]'
+            },
+            left: {
+                content: 'fixed left-0 inset-y-0 w-full max-w-md'
+            }
+        },
+        inset: {
+            true: {},
+            false: {}
+        },
+        overlay: {
+            true: {
+                overlay: 'bg-on-surface/50'
+            }
+        }
+    },
+    compoundVariants: [
+        // Transition animations per side
+        {
+            transition: true,
+            side: 'top',
+            class: {
+                content: 'data-[state=open]:animate-[slide-in-full-top_200ms_ease-out,fade-in_200ms_ease-out] data-[state=closed]:animate-[slide-out-full-top_150ms_ease-in,fade-out_150ms_ease-in]'
+            }
+        },
+        {
+            transition: true,
+            side: 'right',
+            class: {
+                content: 'data-[state=open]:animate-[slide-in-full-right_200ms_ease-out,fade-in_200ms_ease-out] data-[state=closed]:animate-[slide-out-full-right_150ms_ease-in,fade-out_150ms_ease-in]'
+            }
+        },
+        {
+            transition: true,
+            side: 'bottom',
+            class: {
+                content: 'data-[state=open]:animate-[slide-in-full-bottom_200ms_ease-out,fade-in_200ms_ease-out] data-[state=closed]:animate-[slide-out-full-bottom_150ms_ease-in,fade-out_150ms_ease-in]'
+            }
+        },
+        {
+            transition: true,
+            side: 'left',
+            class: {
+                content: 'data-[state=open]:animate-[slide-in-full-left_200ms_ease-out,fade-in_200ms_ease-out] data-[state=closed]:animate-[slide-out-full-left_150ms_ease-in,fade-out_150ms_ease-in]'
+            }
+        },
+        // Inset mode with rounded corners and margins
+        {
+            inset: true,
+            side: 'top',
+            class: {
+                content: 'top-4 inset-x-4 max-h-[calc(90dvh-2rem)] rounded-xl shadow-lg ring ring-outline-variant'
+            }
+        },
+        {
+            inset: true,
+            side: 'right',
+            class: {
+                content: 'right-4 inset-y-4 rounded-xl shadow-lg ring ring-outline-variant'
+            }
+        },
+        {
+            inset: true,
+            side: 'bottom',
+            class: {
+                content: 'bottom-4 inset-x-4 max-h-[calc(90dvh-2rem)] rounded-xl shadow-lg ring ring-outline-variant'
+            }
+        },
+        {
+            inset: true,
+            side: 'left',
+            class: {
+                content: 'left-4 inset-y-4 rounded-xl shadow-lg ring ring-outline-variant'
+            }
+        },
+        // Non-inset mode with edge styling
+        {
+            inset: false,
+            side: 'top',
+            class: {
+                content: 'shadow-lg'
+            }
+        },
+        {
+            inset: false,
+            side: 'right',
+            class: {
+                content: 'shadow-lg'
+            }
+        },
+        {
+            inset: false,
+            side: 'bottom',
+            class: {
+                content: 'shadow-lg'
+            }
+        },
+        {
+            inset: false,
+            side: 'left',
+            class: {
+                content: 'shadow-lg'
+            }
+        }
+    ],
+    defaultVariants: {
+        transition: true,
+        side: 'right',
+        inset: false,
+        overlay: true
+    }
+})
+
+export type SlideoverVariantProps = VariantProps<typeof slideoverVariants>
+export type SlideoverSlots = keyof ReturnType<typeof slideoverVariants>
+export type SlideoverSide = NonNullable<SlideoverVariantProps['side']>
+
+export const slideoverDefaults = {
+    defaultVariants: slideoverVariants.defaultVariants,
+    slots: {} as Partial<Record<SlideoverSlots, string>>
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -20,6 +20,7 @@ export * from './Drawer/index.js'
 export * from './Tooltip/index.js'
 export * from './Modal/index.js'
 export * from './Accordion/index.js'
+export * from './Slideover/index.js'
 
 // Configuration
 export { defineConfig } from './config.js'

--- a/src/lib/theme.css
+++ b/src/lib/theme.css
@@ -466,3 +466,133 @@
     height: 0;
   }
 }
+
+@keyframes slide-in-from-top {
+  from {
+    transform: translateY(-0.5rem);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-in-from-bottom {
+  from {
+    transform: translateY(0.5rem);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-in-from-left {
+  from {
+    transform: translateX(-0.5rem);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slide-in-from-right {
+  from {
+    transform: translateX(0.5rem);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slide-in-full-top {
+  from {
+    transform: translateY(-100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-in-full-bottom {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-in-full-left {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slide-in-full-right {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slide-out-full-top {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-100%);
+  }
+}
+
+@keyframes slide-out-full-bottom {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(100%);
+  }
+}
+
+@keyframes slide-out-full-left {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-100%);
+  }
+}
+
+@keyframes slide-out-full-right {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes zoom-in {
+  from {
+    opacity: 0;
+    scale: 0.95;
+  }
+  to {
+    opacity: 1;
+    scale: 1;
+  }
+}
+
+@keyframes zoom-out {
+  from {
+    opacity: 1;
+    scale: 1;
+  }
+  to {
+    opacity: 0;
+    scale: 0.95;
+  }
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -30,7 +30,8 @@
 		{ href: '/drawer', label: 'Drawer', icon: 'lucide:panel-bottom' },
 		{ href: '/tooltip', label: 'Tooltip', icon: 'lucide:message-square' },
 		{ href: '/modal', label: 'Modal', icon: 'lucide:square-stack' },
-		{ href: '/accordion', label: 'Accordion', icon: 'lucide:chevrons-down-up' }
+		{ href: '/accordion', label: 'Accordion', icon: 'lucide:chevrons-down-up' },
+		{ href: '/slideover', label: 'Slideover', icon: 'lucide:panel-right' }
 	]
 
 	const docItems = [

--- a/src/routes/slideover/+page.svelte
+++ b/src/routes/slideover/+page.svelte
@@ -1,0 +1,715 @@
+<script lang="ts">
+	import { Slideover, Button, Badge, Icon, Separator } from '$lib/index.js'
+
+	// --- State ---
+	let basicOpen = $state(false)
+	let leftOpen = $state(false)
+	let topOpen = $state(false)
+	let bottomOpen = $state(false)
+	let insetRightOpen = $state(false)
+	let insetLeftOpen = $state(false)
+	let insetTopOpen = $state(false)
+	let insetBottomOpen = $state(false)
+	let noCloseOpen = $state(false)
+	let noOverlayOpen = $state(false)
+	let noTransitionOpen = $state(false)
+	let nonDismissibleOpen = $state(false)
+	let slotsOpen = $state(false)
+	let customContentOpen = $state(false)
+	let titleSlotOpen = $state(false)
+	let callbacksOpen = $state(false)
+	let callbackLog = $state<string[]>([])
+	let noPortalOpen = $state(false)
+	let uiOverrideOpen = $state(false)
+	let programmaticOpen = $state(false)
+
+	// Real-world demos
+	let filtersOpen = $state(false)
+	let settingsOpen = $state(false)
+	let cartOpen = $state(false)
+	let notificationsOpen = $state(false)
+
+	function logCallback(name: string) {
+		callbackLog = [...callbackLog.slice(-4), `${new Date().toLocaleTimeString()} — ${name}`]
+	}
+</script>
+
+<div class="space-y-8">
+	<div class="space-y-2">
+		<h1 class="text-2xl font-bold">Slideover</h1>
+		<p class="text-on-surface-variant">
+			A slideover panel component built on top of bits-ui Dialog. Slides in from any side
+			with support for transitions, inset mode, dismissible control, and full slot customization.
+		</p>
+	</div>
+
+	<!-- ==================== SIDE VARIANTS ==================== -->
+	<section class="space-y-3">
+		<h2 class="text-lg font-semibold">Side Variants</h2>
+		<p class="text-sm text-on-surface-variant">
+			Control which side the slideover appears from with the
+			<code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">side</code> prop.
+		</p>
+		<div class="flex flex-wrap gap-3 rounded-lg bg-surface-container-high p-4">
+			<Slideover
+				bind:open={basicOpen}
+				side="right"
+				title="Right Slideover"
+				description="Slides in from the right (default)."
+			>
+				<Button variant="outline" label="Right" />
+				{#snippet body()}
+					<p class="text-on-surface-variant">This panel slides in from the right side (default).</p>
+				{/snippet}
+				{#snippet footer()}
+					<Button label="Close" variant="outline" onclick={() => (basicOpen = false)} />
+				{/snippet}
+			</Slideover>
+
+			<Slideover
+				bind:open={leftOpen}
+				side="left"
+				title="Left Slideover"
+				description="Slides in from the left."
+			>
+				<Button variant="outline" label="Left" />
+				{#snippet body()}
+					<p class="text-on-surface-variant">This panel slides in from the left side.</p>
+				{/snippet}
+				{#snippet footer()}
+					<Button label="Close" variant="outline" onclick={() => (leftOpen = false)} />
+				{/snippet}
+			</Slideover>
+
+			<Slideover
+				bind:open={topOpen}
+				side="top"
+				title="Top Slideover"
+				description="Slides down from the top."
+			>
+				<Button variant="outline" label="Top" />
+				{#snippet body()}
+					<p class="text-on-surface-variant">This panel slides down from the top.</p>
+				{/snippet}
+				{#snippet footer()}
+					<Button label="Close" variant="outline" onclick={() => (topOpen = false)} />
+				{/snippet}
+			</Slideover>
+
+			<Slideover
+				bind:open={bottomOpen}
+				side="bottom"
+				title="Bottom Slideover"
+				description="Slides up from the bottom."
+			>
+				<Button variant="outline" label="Bottom" />
+				{#snippet body()}
+					<p class="text-on-surface-variant">This panel slides up from the bottom.</p>
+				{/snippet}
+				{#snippet footer()}
+					<Button label="Close" variant="outline" onclick={() => (bottomOpen = false)} />
+				{/snippet}
+			</Slideover>
+		</div>
+	</section>
+
+	<!-- ==================== INSET MODE ==================== -->
+	<section class="space-y-3">
+		<h2 class="text-lg font-semibold">Inset Mode</h2>
+		<p class="text-sm text-on-surface-variant">
+			Enable <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">inset</code> mode
+			to add margins and rounded corners to the slideover.
+		</p>
+		<div class="flex flex-wrap gap-3 rounded-lg bg-surface-container-high p-4">
+			<Slideover
+				bind:open={insetRightOpen}
+				inset
+				title="Inset Right"
+				description="Inset mode with rounded corners."
+			>
+				<Button variant="outline" label="Inset (Right)" />
+				{#snippet body()}
+					<p class="text-on-surface-variant">
+						This slideover has margins and rounded corners, giving it a floating appearance.
+					</p>
+				{/snippet}
+				{#snippet footer()}
+					<Button label="Close" variant="outline" onclick={() => (insetRightOpen = false)} />
+				{/snippet}
+			</Slideover>
+
+			<Slideover
+				bind:open={insetLeftOpen}
+				side="left"
+				inset
+				title="Inset Left"
+				description="Inset mode from the left side."
+			>
+				<Button variant="outline" label="Inset (Left)" />
+				{#snippet body()}
+					<p class="text-on-surface-variant">
+						Inset mode from the left with floating panel appearance.
+					</p>
+				{/snippet}
+				{#snippet footer()}
+					<Button label="Close" variant="outline" onclick={() => (insetLeftOpen = false)} />
+				{/snippet}
+			</Slideover>
+
+			<Slideover
+				bind:open={insetTopOpen}
+				side="top"
+				inset
+				title="Inset Top"
+				description="Inset mode from the top."
+			>
+				<Button variant="outline" label="Inset (Top)" />
+				{#snippet body()}
+					<p class="text-on-surface-variant">
+						Inset mode from the top with floating panel appearance.
+					</p>
+				{/snippet}
+				{#snippet footer()}
+					<Button label="Close" variant="outline" onclick={() => (insetTopOpen = false)} />
+				{/snippet}
+			</Slideover>
+
+			<Slideover
+				bind:open={insetBottomOpen}
+				side="bottom"
+				inset
+				title="Inset Bottom"
+				description="Inset mode from the bottom."
+			>
+				<Button variant="outline" label="Inset (Bottom)" />
+				{#snippet body()}
+					<p class="text-on-surface-variant">
+						Inset mode from the bottom with floating panel appearance.
+					</p>
+				{/snippet}
+				{#snippet footer()}
+					<Button label="Close" variant="outline" onclick={() => (insetBottomOpen = false)} />
+				{/snippet}
+			</Slideover>
+		</div>
+	</section>
+
+	<!-- ==================== TRANSITION ==================== -->
+	<section class="space-y-3">
+		<h2 class="text-lg font-semibold">Transition</h2>
+		<p class="text-sm text-on-surface-variant">
+			Animations are enabled by default. Set
+			<code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">transition={'{'}false{'}'}</code>
+			to disable.
+		</p>
+		<div class="rounded-lg bg-surface-container-high p-4">
+			<Slideover
+				bind:open={noTransitionOpen}
+				transition={false}
+				title="No Transition"
+				description="This slideover appears and disappears instantly."
+			>
+				<Button variant="outline" label="No Transition" />
+				{#snippet body()}
+					<p class="text-on-surface-variant">
+						No slide or fade animation — the slideover snaps open and closed.
+					</p>
+				{/snippet}
+				{#snippet footer()}
+					<Button label="Close" variant="outline" onclick={() => (noTransitionOpen = false)} />
+				{/snippet}
+			</Slideover>
+		</div>
+	</section>
+
+	<!-- ==================== CLOSE BUTTON ==================== -->
+	<section class="space-y-3">
+		<h2 class="text-lg font-semibold">Close Button</h2>
+		<p class="text-sm text-on-surface-variant">
+			Hide the close button with <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">close={'{'}false{'}'}</code>.
+		</p>
+		<div class="rounded-lg bg-surface-container-high p-4">
+			<Slideover
+				bind:open={noCloseOpen}
+				close={false}
+				title="No Close Button"
+				description="The X button is hidden."
+			>
+				<Button variant="outline" label="No Close Button" />
+				{#snippet body()}
+					<p class="text-on-surface-variant">
+						There's no X button. Use the footer button or Escape key to close.
+					</p>
+				{/snippet}
+				{#snippet footer()}
+					<Button label="Close" variant="solid" color="primary" onclick={() => (noCloseOpen = false)} />
+				{/snippet}
+			</Slideover>
+		</div>
+	</section>
+
+	<!-- ==================== OVERLAY ==================== -->
+	<section class="space-y-3">
+		<h2 class="text-lg font-semibold">Overlay</h2>
+		<p class="text-sm text-on-surface-variant">
+			Hide the overlay with <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">overlay={'{'}false{'}'}</code>.
+		</p>
+		<div class="rounded-lg bg-surface-container-high p-4">
+			<Slideover
+				bind:open={noOverlayOpen}
+				overlay={false}
+				title="No Overlay"
+				description="The backdrop is hidden."
+			>
+				<Button variant="outline" label="No Overlay" />
+				{#snippet body()}
+					<p class="text-on-surface-variant">
+						The slideover has no backdrop overlay. The page content behind is fully visible.
+					</p>
+				{/snippet}
+				{#snippet footer()}
+					<Button label="Close" variant="outline" onclick={() => (noOverlayOpen = false)} />
+				{/snippet}
+			</Slideover>
+		</div>
+	</section>
+
+	<!-- ==================== NON-DISMISSIBLE ==================== -->
+	<section class="space-y-3">
+		<h2 class="text-lg font-semibold">Non-Dismissible</h2>
+		<p class="text-sm text-on-surface-variant">
+			Set <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">dismissible={'{'}false{'}'}</code>
+			to prevent closing by clicking outside or pressing Escape.
+		</p>
+		<div class="rounded-lg bg-surface-container-high p-4">
+			<Slideover
+				bind:open={nonDismissibleOpen}
+				dismissible={false}
+				close={false}
+				title="Non-Dismissible"
+				description="You must use the button to close."
+			>
+				<Button variant="outline" label="Open (Non-Dismissible)" />
+				{#snippet body()}
+					<p class="text-on-surface-variant">
+						Try clicking outside or pressing Escape — the slideover will not close.
+					</p>
+				{/snippet}
+				{#snippet footer()}
+					<Button
+						label="I Understand"
+						variant="solid"
+						color="primary"
+						onclick={() => (nonDismissibleOpen = false)}
+					/>
+				{/snippet}
+			</Slideover>
+		</div>
+	</section>
+
+	<!-- ==================== SLOTS ==================== -->
+	<section class="space-y-3">
+		<h2 class="text-lg font-semibold">Slots</h2>
+		<p class="text-sm text-on-surface-variant">
+			Customize every part: <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">header</code>,
+			<code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">titleSlot</code>,
+			<code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">descriptionSlot</code>,
+			<code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">body</code>,
+			<code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">footer</code>, or
+			replace all with <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">content</code>.
+		</p>
+		<div class="flex flex-wrap gap-3 rounded-lg bg-surface-container-high p-4">
+			<!-- Custom header slot -->
+			<Slideover bind:open={slotsOpen}>
+				<Button variant="outline" label="Custom Header" />
+				{#snippet header()}
+					<div class="flex items-center gap-3 p-4 sm:px-6">
+						<div class="flex size-10 items-center justify-center rounded-full bg-primary text-on-primary">
+							<Icon name="lucide:settings" size="20" />
+						</div>
+						<div>
+							<h3 class="font-semibold text-on-surface">Custom Header</h3>
+							<p class="text-sm text-on-surface-variant">With icon and layout</p>
+						</div>
+					</div>
+				{/snippet}
+				{#snippet body()}
+					<p class="text-on-surface-variant">
+						The <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">header</code> slot
+						replaces the default title + description + close button with fully custom markup.
+					</p>
+				{/snippet}
+				{#snippet footer()}
+					<Button label="Cancel" variant="outline" onclick={() => (slotsOpen = false)} />
+					<Button label="Confirm" variant="solid" color="primary" onclick={() => (slotsOpen = false)} />
+				{/snippet}
+			</Slideover>
+
+			<!-- Custom title/description slots -->
+			<Slideover bind:open={titleSlotOpen}>
+				<Button variant="outline" label="Custom Title/Desc" />
+				{#snippet titleSlot()}
+					<span class="flex items-center gap-2">
+						<Icon name="lucide:sparkles" size="16" class="text-warning" />
+						Rich Title with Icon
+					</span>
+				{/snippet}
+				{#snippet descriptionSlot()}
+					<span>
+						Description with <Badge variant="soft" color="info" size="xs" label="badge" />
+					</span>
+				{/snippet}
+				{#snippet body()}
+					<p class="text-on-surface-variant">
+						<code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">titleSlot</code> and
+						<code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">descriptionSlot</code>
+						let you customize just the title/description while keeping the default header layout.
+					</p>
+				{/snippet}
+				{#snippet footer()}
+					<Button label="Close" variant="outline" onclick={() => (titleSlotOpen = false)} />
+				{/snippet}
+			</Slideover>
+
+			<!-- Full content slot -->
+			<Slideover bind:open={customContentOpen} title="Custom Content">
+				<Button variant="outline" label="Content Slot" />
+				{#snippet content()}
+					<div class="flex h-full flex-col items-center justify-center gap-4 p-6">
+						<div class="flex size-16 items-center justify-center rounded-full bg-success/10">
+							<Icon name="lucide:check-circle" size="32" class="text-success" />
+						</div>
+						<h3 class="text-xl font-semibold text-on-surface">Action Complete</h3>
+						<p class="text-center text-on-surface-variant">
+							The <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">content</code> slot
+							replaces the entire inner layout (header + body + footer).
+						</p>
+						<Button label="Done" variant="solid" color="primary" onclick={() => (customContentOpen = false)} />
+					</div>
+				{/snippet}
+			</Slideover>
+		</div>
+	</section>
+
+	<!-- ==================== CALLBACKS ==================== -->
+	<section class="space-y-3">
+		<h2 class="text-lg font-semibold">Lifecycle Callbacks</h2>
+		<p class="text-sm text-on-surface-variant">
+			<code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">onOpenChange</code> and
+			<code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">onOpenChangeComplete</code>.
+		</p>
+		<div class="rounded-lg bg-surface-container-high p-4">
+			<div class="mb-3 space-y-1">
+				{#if callbackLog.length === 0}
+					<p class="text-sm text-on-surface-variant italic">Open/close the slideover to see callback logs...</p>
+				{/if}
+				{#each callbackLog as log}
+					<p class="font-mono text-xs text-on-surface-variant">{log}</p>
+				{/each}
+			</div>
+			<Slideover
+				bind:open={callbacksOpen}
+				onOpenChange={(v) => logCallback(`onOpenChange(${v})`)}
+				onOpenChangeComplete={(v) => logCallback(`onOpenChangeComplete(${v})`)}
+				title="Callback Demo"
+				description="Check the log above."
+			>
+				<Button variant="outline" label="Open (With Callbacks)" />
+				{#snippet body()}
+					<p class="text-on-surface-variant">
+						Open, close, and watch the callback log update in real-time.
+					</p>
+				{/snippet}
+				{#snippet footer()}
+					<Button label="Close" variant="outline" onclick={() => (callbacksOpen = false)} />
+				{/snippet}
+			</Slideover>
+		</div>
+	</section>
+
+	<!-- ==================== NO PORTAL ==================== -->
+	<section class="space-y-3">
+		<h2 class="text-lg font-semibold">Without Portal</h2>
+		<p class="text-sm text-on-surface-variant">
+			Set
+			<code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">portal={'{'}false{'}'}</code>
+			to render inline instead of being portalled to the body.
+		</p>
+		<div class="rounded-lg bg-surface-container-high p-4">
+			<Slideover
+				bind:open={noPortalOpen}
+				portal={false}
+				title="No Portal"
+				description="Rendered inline, not in a portal."
+			>
+				<Button variant="outline" label="Open (No Portal)" />
+				{#snippet body()}
+					<p class="text-on-surface-variant">
+						This slideover is rendered inline in the DOM.
+					</p>
+				{/snippet}
+				{#snippet footer()}
+					<Button label="Close" variant="outline" onclick={() => (noPortalOpen = false)} />
+				{/snippet}
+			</Slideover>
+		</div>
+	</section>
+
+	<!-- ==================== PROGRAMMATIC ==================== -->
+	<section class="space-y-3">
+		<h2 class="text-lg font-semibold">Programmatic Control</h2>
+		<p class="text-sm text-on-surface-variant">
+			Control the slideover without a trigger by binding
+			<code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">open</code> externally.
+		</p>
+		<div class="flex gap-3 rounded-lg bg-surface-container-high p-4">
+			<Button variant="outline" label="Open Programmatically" onclick={() => (programmaticOpen = true)} />
+			<Slideover
+				bind:open={programmaticOpen}
+				title="Programmatic Slideover"
+				description="Opened without a trigger slot."
+			>
+				{#snippet body()}
+					<p class="text-on-surface-variant">
+						This slideover has no children slot. It was opened by setting
+						<code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">open = true</code> externally.
+					</p>
+				{/snippet}
+				{#snippet footer()}
+					<Button label="Close" variant="outline" onclick={() => (programmaticOpen = false)} />
+				{/snippet}
+			</Slideover>
+		</div>
+	</section>
+
+	<!-- ==================== UI OVERRIDES ==================== -->
+	<section class="space-y-3">
+		<h2 class="text-lg font-semibold">UI Prop (Style Overrides)</h2>
+		<p class="text-sm text-on-surface-variant">
+			Override individual slot styles via the
+			<code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">ui</code> prop.
+		</p>
+		<div class="rounded-lg bg-surface-container-high p-4">
+			<Slideover
+				bind:open={uiOverrideOpen}
+				title="Styled Slideover"
+				description="Custom styles via the ui prop."
+				ui={{
+					content: 'bg-primary-container',
+					title: 'text-on-primary-container',
+					description: 'text-on-primary-container/70'
+				}}
+			>
+				<Button variant="outline" label="Open Styled Slideover" />
+				{#snippet body()}
+					<p class="text-on-primary-container/80">
+						This slideover overrides
+						<code class="rounded bg-on-primary-container/10 px-1.5 py-0.5 text-xs text-on-primary-container">content</code>,
+						<code class="rounded bg-on-primary-container/10 px-1.5 py-0.5 text-xs text-on-primary-container">title</code>, and
+						<code class="rounded bg-on-primary-container/10 px-1.5 py-0.5 text-xs text-on-primary-container">description</code> slot classes.
+					</p>
+				{/snippet}
+				{#snippet footer()}
+					<Button label="Close" variant="outline" onclick={() => (uiOverrideOpen = false)} />
+				{/snippet}
+			</Slideover>
+		</div>
+	</section>
+
+	<Separator />
+
+	<!-- ==================== REAL WORLD EXAMPLES ==================== -->
+	<section class="space-y-3">
+		<h2 class="text-lg font-semibold">Real World Examples</h2>
+
+		<div class="grid gap-4 sm:grid-cols-2">
+			<!-- Filters Panel -->
+			<div class="rounded-lg bg-surface-container-high p-4">
+				<p class="mb-3 text-sm font-medium">Filters Panel</p>
+				<Slideover
+					bind:open={filtersOpen}
+					side="left"
+					title="Filters"
+					description="Refine your search results."
+				>
+					<Button variant="outline" leadingIcon="lucide:sliders-horizontal" label="Filters" class="w-full" />
+					{#snippet body()}
+						<div class="space-y-6">
+							<div>
+								<h4 class="mb-3 text-sm font-medium text-on-surface">Category</h4>
+								<div class="space-y-2">
+									{#each ['Electronics', 'Clothing', 'Home & Garden', 'Sports'] as category}
+										<label class="flex items-center gap-2">
+											<input type="checkbox" class="rounded border-outline-variant text-primary focus:ring-primary" />
+											<span class="text-sm text-on-surface-variant">{category}</span>
+										</label>
+									{/each}
+								</div>
+							</div>
+							<div>
+								<h4 class="mb-3 text-sm font-medium text-on-surface">Price Range</h4>
+								<div class="flex gap-2">
+									<input type="number" placeholder="Min" class="w-full rounded-md border border-outline-variant bg-surface px-3 py-2 text-sm" />
+									<input type="number" placeholder="Max" class="w-full rounded-md border border-outline-variant bg-surface px-3 py-2 text-sm" />
+								</div>
+							</div>
+							<div>
+								<h4 class="mb-3 text-sm font-medium text-on-surface">Rating</h4>
+								<div class="space-y-2">
+									{#each [4, 3, 2, 1] as stars}
+										<label class="flex items-center gap-2">
+											<input type="radio" name="rating" class="border-outline-variant text-primary focus:ring-primary" />
+											<span class="flex items-center gap-1 text-sm text-on-surface-variant">
+												{stars}+ <Icon name="lucide:star" size="14" class="text-warning" />
+											</span>
+										</label>
+									{/each}
+								</div>
+							</div>
+						</div>
+					{/snippet}
+					{#snippet footer()}
+						<Button label="Reset" variant="outline" onclick={() => (filtersOpen = false)} />
+						<Button label="Apply Filters" variant="solid" color="primary" onclick={() => (filtersOpen = false)} />
+					{/snippet}
+				</Slideover>
+			</div>
+
+			<!-- Settings Panel -->
+			<div class="rounded-lg bg-surface-container-high p-4">
+				<p class="mb-3 text-sm font-medium">Settings Panel</p>
+				<Slideover
+					bind:open={settingsOpen}
+					inset
+					title="Settings"
+					description="Customize your experience."
+				>
+					<Button variant="outline" leadingIcon="lucide:settings" label="Settings" class="w-full" />
+					{#snippet body()}
+						<div class="space-y-6">
+							<div class="flex items-center justify-between">
+								<div>
+									<p class="font-medium text-on-surface">Dark Mode</p>
+									<p class="text-sm text-on-surface-variant">Enable dark theme</p>
+								</div>
+								<input type="checkbox" class="rounded border-outline-variant text-primary focus:ring-primary" />
+							</div>
+							<div class="flex items-center justify-between">
+								<div>
+									<p class="font-medium text-on-surface">Notifications</p>
+									<p class="text-sm text-on-surface-variant">Receive push notifications</p>
+								</div>
+								<input type="checkbox" checked class="rounded border-outline-variant text-primary focus:ring-primary" />
+							</div>
+							<div class="flex items-center justify-between">
+								<div>
+									<p class="font-medium text-on-surface">Sound Effects</p>
+									<p class="text-sm text-on-surface-variant">Play sounds for actions</p>
+								</div>
+								<input type="checkbox" class="rounded border-outline-variant text-primary focus:ring-primary" />
+							</div>
+							<div>
+								<p class="mb-2 font-medium text-on-surface">Language</p>
+								<select class="w-full rounded-md border border-outline-variant bg-surface px-3 py-2 text-sm">
+									<option>English</option>
+									<option>Spanish</option>
+									<option>French</option>
+									<option>German</option>
+								</select>
+							</div>
+						</div>
+					{/snippet}
+					{#snippet footer()}
+						<Button label="Cancel" variant="outline" onclick={() => (settingsOpen = false)} />
+						<Button label="Save Changes" variant="solid" color="primary" onclick={() => (settingsOpen = false)} />
+					{/snippet}
+				</Slideover>
+			</div>
+
+			<!-- Shopping Cart -->
+			<div class="rounded-lg bg-surface-container-high p-4">
+				<p class="mb-3 text-sm font-medium">Shopping Cart</p>
+				<Slideover
+					bind:open={cartOpen}
+					title="Shopping Cart"
+					description="3 items in your cart"
+				>
+					<Button variant="outline" leadingIcon="lucide:shopping-cart" label="Cart (3)" class="w-full" />
+					{#snippet body()}
+						<div class="space-y-4">
+							{#each [
+								{ name: 'Wireless Headphones', price: '$199.99', qty: 1 },
+								{ name: 'USB-C Cable', price: '$19.99', qty: 2 },
+								{ name: 'Phone Case', price: '$29.99', qty: 1 }
+							] as item}
+								<div class="flex items-center gap-3 rounded-lg bg-surface-container p-3">
+									<div class="size-12 rounded-md bg-surface-container-highest"></div>
+									<div class="flex-1">
+										<p class="font-medium text-on-surface">{item.name}</p>
+										<p class="text-sm text-on-surface-variant">Qty: {item.qty}</p>
+									</div>
+									<p class="font-medium text-on-surface">{item.price}</p>
+								</div>
+							{/each}
+							<div class="border-t border-outline-variant pt-4">
+								<div class="flex justify-between">
+									<span class="text-on-surface-variant">Subtotal</span>
+									<span class="font-medium text-on-surface">$269.96</span>
+								</div>
+								<div class="mt-1 flex justify-between">
+									<span class="text-on-surface-variant">Shipping</span>
+									<span class="font-medium text-on-surface">$9.99</span>
+								</div>
+								<div class="mt-2 flex justify-between border-t border-outline-variant pt-2">
+									<span class="font-semibold text-on-surface">Total</span>
+									<span class="font-semibold text-on-surface">$279.95</span>
+								</div>
+							</div>
+						</div>
+					{/snippet}
+					{#snippet footer()}
+						<Button label="Continue Shopping" variant="outline" onclick={() => (cartOpen = false)} />
+						<Button label="Checkout" variant="solid" color="primary" onclick={() => (cartOpen = false)} />
+					{/snippet}
+				</Slideover>
+			</div>
+
+			<!-- Notifications Panel -->
+			<div class="rounded-lg bg-surface-container-high p-4">
+				<p class="mb-3 text-sm font-medium">Notifications Panel</p>
+				<Slideover
+					bind:open={notificationsOpen}
+					title="Notifications"
+					description="You have 5 unread notifications"
+				>
+					<Button variant="outline" leadingIcon="lucide:bell" label="Notifications" class="w-full" />
+					{#snippet body()}
+						<div class="space-y-3">
+							{#each [
+								{ icon: 'lucide:package', title: 'Order shipped', desc: 'Your order #1234 has been shipped', time: '2m ago', color: 'text-info' },
+								{ icon: 'lucide:user-plus', title: 'New follower', desc: 'John Doe started following you', time: '1h ago', color: 'text-primary' },
+								{ icon: 'lucide:message-circle', title: 'New comment', desc: 'Sarah commented on your post', time: '3h ago', color: 'text-success' },
+								{ icon: 'lucide:heart', title: 'Post liked', desc: 'Your post received 100 likes', time: '5h ago', color: 'text-error' },
+								{ icon: 'lucide:calendar', title: 'Event reminder', desc: 'Team meeting in 30 minutes', time: '1d ago', color: 'text-warning' }
+							] as notif}
+								<div class="flex gap-3 rounded-lg bg-surface-container p-3">
+									<div class={`flex size-10 shrink-0 items-center justify-center rounded-full bg-surface-container-highest ${notif.color}`}>
+										<Icon name={notif.icon} size="18" />
+									</div>
+									<div class="flex-1">
+										<p class="font-medium text-on-surface">{notif.title}</p>
+										<p class="text-sm text-on-surface-variant">{notif.desc}</p>
+										<p class="mt-1 text-xs text-on-surface-variant">{notif.time}</p>
+									</div>
+								</div>
+							{/each}
+						</div>
+					{/snippet}
+					{#snippet footer()}
+						<Button label="Mark all as read" variant="outline" class="w-full" onclick={() => (notificationsOpen = false)} />
+					{/snippet}
+				</Slideover>
+			</div>
+		</div>
+	</section>
+</div>


### PR DESCRIPTION
## Summary

Add a new Slideover component built on top of bits-ui Dialog, providing a sliding panel that can appear from any edge of the screen.

### Features

- **Side variants**: Support for `top`, `right`, `bottom`, `left` positioning
- **Inset mode**: Floating panel with margins and rounded corners
- **Transition animations**: Smooth slide-in/out with fade effects using CSS keyframes
- **Overlay control**: Optional backdrop overlay
- **Dismissible control**: Configure whether clicking outside or pressing Escape closes the panel
- **Full slot customization**: `header`, `body`, `footer`, `title`, `description`, `close`, `content` slots
- **Accessibility**: Built on bits-ui Dialog with focus trap, scroll lock, and ARIA attributes
- **Configuration system**: Integrates with `getComponentConfig()` for global theming

### Files Changed

| File | Description |
|------|-------------|
| `src/lib/Slideover/Slideover.svelte` | Main component |
| `src/lib/Slideover/slideover.variants.ts` | Tailwind variants with slots and compound variants |
| `src/lib/Slideover/slideover.types.ts` | TypeScript types extending bits-ui Dialog props |
| `src/lib/Slideover/index.ts` | Public exports |
| `src/lib/Slideover/Slideover.svelte.spec.ts` | Test suite (40+ test cases) |
| `src/lib/theme.css` | Added `slide-in-full-*` and `slide-out-full-*` keyframes |
| `src/lib/index.ts` | Added Slideover export |
| `src/routes/+layout.svelte` | Added Slideover to sidebar navigation |
| `src/routes/slideover/+page.svelte` | Demo page with all variants |

### Usage Example

```svelte
<Slideover bind:open title="Panel Title" description="Optional description">
  <Button label="Open" />
  
  {#snippet body()}
    <p>Panel content here</p>
  {/snippet}
  
  {#snippet footer()}
    <Button label="Close" onclick={() => open = false} />
  {/snippet}
</Slideover>
