### PR TITLE
feat: add Popover component with bits-ui integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,76 +1,142 @@
-# SV5UI
+<p align="center">
+  <img src="https://img.shields.io/badge/sv5ui-Svelte_5_UI-ff3e00?style=for-the-badge&logo=svelte&logoColor=white" alt="SV5UI" />
+</p>
 
-A modern, fully-typed Svelte 5 UI component library built with Tailwind CSS 4.
+<h1 align="center">SV5UI</h1>
 
-[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![npm version](https://img.shields.io/npm/v/sv5ui.svg)](https://www.npmjs.com/package/sv5ui)
+<p align="center">
+  A modern, fully-typed UI component library for Svelte 5.<br/>
+  Built with Tailwind CSS 4, OKLCH color tokens, and accessible headless primitives.
+</p>
 
-## Features
+<p align="center">
+  <a href="https://www.npmjs.com/package/sv5ui"><img src="https://img.shields.io/npm/v/sv5ui.svg?style=flat-square&colorA=18181b&colorB=ff3e00" alt="npm version" /></a>
+  <a href="https://github.com/ndlabdev/sv5ui/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/sv5ui.svg?style=flat-square&colorA=18181b&colorB=ff3e00" alt="license" /></a>
+  <a href="https://www.npmjs.com/package/sv5ui"><img src="https://img.shields.io/npm/dm/sv5ui.svg?style=flat-square&colorA=18181b&colorB=ff3e00" alt="downloads" /></a>
+</p>
 
-- **Svelte 5** - Built with runes, snippets, and the latest Svelte 5 features
-- **Tailwind CSS 4** - Utility-first styling with [Tailwind Variants](https://www.tailwind-variants.org/) for type-safe composable variants
-- **OKLCH Colors** - Semantic color tokens with light/dark mode support
-- **Fully Typed** - Complete TypeScript support with strict mode
-- **Accessible** - Built on [Bits UI](https://bits-ui.com) headless primitives
-- **Customizable** - Global config system to override default variants and slot styles
+---
+
+## Highlights
+
+- **Svelte 5** — Built with runes, snippets, and the latest reactivity model
+- **Tailwind CSS 4** — Utility-first styling with [Tailwind Variants](https://www.tailwind-variants.org/) for type-safe, composable variants
+- **Fully Typed** — Strict TypeScript with exported prop types for every component
+- **Accessible** — Built on [Bits UI](https://bits-ui.com) and [Vaul Svelte](https://vaul-svelte.com) headless primitives
+- **200,000+ Icons** — First-class [Iconify](https://iconify.design) integration
+- **Customizable** — Global config system + per-instance slot overrides
 
 ## Installation
 
 ```bash
 npm install sv5ui
+# or
+pnpm add sv5ui
 ```
 
-Peer dependencies: `svelte >= 5.0.0`, `tailwindcss >= 4.0.0`
+**Peer dependencies:** `svelte >= 5.0.0`, `tailwindcss >= 4.0.0`
 
 ## Quick Start
 
+**1. Import the theme**
+
 ```css
-/* layout.css */
+/* app.css */
 @import 'sv5ui/theme.css';
 @source "../../node_modules/sv5ui/dist";
 ```
 
+**2. Use components**
+
 ```svelte
 <script>
-  import { Button, Alert, Avatar, Badge } from 'sv5ui'
+  import { Button, Avatar, Badge, Tooltip } from 'sv5ui'
 </script>
 
-<Button variant="solid" color="primary">Click me</Button>
-<Alert title="Heads up!" description="Something happened." color="info" variant="soft" />
-<Avatar src="/photo.jpg" alt="John Doe" size="lg" />
-<Badge label="New" color="success" />
+<Tooltip text="Edit profile">
+  <Button variant="soft" color="primary" leadingIcon="lucide:edit">
+    Edit
+  </Button>
+</Tooltip>
+
+<Avatar src="/photo.jpg" alt="Jane Doe" size="lg" />
+<Badge label="Online" color="success" variant="soft" />
 ```
 
 ## Components
 
-| Component | Description |
-|-----------|-------------|
-| **Alert** | Notification banners with actions and close support |
-| **Avatar** | User avatar with image fallback and auto-generated initials |
-| **AvatarGroup** | Grouped avatars with overflow count |
-| **Badge** | Status indicators and tags |
-| **Button** | Interactive button with loading, icon, and block modes |
-| **Card** | Content container with header/body/footer slots |
-| **Chip** | Compact notification indicators with positioning |
-| **Container** | Responsive layout wrapper with max-width constraints |
-| **Icon** | Iconify wrapper with 200,000+ icons |
-| **Kbd** | Keyboard key display with automatic symbol mapping |
-| **Link** | Smart navigation with active state detection |
-| **Progress** | Determinate/indeterminate progress bars with step mode |
-| **Separator** | Dividers with optional label, icon, or avatar content |
-| **Timeline** | Sequence/step visualization with states |
+### General
 
-> Browse the interactive docs by running `pnpm dev` and opening [localhost:5173](http://localhost:5173).
+| Component | Description |
+|:----------|:------------|
+| [**Button**](src/lib/Button) | Versatile button with 6 variants, loading state, icons, and avatar support |
+| [**Link**](src/lib/Link) | Smart anchor with automatic active-state detection based on current route |
+| [**Icon**](src/lib/Icon) | Iconify wrapper — render any of 200,000+ icons by name |
+| [**Kbd**](src/lib/Kbd) | Keyboard shortcut display with OS-aware symbol mapping |
+
+### Layout
+
+| Component | Description |
+|:----------|:------------|
+| [**Card**](src/lib/Card) | Content container with header, body, and footer slots |
+| [**Container**](src/lib/Container) | Responsive max-width wrapper for page content |
+| [**Separator**](src/lib/Separator) | Horizontal/vertical divider with optional label, icon, or avatar |
+
+### Data Display
+
+| Component | Description |
+|:----------|:------------|
+| [**Avatar**](src/lib/Avatar) | Profile image with auto-generated initials fallback |
+| [**AvatarGroup**](src/lib/AvatarGroup) | Stacked avatars with overflow count |
+| [**Badge**](src/lib/Badge) | Status indicators and tags in 4 variants and 8 colors |
+| [**Chip**](src/lib/Chip) | Notification dot indicator with configurable positioning |
+| [**User**](src/lib/User) | User profile display combining avatar, name, and description |
+| [**Timeline**](src/lib/Timeline) | Step/sequence visualization with completed, active, and pending states |
+| [**Skeleton**](src/lib/Skeleton) | Animated loading placeholder |
+| [**Empty**](src/lib/Empty) | Empty state with icon, description, and action slots |
+
+### Feedback
+
+| Component | Description |
+|:----------|:------------|
+| [**Alert**](src/lib/Alert) | Notification banner with icon, actions, and dismissible support |
+| [**Progress**](src/lib/Progress) | Determinate/indeterminate progress bar with step mode and animations |
+
+### Overlay
+
+| Component | Description |
+|:----------|:------------|
+| [**Modal**](src/lib/Modal) | Accessible dialog with overlay, focus trap, and scroll lock |
+| [**Slideover**](src/lib/Slideover) | Side panel sliding from any edge with inset mode |
+| [**Drawer**](src/lib/Drawer) | Draggable bottom/side sheet with snap points |
+| [**Tooltip**](src/lib/Tooltip) | Hover tooltip with arrow, keyboard shortcut display, and portal rendering |
+| [**Popover**](src/lib/Popover) | Floating interactive content panel with focus management |
+| [**Accordion**](src/lib/Accordion) | Expandable sections with single or multiple open modes |
 
 ## Theming
 
-SV5UI uses OKLCH color space with semantic tokens. Light and dark modes work automatically.
+SV5UI uses **OKLCH color space** with semantic tokens. Light and dark modes work out of the box.
 
-**Available color tokens:** `primary`, `secondary`, `tertiary`, `success`, `warning`, `error`, `info`, `surface`
+### Color Tokens
 
-**Dark mode** via `.dark` class or `prefers-color-scheme`, managed through [mode-watcher](https://github.com/svecosystem/mode-watcher).
+Each color provides a set of related tokens for surfaces, text, and containers:
 
-**Custom colors** by overriding CSS variables:
+```
+--color-{name}                  Main color
+--color-on-{name}               Contrast text on main color
+--color-{name}-container        Lighter background variant
+--color-on-{name}-container     Text on container background
+```
+
+**Available colors:** `primary` · `secondary` · `tertiary` · `success` · `warning` · `error` · `info` · `surface`
+
+### Dark Mode
+
+Supported via `.dark` class on `<html>` or `prefers-color-scheme` media query, managed with [mode-watcher](https://github.com/svecosystem/mode-watcher).
+
+### Custom Colors
+
+Override any token with CSS variables:
 
 ```css
 :root {
@@ -81,19 +147,19 @@ SV5UI uses OKLCH color space with semantic tokens. Light and dark modes work aut
 
 ## Customization
 
-### Per-instance overrides
+### Per-instance — `ui` prop
 
-Override slot styles on any component via the `ui` prop:
+Override slot classes directly on any component:
 
 ```svelte
-<Button ui={{ base: 'rounded-full', label: 'font-bold uppercase' }}>
+<Button ui={{ base: 'rounded-full shadow-lg', label: 'font-bold uppercase' }}>
   Custom
 </Button>
 ```
 
-### Global defaults
+### Global — `defineConfig`
 
-Use `defineConfig` to set library-wide defaults:
+Set library-wide defaults for variants, slots, and icons:
 
 ```typescript
 import { defineConfig } from 'sv5ui'
@@ -103,22 +169,41 @@ defineConfig({
     defaultVariants: { variant: 'outline', size: 'lg' },
     slots: { base: 'shadow-md' }
   },
-  icons: { loading: 'svg-spinners:ring-resize' }
+  avatar: {
+    defaultVariants: { size: 'lg' },
+    slots: { root: 'ring-2 ring-primary' }
+  },
+  icons: {
+    loading: 'lucide:loader',
+    close: 'lucide:x'
+  }
 })
 ```
 
 ## Development
 
 ```bash
-pnpm install      # Install dependencies
-pnpm dev          # Start dev server
-pnpm test         # Run tests
-pnpm check        # Type check
-pnpm prepack      # Build library
-pnpm lint         # Lint
-pnpm format       # Format
+pnpm install          # Install dependencies
+pnpm dev              # Dev server at localhost:5173
+pnpm test             # Run unit tests
+pnpm check            # TypeScript check
+pnpm prepack          # Build library package
+pnpm lint             # Lint
+pnpm format           # Format code
 ```
+
+> Run `pnpm dev` and open [localhost:5173](http://localhost:5173) to browse the interactive component demos.
+
+## Tech Stack
+
+| Layer | Technology |
+|:------|:-----------|
+| Framework | [Svelte 5](https://svelte.dev) + [SvelteKit](https://svelte.dev/docs/kit) |
+| Styling | [Tailwind CSS 4](https://tailwindcss.com) + [Tailwind Variants](https://www.tailwind-variants.org/) |
+| Primitives | [Bits UI](https://bits-ui.com) · [Vaul Svelte](https://vaul-svelte.com) |
+| Icons | [Iconify](https://iconify.design) (200,000+ icons) |
+| Testing | [Vitest](https://vitest.dev) + [Playwright](https://playwright.dev) |
 
 ## License
 
-[MIT](LICENSE)
+[MIT](LICENSE) &copy; [ndlabdev](https://github.com/ndlabdev)

--- a/src/lib/Modal/index.ts
+++ b/src/lib/Modal/index.ts
@@ -1,2 +1,2 @@
 export { default as Modal } from './Modal.svelte'
-export type { ModalProps, ModalCloseProps } from './modal.types.js'
+export type { ModalProps } from './modal.types.js'

--- a/src/lib/Modal/modal.types.ts
+++ b/src/lib/Modal/modal.types.ts
@@ -36,13 +36,9 @@ type ContentProps = Pick<
  * Props for customizing the close button appearance.
  */
 export interface ModalCloseProps {
-    /** Button color scheme. */
     color?: NonNullable<ButtonVariantProps['color']>
-    /** Button visual style. */
     variant?: NonNullable<ButtonVariantProps['variant']>
-    /** Button size. */
     size?: NonNullable<ButtonVariantProps['size']>
-    /** Icon displayed inside the close button. Supports any Iconify icon name. */
     icon?: string
 }
 

--- a/src/lib/Popover/Popover.svelte
+++ b/src/lib/Popover/Popover.svelte
@@ -1,0 +1,128 @@
+<script lang="ts" module>
+    import type { PopoverProps } from './popover.types.js'
+
+    export type Props = PopoverProps
+</script>
+
+<script lang="ts">
+    import { Popover } from 'bits-ui'
+    import { popoverVariants, popoverDefaults } from './popover.variants.js'
+    import { getComponentConfig } from '../config.js'
+
+    const config = getComponentConfig('popover', popoverDefaults)
+
+    let {
+        open = $bindable(false),
+        onOpenChange,
+        onOpenChangeComplete,
+        side = config.defaultVariants.side ?? 'bottom',
+        sideOffset = 8,
+        align = 'center',
+        alignOffset = 0,
+        avoidCollisions = true,
+        collisionBoundary,
+        collisionPadding = 8,
+        sticky = 'partial',
+        hideWhenDetached = false,
+        trapFocus = true,
+        preventScroll = false,
+        onOpenAutoFocus,
+        onCloseAutoFocus,
+        onEscapeKeydown,
+        onInteractOutside,
+        forceMount,
+        arrow = false,
+        transition = config.defaultVariants.transition ?? true,
+        portal = true,
+        dismissible = true,
+        ui,
+        class: className,
+        children,
+        content: contentSlot
+    }: Props = $props()
+
+    const showArrow = $derived(!!arrow)
+
+    const variantSlots = $derived(popoverVariants({ side, transition }))
+    const classes = $derived({
+        content: variantSlots.content({ class: [config.slots.content, ui?.content] }),
+        arrow: variantSlots.arrow({ class: [config.slots.arrow, ui?.arrow] })
+    })
+
+    const arrowProps = $derived.by(() => {
+        if (typeof arrow === 'object') {
+            return { width: 12, height: 6, ...arrow }
+        }
+        return { width: 12, height: 6 }
+    })
+
+    const dismissBehavior = $derived(dismissible ? 'close' as const : 'ignore' as const)
+
+    function close() {
+        open = false
+    }
+
+    function handleOpenChange(value: boolean) {
+        open = value
+        onOpenChange?.(value)
+    }
+</script>
+
+{#snippet popoverContentEl()}
+    <Popover.Content
+        {side}
+        {sideOffset}
+        {align}
+        {alignOffset}
+        {avoidCollisions}
+        {collisionBoundary}
+        {collisionPadding}
+        {sticky}
+        {hideWhenDetached}
+        {trapFocus}
+        {preventScroll}
+        escapeKeydownBehavior={dismissBehavior}
+        interactOutsideBehavior={dismissBehavior}
+        {onOpenAutoFocus}
+        {onCloseAutoFocus}
+        {onEscapeKeydown}
+        {onInteractOutside}
+        {forceMount}
+        class={[classes.content, !children ? className : undefined]}
+    >
+        {#if contentSlot}
+            {@render contentSlot({ open, close })}
+        {/if}
+
+        {#if showArrow}
+            <Popover.Arrow
+                width={arrowProps.width}
+                height={arrowProps.height}
+                class={classes.arrow}
+            />
+        {/if}
+    </Popover.Content>
+{/snippet}
+
+<Popover.Root bind:open onOpenChange={handleOpenChange} {onOpenChangeComplete}>
+    {#if children}
+        <Popover.Trigger>
+            {#snippet child({ props })}
+                <span
+                    {...props}
+                    class={className as string}
+                >
+                    {@render children({ open })}
+                </span>
+            {/snippet}
+        </Popover.Trigger>
+    {/if}
+
+    {#if portal}
+        <Popover.Portal>
+            {@render popoverContentEl()}
+        </Popover.Portal>
+    {:else}
+        {@render popoverContentEl()}
+    {/if}
+</Popover.Root>

--- a/src/lib/Popover/Popover.svelte.spec.ts
+++ b/src/lib/Popover/Popover.svelte.spec.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-svelte'
+import Popover from './Popover.svelte'
+
+describe('Popover', () => {
+    const getContent = () => document.querySelector('[data-popover-content]') as HTMLElement | null
+    const getArrow = () => document.querySelector('[data-popover-arrow]') as HTMLElement | null
+
+    // ==================== RENDERING ====================
+
+    describe('rendering', () => {
+        it('should render without crashing', () => {
+            const { container } = render(Popover)
+            expect(container).not.toBeNull()
+        })
+
+        it('should not render content when closed', () => {
+            render(Popover)
+            expect(getContent()).toBeNull()
+        })
+
+        it('should render content when open', async () => {
+            render(Popover, { open: true })
+            await vi.waitFor(() => {
+                expect(getContent()).not.toBeNull()
+            })
+        })
+    })
+
+    // ==================== POSITIONS (SIDE) ====================
+
+    describe('positions', () => {
+        it('should apply bottom side by default', async () => {
+            render(Popover, { open: true })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.getAttribute('data-side')).toBe('bottom')
+            })
+        })
+
+        it('should apply top side', async () => {
+            render(Popover, { open: true, side: 'top' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.getAttribute('data-side')).toBe('top')
+            })
+        })
+
+        it('should apply right side', async () => {
+            render(Popover, { open: true, side: 'right' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.getAttribute('data-side')).toBe('right')
+            })
+        })
+
+        it('should apply left side', async () => {
+            render(Popover, { open: true, side: 'left' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.getAttribute('data-side')).toBe('left')
+            })
+        })
+    })
+
+    // ==================== ALIGNMENT ====================
+
+    describe('alignment', () => {
+        it('should apply center alignment by default', async () => {
+            render(Popover, { open: true })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.getAttribute('data-align')).toBe('center')
+            })
+        })
+
+        it('should apply start alignment', async () => {
+            render(Popover, { open: true, align: 'start' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.getAttribute('data-align')).toBe('start')
+            })
+        })
+
+        it('should apply end alignment', async () => {
+            render(Popover, { open: true, align: 'end' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.getAttribute('data-align')).toBe('end')
+            })
+        })
+    })
+
+    // ==================== ARROW ====================
+
+    describe('arrow', () => {
+        it('should not render arrow by default', async () => {
+            render(Popover, { open: true })
+            await vi.waitFor(() => {
+                expect(getContent()).not.toBeNull()
+            })
+            expect(getArrow()).toBeNull()
+        })
+
+        it('should render arrow when arrow is true', async () => {
+            render(Popover, { open: true, arrow: true })
+            await vi.waitFor(() => {
+                expect(getArrow()).not.toBeNull()
+            })
+        })
+
+        it('should accept custom arrow dimensions', async () => {
+            render(Popover, { open: true, arrow: { width: 16, height: 8 } })
+            await vi.waitFor(() => {
+                const arrow = getArrow()
+                expect(arrow).not.toBeNull()
+                const svg = arrow!.querySelector('svg')
+                expect(svg).not.toBeNull()
+                expect(svg!.getAttribute('width')).toBe('16')
+                expect(svg!.getAttribute('height')).toBe('8')
+            })
+        })
+    })
+
+    // ==================== DISMISSIBLE ====================
+
+    describe('dismissible', () => {
+        it('should render with default dismissible behavior', async () => {
+            render(Popover, { open: true })
+            await vi.waitFor(() => {
+                expect(getContent()).not.toBeNull()
+            })
+        })
+
+        it('should render with non-dismissible behavior', async () => {
+            render(Popover, { open: true, dismissible: false })
+            await vi.waitFor(() => {
+                expect(getContent()).not.toBeNull()
+            })
+        })
+    })
+
+    // ==================== PORTAL ====================
+
+    describe('portal', () => {
+        it('should render in portal by default', async () => {
+            const { container } = render(Popover, { open: true })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(container.contains(content)).toBe(false)
+                expect(document.body.contains(content)).toBe(true)
+            })
+        })
+    })
+
+    // ==================== TRANSITION ====================
+
+    describe('transition', () => {
+        it('should apply transition animation classes by default', async () => {
+            render(Popover, { open: true })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toMatch(/animate-/)
+            })
+        })
+
+        it('should not apply transition classes when transition is false', async () => {
+            render(Popover, { open: true, transition: false })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).not.toMatch(/animate-\[fade/)
+            })
+        })
+    })
+
+    // ==================== VARIANT CLASSES ====================
+
+    describe('variant classes', () => {
+        it('should apply content base classes', async () => {
+            render(Popover, { open: true })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('z-50')
+                expect(content!.className).toContain('bg-surface-container-low')
+                expect(content!.className).toContain('text-on-surface')
+                expect(content!.className).toContain('rounded-md')
+            })
+        })
+
+        it('should apply arrow classes', async () => {
+            render(Popover, { open: true, arrow: true })
+            await vi.waitFor(() => {
+                const arrow = getArrow()
+                expect(arrow).not.toBeNull()
+                expect(arrow!.className).toContain('fill-surface-container-low')
+            })
+        })
+    })
+
+    // ==================== UI SLOT OVERRIDES ====================
+
+    describe('ui slot overrides', () => {
+        it('should apply ui.content class', async () => {
+            render(Popover, { open: true, ui: { content: 'custom-content' } })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('custom-content')
+            })
+        })
+
+        it('should apply ui.arrow class', async () => {
+            render(Popover, { open: true, arrow: true, ui: { arrow: 'custom-arrow' } })
+            await vi.waitFor(() => {
+                const arrow = getArrow()
+                expect(arrow).not.toBeNull()
+                expect(arrow!.className).toContain('custom-arrow')
+            })
+        })
+    })
+
+    // ==================== CALLBACKS ====================
+
+    describe('callbacks', () => {
+        it('should accept onOpenChange callback', async () => {
+            const onOpenChange = vi.fn()
+            render(Popover, { open: true, onOpenChange })
+            await vi.waitFor(() => {
+                expect(getContent()).not.toBeNull()
+            })
+            expect(onOpenChange).toBeTypeOf('function')
+        })
+    })
+
+    // ==================== COMBINED FEATURES ====================
+
+    describe('combined features', () => {
+        it('should render with arrow and custom side', async () => {
+            render(Popover, { open: true, arrow: true, side: 'top' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.getAttribute('data-side')).toBe('top')
+                expect(getArrow()).not.toBeNull()
+            })
+        })
+
+        it('should render with custom alignment and side', async () => {
+            render(Popover, { open: true, side: 'right', align: 'start' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.getAttribute('data-side')).toBe('right')
+                expect(content!.getAttribute('data-align')).toBe('start')
+            })
+        })
+
+        it('should render with all ui overrides', async () => {
+            render(Popover, {
+                open: true,
+                arrow: true,
+                ui: {
+                    content: 'ct-custom',
+                    arrow: 'ar-custom'
+                }
+            })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('ct-custom')
+                const arrow = getArrow()
+                expect(arrow).not.toBeNull()
+                expect(arrow!.className).toContain('ar-custom')
+            })
+        })
+
+        it('should render non-dismissible with arrow', async () => {
+            render(Popover, { open: true, arrow: true, dismissible: false })
+            await vi.waitFor(() => {
+                expect(getContent()).not.toBeNull()
+                expect(getArrow()).not.toBeNull()
+            })
+        })
+    })
+})

--- a/src/lib/Popover/index.ts
+++ b/src/lib/Popover/index.ts
@@ -1,0 +1,2 @@
+export { default as Popover } from './Popover.svelte'
+export type { PopoverProps } from './popover.types.js'

--- a/src/lib/Popover/popover.types.ts
+++ b/src/lib/Popover/popover.types.ts
@@ -1,0 +1,83 @@
+import type { Snippet } from 'svelte'
+import type { ClassNameValue } from 'tailwind-merge'
+import type { PopoverSlots, PopoverVariantProps } from './popover.variants.js'
+import type {
+    PopoverRootPropsWithoutHTML,
+    PopoverContentPropsWithoutHTML,
+    PopoverArrowPropsWithoutHTML
+} from 'bits-ui'
+
+type RootProps = Pick<
+    PopoverRootPropsWithoutHTML,
+    | 'open'
+    | 'onOpenChange'
+    | 'onOpenChangeComplete'
+>
+
+type ContentProps = Pick<
+    PopoverContentPropsWithoutHTML,
+    | 'side'
+    | 'sideOffset'
+    | 'align'
+    | 'alignOffset'
+    | 'avoidCollisions'
+    | 'collisionBoundary'
+    | 'collisionPadding'
+    | 'sticky'
+    | 'hideWhenDetached'
+    | 'trapFocus'
+    | 'preventScroll'
+    | 'onOpenAutoFocus'
+    | 'onCloseAutoFocus'
+    | 'onEscapeKeydown'
+    | 'onInteractOutside'
+    | 'forceMount'
+>
+
+export interface PopoverProps extends RootProps, ContentProps {
+    /**
+     * Display an arrow alongside the popover.
+     * Can be a boolean or arrow props for customization.
+     * @default false
+     */
+    arrow?: boolean | Pick<PopoverArrowPropsWithoutHTML, 'width' | 'height'>
+
+    /**
+     * Animate the popover on open and close.
+     * @default true
+     */
+    transition?: PopoverVariantProps['transition']
+
+    /**
+     * Render the popover content in a portal.
+     * @default true
+     */
+    portal?: boolean
+
+    /**
+     * Allow dismissing the popover by clicking outside or pressing Escape.
+     * @default true
+     */
+    dismissible?: boolean
+
+    /**
+     * Additional CSS class for the trigger wrapper.
+     */
+    class?: ClassNameValue
+
+    /**
+     * Override classes for popover slots.
+     */
+    ui?: Partial<Record<PopoverSlots, ClassNameValue>>
+
+    /**
+     * Default slot content used as the trigger element.
+     * When provided, clicking this element opens the popover.
+     */
+    children?: Snippet<[{ open: boolean }]>
+
+    /**
+     * Custom popover content.
+     */
+    content?: Snippet<[{ open: boolean; close: () => void }]>
+}

--- a/src/lib/Popover/popover.variants.ts
+++ b/src/lib/Popover/popover.variants.ts
@@ -1,0 +1,48 @@
+import { tv, type VariantProps } from 'tailwind-variants'
+
+export const popoverVariants = tv({
+    slots: {
+        content: [
+            'z-50',
+            'bg-surface-container-low text-on-surface',
+            'rounded-md',
+            '[--ui-border-color:var(--color-outline-variant)]',
+            '[filter:drop-shadow(0_4px_6px_rgb(0_0_0/0.07))_drop-shadow(0_2px_4px_rgb(0_0_0/0.06))_drop-shadow(0_0_1px_var(--ui-border-color))]',
+            'focus:outline-none pointer-events-auto'
+        ],
+        arrow: 'fill-surface-container-low text-surface-container-low'
+    },
+    variants: {
+        side: {
+            top: {
+                content: 'data-[state=open]:animate-[slide-in-from-bottom_150ms_ease-out] data-[state=closed]:animate-[slide-in-from-top_100ms_ease-in_reverse]'
+            },
+            right: {
+                content: 'data-[state=open]:animate-[slide-in-from-left_150ms_ease-out] data-[state=closed]:animate-[slide-in-from-right_100ms_ease-in_reverse]'
+            },
+            bottom: {
+                content: 'data-[state=open]:animate-[slide-in-from-top_150ms_ease-out] data-[state=closed]:animate-[slide-in-from-bottom_100ms_ease-in_reverse]'
+            },
+            left: {
+                content: 'data-[state=open]:animate-[slide-in-from-right_150ms_ease-out] data-[state=closed]:animate-[slide-in-from-left_100ms_ease-in_reverse]'
+            }
+        },
+        transition: {
+            true: {
+                content: 'data-[state=open]:animate-[fade-in_150ms_ease-out,scale-in_150ms_ease-out] data-[state=closed]:animate-[fade-out_100ms_ease-in,scale-out_100ms_ease-in]'
+            }
+        }
+    },
+    defaultVariants: {
+        side: 'bottom',
+        transition: true
+    }
+})
+
+export type PopoverVariantProps = VariantProps<typeof popoverVariants>
+export type PopoverSlots = keyof ReturnType<typeof popoverVariants>
+
+export const popoverDefaults = {
+    defaultVariants: popoverVariants.defaultVariants,
+    slots: {} as Partial<Record<PopoverSlots, string>>
+}

--- a/src/lib/Popover/popover.variants.ts
+++ b/src/lib/Popover/popover.variants.ts
@@ -4,13 +4,13 @@ export const popoverVariants = tv({
     slots: {
         content: [
             'z-50',
-            'bg-surface-container-low text-on-surface',
+            'bg-inverse-surface text-inverse-on-surface',
             'rounded-md',
-            '[--ui-border-color:var(--color-outline-variant)]',
-            '[filter:drop-shadow(0_4px_6px_rgb(0_0_0/0.07))_drop-shadow(0_2px_4px_rgb(0_0_0/0.06))_drop-shadow(0_0_1px_var(--ui-border-color))]',
+            '[--ui-border-color:rgb(255_255_255/0.1)]',
+            '[filter:drop-shadow(0_1px_2px_rgb(0_0_0/0.1))_drop-shadow(0_0_1px_var(--ui-border-color))]',
             'focus:outline-none pointer-events-auto'
         ],
-        arrow: 'fill-surface-container-low text-surface-container-low'
+        arrow: 'fill-inverse-surface text-inverse-surface'
     },
     variants: {
         side: {

--- a/src/lib/Slideover/index.ts
+++ b/src/lib/Slideover/index.ts
@@ -1,3 +1,2 @@
 export { default as Slideover } from './Slideover.svelte'
-export type { SlideoverProps, SlideoverCloseProps } from './slideover.types.js'
-export type { SlideoverSide } from './slideover.variants.js'
+export type { SlideoverProps } from './slideover.types.js'

--- a/src/lib/Slideover/slideover.types.ts
+++ b/src/lib/Slideover/slideover.types.ts
@@ -36,13 +36,9 @@ type ContentProps = Pick<
  * Props for customizing the close button appearance.
  */
 export interface SlideoverCloseProps {
-    /** Button color scheme. */
     color?: NonNullable<ButtonVariantProps['color']>
-    /** Button visual style. */
     variant?: NonNullable<ButtonVariantProps['variant']>
-    /** Button size. */
     size?: NonNullable<ButtonVariantProps['size']>
-    /** Icon displayed inside the close button. Supports any Iconify icon name. */
     icon?: string
 }
 

--- a/src/lib/Slideover/slideover.variants.ts
+++ b/src/lib/Slideover/slideover.variants.ts
@@ -43,7 +43,6 @@ export const slideoverVariants = tv({
         }
     },
     compoundVariants: [
-        // Transition animations per side
         {
             transition: true,
             side: 'top',
@@ -72,7 +71,6 @@ export const slideoverVariants = tv({
                 content: 'data-[state=open]:animate-[slide-in-full-left_200ms_ease-out,fade-in_200ms_ease-out] data-[state=closed]:animate-[slide-out-full-left_150ms_ease-in,fade-out_150ms_ease-in]'
             }
         },
-        // Inset mode with rounded corners and margins
         {
             inset: true,
             side: 'top',
@@ -101,7 +99,6 @@ export const slideoverVariants = tv({
                 content: 'left-4 inset-y-4 rounded-xl shadow-lg ring ring-outline-variant'
             }
         },
-        // Non-inset mode with edge styling
         {
             inset: false,
             side: 'top',
@@ -141,7 +138,6 @@ export const slideoverVariants = tv({
 
 export type SlideoverVariantProps = VariantProps<typeof slideoverVariants>
 export type SlideoverSlots = keyof ReturnType<typeof slideoverVariants>
-export type SlideoverSide = NonNullable<SlideoverVariantProps['side']>
 
 export const slideoverDefaults = {
     defaultVariants: slideoverVariants.defaultVariants,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -21,6 +21,7 @@ export * from './Tooltip/index.js'
 export * from './Modal/index.js'
 export * from './Accordion/index.js'
 export * from './Slideover/index.js'
+export * from './Popover/index.js'
 
 // Configuration
 export { defineConfig } from './config.js'

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -31,7 +31,8 @@
 		{ href: '/tooltip', label: 'Tooltip', icon: 'lucide:message-square' },
 		{ href: '/modal', label: 'Modal', icon: 'lucide:square-stack' },
 		{ href: '/accordion', label: 'Accordion', icon: 'lucide:chevrons-down-up' },
-		{ href: '/slideover', label: 'Slideover', icon: 'lucide:panel-right' }
+		{ href: '/slideover', label: 'Slideover', icon: 'lucide:panel-right' },
+		{ href: '/popover', label: 'Popover', icon: 'lucide:message-circle' }
 	]
 
 	const docItems = [

--- a/src/routes/popover/+page.svelte
+++ b/src/routes/popover/+page.svelte
@@ -25,8 +25,8 @@
                 {/snippet}
                 {#snippet content({ close })}
                     <div class="p-4 w-72">
-                        <p class="text-sm font-medium text-on-surface">Popover Content</p>
-                        <p class="mt-1 text-sm text-on-surface-variant">
+                        <p class="text-sm font-medium">Popover Content</p>
+                        <p class="mt-1 text-sm opacity-70">
                             This is a simple popover with some informational text.
                         </p>
                     </div>
@@ -191,7 +191,7 @@
         </p>
         <div class="flex flex-wrap gap-4 rounded-lg border border-outline-variant bg-surface-container-low p-6">
             <!-- User Profile Card -->
-            <Popover>
+            <Popover ui={{ content: 'bg-surface-container-low text-on-surface [--ui-border-color:var(--color-outline-variant)]' }}>
                 {#snippet children({ open })}
                     <Button variant="soft" icon="lucide:user">Profile</Button>
                 {/snippet}
@@ -224,7 +224,7 @@
             </Popover>
 
             <!-- Notification Panel -->
-            <Popover>
+            <Popover ui={{ content: 'bg-surface-container-low text-on-surface [--ui-border-color:var(--color-outline-variant)]' }}>
                 {#snippet children({ open })}
                     <Button variant="outline" icon="lucide:bell">Notifications</Button>
                 {/snippet}
@@ -283,7 +283,7 @@
                 {#snippet content({ close })}
                     <div class="p-4 w-72">
                         <div class="flex items-center justify-between">
-                            <p class="font-medium text-on-surface">Confirm Action</p>
+                            <p class="font-medium">Confirm Action</p>
                             <Button
                                 icon="lucide:x"
                                 square
@@ -292,7 +292,7 @@
                                 onclick={close}
                             />
                         </div>
-                        <p class="mt-2 text-sm text-on-surface-variant">
+                        <p class="mt-2 text-sm opacity-70">
                             Are you sure you want to proceed with this action?
                         </p>
                         <div class="mt-4 flex justify-end gap-2">
@@ -320,7 +320,7 @@
                 {/snippet}
                 {#snippet content({ close })}
                     <div class="p-4 w-64">
-                        <p class="text-sm text-on-surface">Controlled popover content</p>
+                        <p class="text-sm">Controlled popover content</p>
                     </div>
                 {/snippet}
             </Popover>
@@ -348,8 +348,8 @@
                 {/snippet}
                 {#snippet content({ close })}
                     <div class="p-4 w-72">
-                        <p class="text-sm font-medium text-on-surface">Cannot dismiss by clicking outside</p>
-                        <p class="mt-1 text-sm text-on-surface-variant">
+                        <p class="text-sm font-medium">Cannot dismiss by clicking outside</p>
+                        <p class="mt-1 text-sm opacity-70">
                             You must use the close button to dismiss this popover.
                         </p>
                         <div class="mt-3 flex justify-end">
@@ -463,7 +463,7 @@
         <div class="space-y-2">
             <h3 class="text-lg font-medium text-on-surface">Share Menu</h3>
             <div class="flex flex-wrap gap-4 rounded-lg border border-outline-variant bg-surface-container-low p-6">
-                <Popover>
+                <Popover ui={{ content: 'bg-surface-container-low text-on-surface [--ui-border-color:var(--color-outline-variant)]' }}>
                     {#snippet children({ open })}
                         <Button variant="outline" icon="lucide:share-2">Share</Button>
                     {/snippet}
@@ -483,7 +483,7 @@
         <div class="space-y-2">
             <h3 class="text-lg font-medium text-on-surface">Color Picker</h3>
             <div class="flex flex-wrap gap-4 rounded-lg border border-outline-variant bg-surface-container-low p-6">
-                <Popover>
+                <Popover ui={{ content: 'bg-surface-container-low text-on-surface [--ui-border-color:var(--color-outline-variant)]' }}>
                     {#snippet children({ open })}
                         <Button variant="outline" icon="lucide:palette">Pick Color</Button>
                     {/snippet}
@@ -509,7 +509,7 @@
         <div class="space-y-2">
             <h3 class="text-lg font-medium text-on-surface">Filter Panel</h3>
             <div class="flex flex-wrap gap-4 rounded-lg border border-outline-variant bg-surface-container-low p-6">
-                <Popover>
+                <Popover ui={{ content: 'bg-surface-container-low text-on-surface [--ui-border-color:var(--color-outline-variant)]' }}>
                     {#snippet children({ open })}
                         <Button variant="outline" icon="lucide:filter">Filters</Button>
                     {/snippet}

--- a/src/routes/popover/+page.svelte
+++ b/src/routes/popover/+page.svelte
@@ -1,0 +1,551 @@
+<script lang="ts">
+    import { Popover, Button, Badge, Icon, Separator } from '$lib/index.js'
+
+    let controlledOpen = $state(false)
+</script>
+
+<div class="space-y-12">
+    <header>
+        <h1 class="text-3xl font-bold text-on-surface">Popover</h1>
+        <p class="mt-2 text-on-surface-variant">
+            Display rich content in a floating panel triggered by click. Built on bits-ui Popover primitive.
+        </p>
+    </header>
+
+    <!-- Basic Usage -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Basic Usage</h2>
+        <p class="text-sm text-on-surface-variant">
+            A simple popover with custom content.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg border border-outline-variant bg-surface-container-low p-6">
+            <Popover>
+                {#snippet children({ open })}
+                    <Button variant="outline">Click me</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-4 w-72">
+                        <p class="text-sm font-medium text-on-surface">Popover Content</p>
+                        <p class="mt-1 text-sm text-on-surface-variant">
+                            This is a simple popover with some informational text.
+                        </p>
+                    </div>
+                {/snippet}
+            </Popover>
+        </div>
+    </section>
+
+    <!-- Positions (Side) -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Positions</h2>
+        <p class="text-sm text-on-surface-variant">
+            Control popover placement with the <code class="text-primary">side</code> prop.
+        </p>
+        <div class="flex flex-wrap items-center justify-center gap-8 rounded-lg border border-outline-variant bg-surface-container-low p-12">
+            <Popover side="top">
+                {#snippet children({ open })}
+                    <Button variant="soft">Top</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-3">
+                        <p class="text-sm">Popover on top</p>
+                    </div>
+                {/snippet}
+            </Popover>
+
+            <Popover side="right">
+                {#snippet children({ open })}
+                    <Button variant="soft">Right</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-3">
+                        <p class="text-sm">Popover on right</p>
+                    </div>
+                {/snippet}
+            </Popover>
+
+            <Popover side="bottom">
+                {#snippet children({ open })}
+                    <Button variant="soft">Bottom</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-3">
+                        <p class="text-sm">Popover on bottom</p>
+                    </div>
+                {/snippet}
+            </Popover>
+
+            <Popover side="left">
+                {#snippet children({ open })}
+                    <Button variant="soft">Left</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-3">
+                        <p class="text-sm">Popover on left</p>
+                    </div>
+                {/snippet}
+            </Popover>
+        </div>
+    </section>
+
+    <!-- Alignment -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Alignment</h2>
+        <p class="text-sm text-on-surface-variant">
+            Control alignment with the <code class="text-primary">align</code> prop.
+        </p>
+        <div class="flex flex-wrap items-center justify-center gap-8 rounded-lg border border-outline-variant bg-surface-container-low p-12">
+            <Popover side="bottom" align="start">
+                {#snippet children({ open })}
+                    <Button variant="outline">Start</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-3 w-48">
+                        <p class="text-sm">Aligned to start</p>
+                    </div>
+                {/snippet}
+            </Popover>
+
+            <Popover side="bottom" align="center">
+                {#snippet children({ open })}
+                    <Button variant="outline">Center</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-3 w-48">
+                        <p class="text-sm">Aligned to center</p>
+                    </div>
+                {/snippet}
+            </Popover>
+
+            <Popover side="bottom" align="end">
+                {#snippet children({ open })}
+                    <Button variant="outline">End</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-3 w-48">
+                        <p class="text-sm">Aligned to end</p>
+                    </div>
+                {/snippet}
+            </Popover>
+        </div>
+    </section>
+
+    <!-- With Arrow -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">With Arrow</h2>
+        <p class="text-sm text-on-surface-variant">
+            Add an arrow pointing to the trigger element.
+        </p>
+        <div class="flex flex-wrap items-center justify-center gap-8 rounded-lg border border-outline-variant bg-surface-container-low p-12">
+            <Popover arrow side="top">
+                {#snippet children({ open })}
+                    <Button>Top Arrow</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-3">
+                        <p class="text-sm">Content with arrow</p>
+                    </div>
+                {/snippet}
+            </Popover>
+
+            <Popover arrow side="right">
+                {#snippet children({ open })}
+                    <Button>Right Arrow</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-3">
+                        <p class="text-sm">Content with arrow</p>
+                    </div>
+                {/snippet}
+            </Popover>
+
+            <Popover arrow side="bottom">
+                {#snippet children({ open })}
+                    <Button variant="soft">Bottom Arrow</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-3">
+                        <p class="text-sm">Content with arrow</p>
+                    </div>
+                {/snippet}
+            </Popover>
+
+            <Popover arrow side="left">
+                {#snippet children({ open })}
+                    <Button variant="soft">Left Arrow</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-3">
+                        <p class="text-sm">Content with arrow</p>
+                    </div>
+                {/snippet}
+            </Popover>
+        </div>
+    </section>
+
+    <!-- Rich Content -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Rich Content</h2>
+        <p class="text-sm text-on-surface-variant">
+            Popovers can contain rich, interactive content.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg border border-outline-variant bg-surface-container-low p-6">
+            <!-- User Profile Card -->
+            <Popover>
+                {#snippet children({ open })}
+                    <Button variant="soft" icon="lucide:user">Profile</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="w-72">
+                        <div class="p-4">
+                            <div class="flex items-center gap-3">
+                                <div class="flex size-10 items-center justify-center rounded-full bg-primary text-on-primary">
+                                    <Icon name="lucide:user" size="20" />
+                                </div>
+                                <div>
+                                    <p class="font-medium text-on-surface">John Doe</p>
+                                    <p class="text-sm text-on-surface-variant">john@example.com</p>
+                                </div>
+                            </div>
+                            <Separator class="my-3" />
+                            <div class="flex gap-4 text-sm text-on-surface-variant">
+                                <span><strong class="text-on-surface">128</strong> posts</span>
+                                <span><strong class="text-on-surface">1.2k</strong> followers</span>
+                                <span><strong class="text-on-surface">256</strong> following</span>
+                            </div>
+                        </div>
+                        <Separator />
+                        <div class="p-2">
+                            <Button variant="ghost" size="sm" class="w-full justify-start" icon="lucide:settings">Settings</Button>
+                            <Button variant="ghost" size="sm" class="w-full justify-start" icon="lucide:log-out" color="error">Sign out</Button>
+                        </div>
+                    </div>
+                {/snippet}
+            </Popover>
+
+            <!-- Notification Panel -->
+            <Popover>
+                {#snippet children({ open })}
+                    <Button variant="outline" icon="lucide:bell">Notifications</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="w-80">
+                        <div class="flex items-center justify-between p-4 pb-2">
+                            <p class="font-medium text-on-surface">Notifications</p>
+                            <Badge label="3 new" size="xs" color="primary" />
+                        </div>
+                        <div class="divide-y divide-outline-variant">
+                            <div class="flex gap-3 p-4">
+                                <div class="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+                                    <Icon name="lucide:message-circle" size="16" />
+                                </div>
+                                <div>
+                                    <p class="text-sm text-on-surface">New comment on your post</p>
+                                    <p class="text-xs text-on-surface-variant">2 minutes ago</p>
+                                </div>
+                            </div>
+                            <div class="flex gap-3 p-4">
+                                <div class="flex size-8 shrink-0 items-center justify-center rounded-full bg-success/10 text-success">
+                                    <Icon name="lucide:user-plus" size="16" />
+                                </div>
+                                <div>
+                                    <p class="text-sm text-on-surface">New follower: Jane Smith</p>
+                                    <p class="text-xs text-on-surface-variant">1 hour ago</p>
+                                </div>
+                            </div>
+                            <div class="flex gap-3 p-4">
+                                <div class="flex size-8 shrink-0 items-center justify-center rounded-full bg-warning/10 text-warning">
+                                    <Icon name="lucide:star" size="16" />
+                                </div>
+                                <div>
+                                    <p class="text-sm text-on-surface">Your post was featured</p>
+                                    <p class="text-xs text-on-surface-variant">3 hours ago</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                {/snippet}
+            </Popover>
+        </div>
+    </section>
+
+    <!-- With Close Button -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">With Close Action</h2>
+        <p class="text-sm text-on-surface-variant">
+            The <code class="text-primary">content</code> slot exposes a <code class="text-primary">close</code> function to programmatically dismiss the popover.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg border border-outline-variant bg-surface-container-low p-6">
+            <Popover>
+                {#snippet children({ open })}
+                    <Button variant="outline">Open with close button</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-4 w-72">
+                        <div class="flex items-center justify-between">
+                            <p class="font-medium text-on-surface">Confirm Action</p>
+                            <Button
+                                icon="lucide:x"
+                                square
+                                variant="ghost"
+                                size="xs"
+                                onclick={close}
+                            />
+                        </div>
+                        <p class="mt-2 text-sm text-on-surface-variant">
+                            Are you sure you want to proceed with this action?
+                        </p>
+                        <div class="mt-4 flex justify-end gap-2">
+                            <Button variant="outline" size="sm" onclick={close}>Cancel</Button>
+                            <Button size="sm" onclick={close}>Confirm</Button>
+                        </div>
+                    </div>
+                {/snippet}
+            </Popover>
+        </div>
+    </section>
+
+    <!-- Controlled State -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Controlled State</h2>
+        <p class="text-sm text-on-surface-variant">
+            Control popover visibility programmatically with <code class="text-primary">open</code> binding.
+        </p>
+        <div class="flex flex-wrap items-center gap-4 rounded-lg border border-outline-variant bg-surface-container-low p-6">
+            <Popover bind:open={controlledOpen}>
+                {#snippet children({ open })}
+                    <Button variant={controlledOpen ? 'solid' : 'outline'}>
+                        {controlledOpen ? 'Popover is open' : 'Click to open'}
+                    </Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-4 w-64">
+                        <p class="text-sm text-on-surface">Controlled popover content</p>
+                    </div>
+                {/snippet}
+            </Popover>
+
+            <Button variant="soft" onclick={() => controlledOpen = !controlledOpen}>
+                Toggle: {controlledOpen ? 'Close' : 'Open'}
+            </Button>
+
+            <span class="text-sm text-on-surface-variant">
+                State: <code class="text-primary">{controlledOpen}</code>
+            </span>
+        </div>
+    </section>
+
+    <!-- Not Dismissible -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Non-dismissible</h2>
+        <p class="text-sm text-on-surface-variant">
+            Prevent dismissing by clicking outside or pressing Escape. Only the close function can dismiss.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg border border-outline-variant bg-surface-container-low p-6">
+            <Popover dismissible={false}>
+                {#snippet children({ open })}
+                    <Button variant="outline">Non-dismissible</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-4 w-72">
+                        <p class="text-sm font-medium text-on-surface">Cannot dismiss by clicking outside</p>
+                        <p class="mt-1 text-sm text-on-surface-variant">
+                            You must use the close button to dismiss this popover.
+                        </p>
+                        <div class="mt-3 flex justify-end">
+                            <Button size="sm" onclick={close}>Got it</Button>
+                        </div>
+                    </div>
+                {/snippet}
+            </Popover>
+        </div>
+    </section>
+
+    <!-- Without Portal -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Without Portal</h2>
+        <p class="text-sm text-on-surface-variant">
+            Render popover inline instead of in a portal.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg border border-outline-variant bg-surface-container-low p-6">
+            <Popover portal>
+                {#snippet children({ open })}
+                    <Button variant="outline">With Portal</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-3">
+                        <p class="text-sm">Rendered in portal (default)</p>
+                    </div>
+                {/snippet}
+            </Popover>
+
+            <Popover portal={false}>
+                {#snippet children({ open })}
+                    <Button variant="outline">Without Portal</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-3">
+                        <p class="text-sm">Rendered inline</p>
+                    </div>
+                {/snippet}
+            </Popover>
+        </div>
+    </section>
+
+    <!-- UI Slot Overrides -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">UI Slot Overrides</h2>
+        <p class="text-sm text-on-surface-variant">
+            Customize individual popover parts with the <code class="text-primary">ui</code> prop.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg border border-outline-variant bg-surface-container-low p-6">
+            <Popover
+                ui={{
+                    content: 'bg-primary text-on-primary [--ui-border-color:var(--color-primary)]',
+                    arrow: 'fill-primary text-primary'
+                }}
+                arrow
+            >
+                {#snippet children({ open })}
+                    <Button>Primary Style</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-4 w-64">
+                        <p class="text-sm font-medium">Custom styled popover</p>
+                        <p class="mt-1 text-sm opacity-80">With primary background color.</p>
+                    </div>
+                {/snippet}
+            </Popover>
+
+            <Popover
+                ui={{
+                    content: 'bg-error text-on-error [--ui-border-color:var(--color-error)]',
+                    arrow: 'fill-error text-error'
+                }}
+                arrow
+            >
+                {#snippet children({ open })}
+                    <Button color="error" variant="soft">Error Style</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-4 w-64">
+                        <p class="text-sm font-medium">Error popover</p>
+                        <p class="mt-1 text-sm opacity-80">Something went wrong.</p>
+                    </div>
+                {/snippet}
+            </Popover>
+
+            <Popover
+                ui={{
+                    content: 'rounded-xl shadow-2xl'
+                }}
+            >
+                {#snippet children({ open })}
+                    <Button variant="outline">Custom Rounding</Button>
+                {/snippet}
+                {#snippet content({ close })}
+                    <div class="p-4 w-64">
+                        <p class="text-sm">Extra rounded with larger shadow.</p>
+                    </div>
+                {/snippet}
+            </Popover>
+        </div>
+    </section>
+
+    <!-- Real World Examples -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Real World Examples</h2>
+        <p class="text-sm text-on-surface-variant">
+            Common popover use cases in applications.
+        </p>
+
+        <!-- Share Menu -->
+        <div class="space-y-2">
+            <h3 class="text-lg font-medium text-on-surface">Share Menu</h3>
+            <div class="flex flex-wrap gap-4 rounded-lg border border-outline-variant bg-surface-container-low p-6">
+                <Popover>
+                    {#snippet children({ open })}
+                        <Button variant="outline" icon="lucide:share-2">Share</Button>
+                    {/snippet}
+                    {#snippet content({ close })}
+                        <div class="w-56 p-2">
+                            <Button variant="ghost" size="sm" class="w-full justify-start" icon="lucide:link" onclick={close}>Copy link</Button>
+                            <Button variant="ghost" size="sm" class="w-full justify-start" icon="lucide:twitter" onclick={close}>Twitter</Button>
+                            <Button variant="ghost" size="sm" class="w-full justify-start" icon="lucide:facebook" onclick={close}>Facebook</Button>
+                            <Button variant="ghost" size="sm" class="w-full justify-start" icon="lucide:mail" onclick={close}>Email</Button>
+                        </div>
+                    {/snippet}
+                </Popover>
+            </div>
+        </div>
+
+        <!-- Color Picker -->
+        <div class="space-y-2">
+            <h3 class="text-lg font-medium text-on-surface">Color Picker</h3>
+            <div class="flex flex-wrap gap-4 rounded-lg border border-outline-variant bg-surface-container-low p-6">
+                <Popover>
+                    {#snippet children({ open })}
+                        <Button variant="outline" icon="lucide:palette">Pick Color</Button>
+                    {/snippet}
+                    {#snippet content({ close })}
+                        <div class="p-4 w-56">
+                            <p class="mb-3 text-sm font-medium text-on-surface">Choose a color</p>
+                            <div class="grid grid-cols-5 gap-2">
+                                {#each ['bg-red-500', 'bg-orange-500', 'bg-yellow-500', 'bg-green-500', 'bg-teal-500', 'bg-blue-500', 'bg-indigo-500', 'bg-purple-500', 'bg-pink-500', 'bg-gray-500'] as color}
+                                    <button
+                                        class="size-8 rounded-full {color} hover:ring-2 hover:ring-offset-2 hover:ring-outline transition-all"
+                                        aria-label="Select {color.replace('bg-', '').replace('-500', '')} color"
+                                        onclick={close}
+                                    ></button>
+                                {/each}
+                            </div>
+                        </div>
+                    {/snippet}
+                </Popover>
+            </div>
+        </div>
+
+        <!-- Filter Panel -->
+        <div class="space-y-2">
+            <h3 class="text-lg font-medium text-on-surface">Filter Panel</h3>
+            <div class="flex flex-wrap gap-4 rounded-lg border border-outline-variant bg-surface-container-low p-6">
+                <Popover>
+                    {#snippet children({ open })}
+                        <Button variant="outline" icon="lucide:filter">Filters</Button>
+                    {/snippet}
+                    {#snippet content({ close })}
+                        <div class="w-72">
+                            <div class="p-4">
+                                <p class="font-medium text-on-surface">Filter Results</p>
+                            </div>
+                            <Separator />
+                            <div class="p-4 space-y-3">
+                                <div>
+                                    <p class="text-sm font-medium text-on-surface">Status</p>
+                                    <div class="mt-1 flex gap-2">
+                                        <Badge label="Active" color="success" />
+                                        <Badge label="Pending" color="warning" />
+                                        <Badge label="Closed" color="error" />
+                                    </div>
+                                </div>
+                                <div>
+                                    <p class="text-sm font-medium text-on-surface">Priority</p>
+                                    <div class="mt-1 flex gap-2">
+                                        <Badge label="High" />
+                                        <Badge label="Medium" />
+                                        <Badge label="Low" />
+                                    </div>
+                                </div>
+                            </div>
+                            <Separator />
+                            <div class="p-3 flex justify-end gap-2">
+                                <Button variant="ghost" size="sm" onclick={close}>Reset</Button>
+                                <Button size="sm" onclick={close}>Apply</Button>
+                            </div>
+                        </div>
+                    {/snippet}
+                </Popover>
+            </div>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
## Summary

Add a new `Popover` component to the library, built on [bits-ui](https://bits-ui.com/docs/components/popover) Popover primitives. The component provides click-triggered floating panels for displaying rich, interactive content.

## Features

### Core
- **Click-to-toggle** behavior using bits-ui `Popover.Root` / `Popover.Trigger` / `Popover.Content`
- **Positioning** via `side` (`top` | `right` | `bottom` | `left`) and `align` (`start` | `center` | `end`) props, powered by Floating UI
- **Collision detection** with configurable boundary, padding, and sticky behavior
- **Portal rendering** enabled by default, with opt-out via `portal={false}`
- **Controlled state** via bindable `open` prop and `onOpenChange` / `onOpenChangeComplete` callbacks
- **Dismissible** prop to control escape keydown and interact-outside behavior (`close` vs `ignore`)
- **Focus trap** and **scroll prevention** options for accessibility
- **`forceMount`** support for persistent DOM presence

### Arrow
- Toggle with `arrow` prop (boolean) or pass `{ width, height }` for custom dimensions
- Arrow color follows content background using both `fill-*` and `text-*` classes (bits-ui arrow SVG uses `fill="currentColor"`)

### Styling
- **Unified border + shadow** using CSS `filter: drop-shadow()` on the content element, which naturally wraps around the arrow child — unlike `box-shadow` / `ring` which only follow the element's box shape
- **Customizable border color** via CSS variable `--ui-border-color` (defaults to `--color-outline-variant`), making it easy to override:
  ```svelte
  <Popover ui={{ content: '[--ui-border-color:var(--color-primary)]' }}>
  ```
- **Slot-based `ui` prop** for overriding `content` and `arrow` classes independently
- **Transition animations** per side (slide-in/out) combined with fade/scale, configurable via `transition` prop
- Built with `tailwind-variants` (`tv()`) following the library's existing variant system
- Supports global config overrides via `getComponentConfig('popover', ...)`

### Content slot
- Exposes `{ open: boolean, close: () => void }` to the content snippet
- `close()` sets `open = false` without double-firing `onOpenChange`

## Files

| File | Description |
|---|---|
| `src/lib/Popover/Popover.svelte` | Main component — individual props passed to `Popover.Content` (not spread) for granular Svelte 5 reactivity |
| `src/lib/Popover/popover.types.ts` | TypeScript interface picking from bits-ui `PopoverRootPropsWithoutHTML` and `PopoverContentPropsWithoutHTML` |
| `src/lib/Popover/popover.variants.ts` | Theme variants with `content` and `arrow` slots, side-based slide animations, and fade/scale transitions |
| `src/lib/Popover/index.ts` | Barrel export |
| `src/lib/Popover/Popover.svelte.spec.ts` | 27 test cases |
| `src/routes/popover/+page.svelte` | Demo page with 10 sections |
| `src/lib/index.ts` | Added `Popover` export |
| `src/routes/+layout.svelte` | Added Popover to sidebar navigation |

### Minor cleanup (Modal / Slideover)
- Removed unused type exports (`ModalCloseProps`, `SlideoverCloseProps`, `SlideoverSide`)
- Removed redundant JSDoc comments on internal `CloseProps` interfaces
- Removed unnecessary code comments in `slideover.variants.ts`

## Demo page sections

1. **Basic Usage** — simple popover with text content
2. **Positions** — top / right / bottom / left side placement
3. **Alignment** — start / center / end alignment
4. **With Arrow** — arrow on all four sides
5. **Rich Content** — user profile card, notification panel
6. **With Close Action** — content slot `close()` function usage with confirm dialog
7. **Controlled State** — external `bind:open` with toggle button and state display
8. **Non-dismissible** — escape / click-outside ignored, only `close()` works
9. **Without Portal** — inline rendering comparison
10. **UI Slot Overrides** — primary color, error color, custom rounding
11. **Real World Examples** — share menu, color picker, filter panel

## Test plan

- [x] 27 unit tests pass (vitest + playwright browser)
  - Rendering (3): basic render, closed/open states
  - Positions (4): all four sides via `data-side` attribute
  - Alignment (3): start/center/end via `data-align` attribute
  - Arrow (3): hidden by default, visible when enabled, custom SVG dimensions
  - Dismissible (2): default and non-dismissible rendering
  - Portal (1): content renders to `document.body`, not inside container
  - Transition (2): animation classes present/absent
  - Variant classes (2): content base classes, arrow fill classes
  - UI slot overrides (2): custom content and arrow class injection
  - Callbacks (1): `onOpenChange` type check
  - Combined features (4): arrow+side, alignment+side, all UI overrides, non-dismissible+arrow
- [ ] Verify demo page renders correctly at `/popover`
- [ ] Test arrow + border alignment with custom UI overrides (primary, error)
- [ ] Test dismissible vs non-dismissible behavior
- [ ] Test portal vs inline rendering
