### PR TITLE
feat: add forceMount and transition props to Tooltip component

### DIFF
--- a/src/lib/Tooltip/Tooltip.svelte
+++ b/src/lib/Tooltip/Tooltip.svelte
@@ -13,7 +13,6 @@
     const config = getComponentConfig('tooltip', tooltipDefaults)
 
     let {
-        // Root props
         open = $bindable(false),
         onOpenChange,
         delayDuration,
@@ -21,7 +20,6 @@
         disableCloseOnTriggerClick,
         ignoreNonKeyboardFocus,
         disabled = false,
-        // Content props
         side = config.defaultVariants.side ?? 'bottom',
         sideOffset = 8,
         align = 'center',
@@ -32,10 +30,11 @@
         sticky = 'partial',
         hideWhenDetached = false,
         onEscapeKeydown,
-        // Own props
+        forceMount,
         text,
         kbds,
         arrow = false,
+        transition = config.defaultVariants.transition ?? true,
         portal = true,
         ui,
         class: className,
@@ -50,7 +49,7 @@
     const showArrow = $derived(!!arrow)
 
     // Compute variant classes
-    const variantSlots = $derived(tooltipVariants({ side }))
+    const variantSlots = $derived(tooltipVariants({ side, transition }))
     const classes = $derived({
         content: variantSlots.content({ class: [config.slots.content, ui?.content] }),
         arrow: variantSlots.arrow({ class: [config.slots.arrow, ui?.arrow] }),
@@ -77,7 +76,7 @@
 
         {#if hasKbds}
             <span class={classes.kbds}>
-                {#each kbds as kbd, index}
+                {#each kbds as kbd, index (index)}
                     {#if index > 0}
                         <span class="mx-0.5 text-inverse-on-surface/60">·</span>
                     {/if}
@@ -104,6 +103,7 @@
         {sticky}
         {hideWhenDetached}
         {onEscapeKeydown}
+        {forceMount}
         class={classes.content}
     >
         {@render tooltipContent()}

--- a/src/lib/Tooltip/tooltip.types.ts
+++ b/src/lib/Tooltip/tooltip.types.ts
@@ -1,6 +1,6 @@
 import type { Snippet } from 'svelte'
 import type { ClassNameValue } from 'tailwind-merge'
-import type { TooltipSlots } from './tooltip.variants.js'
+import type { TooltipSlots, TooltipVariantProps } from './tooltip.variants.js'
 import type {
     TooltipRootPropsWithoutHTML,
     TooltipContentPropsWithoutHTML,
@@ -34,6 +34,7 @@ type ContentProps = Pick<
     | 'sticky'
     | 'hideWhenDetached'
     | 'onEscapeKeydown'
+    | 'forceMount'
 >
 
 export interface TooltipProps extends RootProps, ContentProps {
@@ -55,6 +56,12 @@ export interface TooltipProps extends RootProps, ContentProps {
      * @default false
      */
     arrow?: boolean | Pick<TooltipArrowPropsWithoutHTML, 'width' | 'height'>
+
+    /**
+     * Animate the tooltip on open and close.
+     * @default true
+     */
+    transition?: TooltipVariantProps['transition']
 
     /**
      * Render the tooltip in a portal.

--- a/src/lib/Tooltip/tooltip.variants.ts
+++ b/src/lib/Tooltip/tooltip.variants.ts
@@ -7,27 +7,36 @@ export const tooltipVariants = tv({
             'bg-inverse-surface text-inverse-on-surface',
             'shadow-sm rounded-md',
             'px-2.5 py-1.5 text-xs',
-            'select-none pointer-events-auto',
-            'data-[state=delayed-open]:animate-in data-[state=closed]:animate-out',
-            'data-[state=closed]:fade-out-0 data-[state=delayed-open]:fade-in-0',
-            'data-[state=closed]:zoom-out-95 data-[state=delayed-open]:zoom-in-95',
-            'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
-            'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2'
+            'select-none pointer-events-auto'
         ],
-        arrow: 'fill-inverse-surface',
+        arrow: 'fill-inverse-surface text-inverse-surface',
         text: 'truncate',
         kbds: 'hidden lg:inline-flex items-center shrink-0 gap-0.5'
     },
     variants: {
         side: {
-            top: {},
-            right: {},
-            bottom: {},
-            left: {}
+            top: {
+                content: 'data-[state=delayed-open]:animate-[slide-in-from-bottom_150ms_ease-out] data-[state=closed]:animate-[slide-in-from-top_100ms_ease-in_reverse]'
+            },
+            right: {
+                content: 'data-[state=delayed-open]:animate-[slide-in-from-left_150ms_ease-out] data-[state=closed]:animate-[slide-in-from-right_100ms_ease-in_reverse]'
+            },
+            bottom: {
+                content: 'data-[state=delayed-open]:animate-[slide-in-from-top_150ms_ease-out] data-[state=closed]:animate-[slide-in-from-bottom_100ms_ease-in_reverse]'
+            },
+            left: {
+                content: 'data-[state=delayed-open]:animate-[slide-in-from-right_150ms_ease-out] data-[state=closed]:animate-[slide-in-from-left_100ms_ease-in_reverse]'
+            }
+        },
+        transition: {
+            true: {
+                content: 'data-[state=delayed-open]:animate-[fade-in_150ms_ease-out,zoom-in_150ms_ease-out] data-[state=closed]:animate-[fade-out_100ms_ease-in,zoom-out_100ms_ease-in]'
+            }
         }
     },
     defaultVariants: {
-        side: 'bottom'
+        side: 'bottom',
+        transition: true
     }
 })
 

--- a/src/lib/theme.css
+++ b/src/lib/theme.css
@@ -466,3 +466,61 @@
     height: 0;
   }
 }
+
+@keyframes slide-in-from-top {
+  from {
+    transform: translateY(-0.5rem);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-in-from-bottom {
+  from {
+    transform: translateY(0.5rem);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-in-from-left {
+  from {
+    transform: translateX(-0.5rem);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slide-in-from-right {
+  from {
+    transform: translateX(0.5rem);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes zoom-in {
+  from {
+    opacity: 0;
+    scale: 0.95;
+  }
+  to {
+    opacity: 1;
+    scale: 1;
+  }
+}
+
+@keyframes zoom-out {
+  from {
+    opacity: 1;
+    scale: 1;
+  }
+  to {
+    opacity: 0;
+    scale: 0.95;
+  }
+}


### PR DESCRIPTION
## Summary

Enhance the Tooltip component with new `forceMount` and `transition` props, along with improved animation keyframes.

### Changes

- **`forceMount` prop**: Pass-through to bits-ui for controlling mount behavior
- **`transition` prop**: Enable/disable animations (default: `true`)
- **Animation keyframes**: Add reusable CSS keyframes for slide and zoom effects
- **Each block key fix**: Add key to `{#each}` block for keyboard shortcuts rendering

### Files Changed

| File | Description |
|------|-------------|
| `src/lib/Tooltip/Tooltip.svelte` | Add forceMount, transition props; fix each block key |
| `src/lib/Tooltip/tooltip.types.ts` | Add forceMount and transition type definitions |
| `src/lib/Tooltip/tooltip.variants.ts` | Side-specific slide animations with transition variant |
| `src/lib/theme.css` | Add slide-in-from-*, zoom-in, zoom-out keyframes |

### New Props

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `forceMount` | `boolean` | - | Force mount tooltip content in DOM |
| `transition` | `boolean` | `true` | Enable/disable open/close animations |

### Animation Keyframes Added

- `slide-in-from-top/bottom/left/right` - 0.5rem slide animations
- `zoom-in` / `zoom-out` - Scale 0.95 → 1 with opacity

## Test plan

- [ ] Test tooltip with `forceMount={true}` - content should always be in DOM
- [ ] Test `transition={false}` - tooltip should appear/disappear instantly
- [ ] Test all 4 sides with animations
- [ ] Verify keyboard shortcuts render correctly
