### PR TITLE
fix: auto-detect source in theme.css, remove manual @source for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ pnpm add sv5ui
 **1. Import the theme**
 
 ```css
-/* app.css */
+/* layout.css */
 @import 'sv5ui/theme.css';
-@source '../../node_modules/sv5ui/dist';
 ```
 
 **2. Use components**

--- a/src/lib/theme.css
+++ b/src/lib/theme.css
@@ -8,6 +8,7 @@
  */
 
 @import 'tailwindcss';
+@source '.';
 
 /* ============================================
  * DARK MODE CONFIGURATION


### PR DESCRIPTION
## Summary
- Add `@source '.'` to `theme.css` so Tailwind automatically scans sv5ui components when users import the theme
- Remove `@source '../../node_modules/sv5ui/dist'` from README Quick Start guide

Users now only need one line to set up:
```css
@import 'sv5ui/theme.css';
