### PR TITLE
feat: add Calendar component

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     ],
     "dependencies": {
         "@iconify/svelte": "^5.2.1",
+        "@internationalized/date": "^3.11.0",
         "bits-ui": "^2.15.4",
         "tailwind-merge": "^3.4.0",
         "tailwind-variants": "^3.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,12 @@ importers:
       '@iconify/svelte':
         specifier: ^5.2.1
         version: 5.2.1(svelte@5.48.2)
+      '@internationalized/date':
+        specifier: ^3.11.0
+        version: 3.11.0
       bits-ui:
         specifier: ^2.15.4
-        version: 2.15.4(@internationalized/date@3.10.1)(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.2)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.48.2)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.48.2)
+        version: 2.15.4(@internationalized/date@3.11.0)(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.2)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.48.2)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.48.2)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -344,8 +347,8 @@ packages:
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
-  '@internationalized/date@3.10.1':
-    resolution: {integrity: sha512-oJrXtQiAXLvT9clCf1K4kxp3eKsQhIaZqxEyowkBcsvZDdZkbWrVmnGknxs5flTD0VGsxrxKgBCZty1EzoiMzA==}
+  '@internationalized/date@3.11.0':
+    resolution: {integrity: sha512-BOx5huLAWhicM9/ZFs84CzP+V3gBW6vlpM02yzsdYC7TGlZJX1OJiEEHcSayF00Z+3jLlm4w79amvSt6RqKN3Q==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -404,66 +407,79 @@ packages:
     resolution: {integrity: sha512-E8jKK87uOvLrrLN28jnAAAChNq5LeCd2mGgZF+fGF5D507WlG/Noct3lP/QzQ6MrqJ5BCKNwI9ipADB6jyiq2A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.56.0':
     resolution: {integrity: sha512-jQosa5FMYF5Z6prEpTCCmzCXz6eKr/tCBssSmQGEeozA9tkRUty/5Vx06ibaOP9RCrW1Pvb8yp3gvZhHwTDsJw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.56.0':
     resolution: {integrity: sha512-uQVoKkrC1KGEV6udrdVahASIsaF8h7iLG0U0W+Xn14ucFwi6uS539PsAr24IEF9/FoDtzMeeJXJIBo5RkbNWvQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.56.0':
     resolution: {integrity: sha512-vLZ1yJKLxhQLFKTs42RwTwa6zkGln+bnXc8ueFGMYmBTLfNu58sl5/eXyxRa2RarTkJbXl8TKPgfS6V5ijNqEA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.56.0':
     resolution: {integrity: sha512-FWfHOCub564kSE3xJQLLIC/hbKqHSVxy8vY75/YHHzWvbJL7aYJkdgwD/xGfUlL5UV2SB7otapLrcCj2xnF1dg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.56.0':
     resolution: {integrity: sha512-z1EkujxIh7nbrKL1lmIpqFTc/sr0u8Uk0zK/qIEFldbt6EDKWFk/pxFq3gYj4Bjn3aa9eEhYRlL3H8ZbPT1xvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.56.0':
     resolution: {integrity: sha512-iNFTluqgdoQC7AIE8Q34R3AuPrJGJirj5wMUErxj22deOcY7XwZRaqYmB6ZKFHoVGqRcRd0mqO+845jAibKCkw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.56.0':
     resolution: {integrity: sha512-MtMeFVlD2LIKjp2sE2xM2slq3Zxf9zwVuw0jemsxvh1QOpHSsSzfNOTH9uYW9i1MXFxUSMmLpeVeUzoNOKBaWg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.56.0':
     resolution: {integrity: sha512-in+v6wiHdzzVhYKXIk5U74dEZHdKN9KH0Q4ANHOTvyXPG41bajYRsy7a8TPKbYPl34hU7PP7hMVHRvv/5aCSew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.56.0':
     resolution: {integrity: sha512-yni2raKHB8m9NQpI9fPVwN754mn6dHQSbDTwxdr9SE0ks38DTjLMMBjrwvB5+mXrX+C0npX0CVeCUcvvvD8CNQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.56.0':
     resolution: {integrity: sha512-zhLLJx9nQPu7wezbxt2ut+CI4YlXi68ndEve16tPc/iwoylWS9B3FxpLS2PkmfYgDQtosah07Mj9E0khc3Y+vQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.56.0':
     resolution: {integrity: sha512-MVC6UDp16ZSH7x4rtuJPAEoE1RwS8N4oK9DLHy3FTEdFoUTCFVzMfJl/BVJ330C+hx8FfprA5Wqx4FhZXkj2Kw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.56.0':
     resolution: {integrity: sha512-ZhGH1eA4Qv0lxaV00azCIS1ChedK0V32952Md3FtnxSqZTBTd6tgil4nZT5cU8B+SIw3PFYkvyR4FKo2oyZIHA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.56.0':
     resolution: {integrity: sha512-O16XcmyDeFI9879pEcmtWvD/2nyxR9mF7Gs44lf1vGGx8Vg2DRNx11aVXBEqOQhWb92WN4z7fW/q4+2NYzCbBA==}
@@ -587,24 +603,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1135,24 +1155,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -1885,7 +1909,7 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
-  '@internationalized/date@3.10.1':
+  '@internationalized/date@3.11.0':
     dependencies:
       '@swc/helpers': 0.5.18
 
@@ -2326,11 +2350,11 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  bits-ui@2.15.4(@internationalized/date@3.10.1)(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.2)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.48.2)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.48.2):
+  bits-ui@2.15.4(@internationalized/date@3.11.0)(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.2)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.48.2)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.48.2):
     dependencies:
       '@floating-ui/core': 1.7.3
       '@floating-ui/dom': 1.7.4
-      '@internationalized/date': 3.10.1
+      '@internationalized/date': 3.11.0
       esm-env: 1.2.2
       runed: 0.35.1(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.2)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.48.2)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.48.2)
       svelte: 5.48.2

--- a/src/lib/Calendar/Calendar.svelte
+++ b/src/lib/Calendar/Calendar.svelte
@@ -1,0 +1,460 @@
+<script lang="ts" module>
+    import type {
+        CalendarProps,
+        CalendarRangeProps,
+        CalendarSingleProps,
+        CalendarMultipleProps
+    } from './calendar.types.js'
+
+    export type Props = CalendarProps
+</script>
+
+<script lang="ts">
+    import { Calendar, RangeCalendar } from 'bits-ui'
+    import { calendarVariants, calendarDefaults } from './calendar.variants.js'
+    import { getComponentConfig } from '../config.js'
+    import Icon from '../Icon/Icon.svelte'
+    import type { DateValue } from '@internationalized/date'
+    import type { Month } from 'bits-ui'
+
+    const config = getComponentConfig('calendar', calendarDefaults)
+
+    let {
+        // Value props
+        value = $bindable(),
+        onValueChange,
+        placeholder = $bindable(),
+        onPlaceholderChange,
+
+        // Range-specific props
+        range = false,
+
+        // Navigation icons
+        prevMonthIcon = 'lucide:chevron-left',
+        nextMonthIcon = 'lucide:chevron-right',
+        prevYearIcon = 'lucide:chevrons-left',
+        nextYearIcon = 'lucide:chevrons-right',
+
+        // Controls
+        monthControls = true,
+        yearControls = false,
+        weekNumbers = false,
+
+        // Calendar props
+        preventDeselect = false,
+        minValue,
+        maxValue,
+        disabled = false,
+        pagedNavigation = false,
+        weekStartsOn = 0,
+        weekdayFormat = 'short',
+        isDateDisabled,
+        isDateUnavailable,
+        fixedWeeks = false,
+        numberOfMonths = 1,
+        calendarLabel,
+        locale = 'en',
+        readonly = false,
+        disableDaysOutsideMonth = false,
+
+        // Styling
+        color = config.defaultVariants.color ?? 'primary',
+        size = config.defaultVariants.size ?? 'md',
+        variant = config.defaultVariants.variant ?? 'solid',
+        ui,
+        class: className,
+
+        // Snippets
+        heading: headingSlot,
+        day: daySlot,
+        weekday: weekdaySlot,
+
+        // Spread remaining props (initialFocus, type, minDays, maxDays, etc.)
+        ...restProps
+    }: Props = $props()
+
+    // Compute variant classes
+    const variantSlots = $derived(calendarVariants({ color, size, variant, weekNumbers }))
+    const classes = $derived({
+        root: variantSlots.root({ class: [config.slots.root, className, ui?.root] }),
+        header: variantSlots.header({ class: [config.slots.header, ui?.header] }),
+        body: variantSlots.body({ class: [config.slots.body, ui?.body] }),
+        heading: variantSlots.heading({ class: [config.slots.heading, ui?.heading] }),
+        navButton: variantSlots.navButton({ class: [config.slots.navButton, ui?.navButton] }),
+        navButtonIcon: variantSlots.navButtonIcon({
+            class: [config.slots.navButtonIcon, ui?.navButtonIcon]
+        }),
+        grid: variantSlots.grid({ class: [config.slots.grid, ui?.grid] }),
+        gridWeekDaysRow: variantSlots.gridWeekDaysRow({
+            class: [config.slots.gridWeekDaysRow, ui?.gridWeekDaysRow]
+        }),
+        gridBody: variantSlots.gridBody({ class: [config.slots.gridBody, ui?.gridBody] }),
+        gridRow: variantSlots.gridRow({ class: [config.slots.gridRow, ui?.gridRow] }),
+        headCell: variantSlots.headCell({ class: [config.slots.headCell, ui?.headCell] }),
+        headCellWeek: variantSlots.headCellWeek({
+            class: [config.slots.headCellWeek, ui?.headCellWeek]
+        }),
+        cell: variantSlots.cell({ class: [config.slots.cell, ui?.cell] }),
+        cellTrigger: variantSlots.cellTrigger({
+            class: [config.slots.cellTrigger, ui?.cellTrigger]
+        }),
+        cellWeek: variantSlots.cellWeek({ class: [config.slots.cellWeek, ui?.cellWeek] })
+    })
+
+    // Year navigation helper
+    function paginateYear(date: DateValue, years: number): DateValue {
+        return date.add({ years })
+    }
+
+    // Common calendar props
+    const commonProps = $derived({
+        placeholder,
+        onPlaceholderChange: (val: DateValue) => {
+            placeholder = val
+            onPlaceholderChange?.(val)
+        },
+        preventDeselect,
+        minValue,
+        maxValue,
+        disabled,
+        pagedNavigation,
+        weekStartsOn,
+        weekdayFormat,
+        isDateDisabled,
+        isDateUnavailable,
+        fixedWeeks,
+        numberOfMonths,
+        calendarLabel,
+        locale,
+        readonly,
+        disableDaysOutsideMonth
+    })
+</script>
+
+{#snippet calendarContent(months: Month<DateValue>[], weekdays: string[])}
+    {#each months as month, monthIndex (monthIndex)}
+        <div>
+            <Calendar.Header class={classes.header}>
+                {#if headingSlot}
+                    {@render headingSlot({
+                        headingValue: month.value
+                            .toDate('UTC')
+                            .toLocaleDateString(locale, { month: 'long', year: 'numeric' }),
+                        prevMonth: () => {},
+                        nextMonth: () => {},
+                        prevYear: () => {
+                            if (placeholder) placeholder = paginateYear(placeholder, -1)
+                        },
+                        nextYear: () => {
+                            if (placeholder) placeholder = paginateYear(placeholder, 1)
+                        }
+                    })}
+                {:else}
+                    <div class="flex items-center gap-1">
+                        {#if yearControls}
+                            <button
+                                type="button"
+                                class={classes.navButton}
+                                onclick={() => {
+                                    if (placeholder) placeholder = paginateYear(placeholder, -1)
+                                }}
+                                aria-label="Previous year"
+                            >
+                                <Icon name={prevYearIcon} class={classes.navButtonIcon} />
+                            </button>
+                        {/if}
+                        {#if monthControls}
+                            <Calendar.PrevButton class={classes.navButton}>
+                                <Icon name={prevMonthIcon} class={classes.navButtonIcon} />
+                            </Calendar.PrevButton>
+                        {/if}
+                    </div>
+
+                    <Calendar.Heading class={classes.heading} />
+
+                    <div class="flex items-center gap-1">
+                        {#if monthControls}
+                            <Calendar.NextButton class={classes.navButton}>
+                                <Icon name={nextMonthIcon} class={classes.navButtonIcon} />
+                            </Calendar.NextButton>
+                        {/if}
+                        {#if yearControls}
+                            <button
+                                type="button"
+                                class={classes.navButton}
+                                onclick={() => {
+                                    if (placeholder) placeholder = paginateYear(placeholder, 1)
+                                }}
+                                aria-label="Next year"
+                            >
+                                <Icon name={nextYearIcon} class={classes.navButtonIcon} />
+                            </button>
+                        {/if}
+                    </div>
+                {/if}
+            </Calendar.Header>
+
+            <Calendar.Grid class={classes.grid}>
+                <Calendar.GridHead>
+                    <Calendar.GridRow class={classes.gridWeekDaysRow}>
+                        {#if weekNumbers}
+                            <Calendar.HeadCell class={classes.headCellWeek}>#</Calendar.HeadCell>
+                        {/if}
+                        {#each weekdays as wd (wd)}
+                            <Calendar.HeadCell class={classes.headCell}>
+                                {#if weekdaySlot}
+                                    {@render weekdaySlot({ weekday: wd })}
+                                {:else}
+                                    {wd}
+                                {/if}
+                            </Calendar.HeadCell>
+                        {/each}
+                    </Calendar.GridRow>
+                </Calendar.GridHead>
+
+                <Calendar.GridBody class={classes.gridBody}>
+                    {#each month.weeks as week, weekIndex (weekIndex)}
+                        <Calendar.GridRow class={classes.gridRow}>
+                            {#if weekNumbers}
+                                <td class={classes.cellWeek}>
+                                    {weekIndex + 1}
+                                </td>
+                            {/if}
+                            {#each week as date (date.toString())}
+                                <Calendar.Cell {date} month={month.value} class={classes.cell}>
+                                    <Calendar.Day class={classes.cellTrigger}>
+                                        {#snippet child({
+                                            props,
+                                            selected,
+                                            disabled: dayDisabled,
+                                            unavailable
+                                        })}
+                                            {#if daySlot}
+                                                <span {...props}>
+                                                    {@render daySlot({
+                                                        date,
+                                                        day: date.day.toString(),
+                                                        selected,
+                                                        disabled: dayDisabled,
+                                                        unavailable
+                                                    })}
+                                                </span>
+                                            {:else}
+                                                <span {...props}>
+                                                    {date.day}
+                                                </span>
+                                            {/if}
+                                        {/snippet}
+                                    </Calendar.Day>
+                                </Calendar.Cell>
+                            {/each}
+                        </Calendar.GridRow>
+                    {/each}
+                </Calendar.GridBody>
+            </Calendar.Grid>
+        </div>
+    {/each}
+{/snippet}
+
+{#snippet rangeCalendarContent(months: Month<DateValue>[], weekdays: string[])}
+    {#each months as month, monthIndex (monthIndex)}
+        <div>
+            <RangeCalendar.Header class={classes.header}>
+                {#if headingSlot}
+                    {@render headingSlot({
+                        headingValue: month.value
+                            .toDate('UTC')
+                            .toLocaleDateString(locale, { month: 'long', year: 'numeric' }),
+                        prevMonth: () => {},
+                        nextMonth: () => {},
+                        prevYear: () => {
+                            if (placeholder) placeholder = paginateYear(placeholder, -1)
+                        },
+                        nextYear: () => {
+                            if (placeholder) placeholder = paginateYear(placeholder, 1)
+                        }
+                    })}
+                {:else}
+                    <div class="flex items-center gap-1">
+                        {#if yearControls}
+                            <button
+                                type="button"
+                                class={classes.navButton}
+                                onclick={() => {
+                                    if (placeholder) placeholder = paginateYear(placeholder, -1)
+                                }}
+                                aria-label="Previous year"
+                            >
+                                <Icon name={prevYearIcon} class={classes.navButtonIcon} />
+                            </button>
+                        {/if}
+                        {#if monthControls}
+                            <RangeCalendar.PrevButton class={classes.navButton}>
+                                <Icon name={prevMonthIcon} class={classes.navButtonIcon} />
+                            </RangeCalendar.PrevButton>
+                        {/if}
+                    </div>
+
+                    <RangeCalendar.Heading class={classes.heading} />
+
+                    <div class="flex items-center gap-1">
+                        {#if monthControls}
+                            <RangeCalendar.NextButton class={classes.navButton}>
+                                <Icon name={nextMonthIcon} class={classes.navButtonIcon} />
+                            </RangeCalendar.NextButton>
+                        {/if}
+                        {#if yearControls}
+                            <button
+                                type="button"
+                                class={classes.navButton}
+                                onclick={() => {
+                                    if (placeholder) placeholder = paginateYear(placeholder, 1)
+                                }}
+                                aria-label="Next year"
+                            >
+                                <Icon name={nextYearIcon} class={classes.navButtonIcon} />
+                            </button>
+                        {/if}
+                    </div>
+                {/if}
+            </RangeCalendar.Header>
+
+            <RangeCalendar.Grid class={classes.grid}>
+                <RangeCalendar.GridHead>
+                    <RangeCalendar.GridRow class={classes.gridWeekDaysRow}>
+                        {#if weekNumbers}
+                            <RangeCalendar.HeadCell class={classes.headCellWeek}
+                                >#</RangeCalendar.HeadCell
+                            >
+                        {/if}
+                        {#each weekdays as wd (wd)}
+                            <RangeCalendar.HeadCell class={classes.headCell}>
+                                {#if weekdaySlot}
+                                    {@render weekdaySlot({ weekday: wd })}
+                                {:else}
+                                    {wd}
+                                {/if}
+                            </RangeCalendar.HeadCell>
+                        {/each}
+                    </RangeCalendar.GridRow>
+                </RangeCalendar.GridHead>
+
+                <RangeCalendar.GridBody class={classes.gridBody}>
+                    {#each month.weeks as week, weekIndex (weekIndex)}
+                        <RangeCalendar.GridRow class={classes.gridRow}>
+                            {#if weekNumbers}
+                                <td class={classes.cellWeek}>
+                                    {weekIndex + 1}
+                                </td>
+                            {/if}
+                            {#each week as date (date.toString())}
+                                <RangeCalendar.Cell {date} month={month.value} class={classes.cell}>
+                                    <RangeCalendar.Day class={classes.cellTrigger}>
+                                        {#snippet child({
+                                            props,
+                                            selected,
+                                            disabled: dayDisabled,
+                                            unavailable
+                                        })}
+                                            {#if daySlot}
+                                                <span {...props}>
+                                                    {@render daySlot({
+                                                        date,
+                                                        day: date.day.toString(),
+                                                        selected,
+                                                        disabled: dayDisabled,
+                                                        unavailable
+                                                    })}
+                                                </span>
+                                            {:else}
+                                                <span {...props}>
+                                                    {date.day}
+                                                </span>
+                                            {/if}
+                                        {/snippet}
+                                    </RangeCalendar.Day>
+                                </RangeCalendar.Cell>
+                            {/each}
+                        </RangeCalendar.GridRow>
+                    {/each}
+                </RangeCalendar.GridBody>
+            </RangeCalendar.Grid>
+        </div>
+    {/each}
+{/snippet}
+
+{#if range}
+    {@const rangeProps = restProps as Omit<
+        CalendarRangeProps,
+        | keyof typeof commonProps
+        | 'range'
+        | 'value'
+        | 'onValueChange'
+        | 'color'
+        | 'size'
+        | 'variant'
+        | 'class'
+        | 'ui'
+        | 'heading'
+        | 'day'
+        | 'weekday'
+        | 'prevMonthIcon'
+        | 'nextMonthIcon'
+        | 'prevYearIcon'
+        | 'nextYearIcon'
+        | 'monthControls'
+        | 'yearControls'
+        | 'weekNumbers'
+    >}
+    <RangeCalendar.Root
+        bind:value={value as CalendarRangeProps['value']}
+        onValueChange={onValueChange as CalendarRangeProps['onValueChange']}
+        {...commonProps}
+        minDays={rangeProps.minDays}
+        maxDays={rangeProps.maxDays}
+        onStartValueChange={rangeProps.onStartValueChange}
+        onEndValueChange={rangeProps.onEndValueChange}
+        excludeDisabled={rangeProps.excludeDisabled}
+        class={classes.root}
+    >
+        {#snippet children({ months, weekdays })}
+            <div class={classes.body}>
+                {@render rangeCalendarContent(months, weekdays)}
+            </div>
+        {/snippet}
+    </RangeCalendar.Root>
+{:else}
+    {@const calType = (restProps as { type?: 'single' | 'multiple' }).type ?? 'single'}
+    {@const calInitialFocus = (restProps as { initialFocus?: boolean }).initialFocus}
+    {#if calType === 'multiple'}
+        <Calendar.Root
+            bind:value={value as CalendarMultipleProps['value']}
+            onValueChange={onValueChange as CalendarMultipleProps['onValueChange']}
+            {...commonProps}
+            type="multiple"
+            initialFocus={calInitialFocus}
+            class={classes.root}
+        >
+            {#snippet children({ months, weekdays })}
+                <div class={classes.body}>
+                    {@render calendarContent(months, weekdays)}
+                </div>
+            {/snippet}
+        </Calendar.Root>
+    {:else}
+        <Calendar.Root
+            bind:value={value as CalendarSingleProps['value']}
+            onValueChange={onValueChange as CalendarSingleProps['onValueChange']}
+            {...commonProps}
+            type="single"
+            initialFocus={calInitialFocus}
+            class={classes.root}
+        >
+            {#snippet children({ months, weekdays })}
+                <div class={classes.body}>
+                    {@render calendarContent(months, weekdays)}
+                </div>
+            {/snippet}
+        </Calendar.Root>
+    {/if}
+{/if}

--- a/src/lib/Calendar/Calendar.svelte.spec.ts
+++ b/src/lib/Calendar/Calendar.svelte.spec.ts
@@ -1,0 +1,558 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-svelte'
+import Calendar from './Calendar.svelte'
+import { CalendarDate } from '@internationalized/date'
+import type { DateValue } from '@internationalized/date'
+
+describe('Calendar', () => {
+    const getRoot = () => document.querySelector('[data-calendar-root]') as HTMLElement | null
+    const getHeader = () => document.querySelector('[data-calendar-header]') as HTMLElement | null
+    const getHeading = () => document.querySelector('[data-calendar-heading]') as HTMLElement | null
+    const getPrevButton = () =>
+        document.querySelector('[data-calendar-prev-button]') as HTMLElement | null
+    const getNextButton = () =>
+        document.querySelector('[data-calendar-next-button]') as HTMLElement | null
+    const getGrid = () => document.querySelector('[data-calendar-grid]') as HTMLElement | null
+    const getDays = () => document.querySelectorAll('[data-calendar-day]')
+    const getHeadCells = () => document.querySelectorAll('[data-calendar-head-cell]')
+
+    // ==================== RENDERING ====================
+
+    describe('rendering', () => {
+        it('should render without crashing', () => {
+            const { container } = render(Calendar)
+            expect(container).not.toBeNull()
+        })
+
+        it('should render the calendar root', async () => {
+            render(Calendar)
+            await vi.waitFor(() => {
+                expect(getRoot()).not.toBeNull()
+            })
+        })
+
+        it('should render the header', async () => {
+            render(Calendar)
+            await vi.waitFor(() => {
+                expect(getHeader()).not.toBeNull()
+            })
+        })
+
+        it('should render the heading with month and year', async () => {
+            render(Calendar, { placeholder: new CalendarDate(2024, 3, 15) })
+            await vi.waitFor(() => {
+                const heading = getHeading()
+                expect(heading).not.toBeNull()
+                expect(heading!.textContent).toContain('March')
+                expect(heading!.textContent).toContain('2024')
+            })
+        })
+
+        it('should render navigation buttons by default', async () => {
+            render(Calendar)
+            await vi.waitFor(() => {
+                expect(getPrevButton()).not.toBeNull()
+                expect(getNextButton()).not.toBeNull()
+            })
+        })
+
+        it('should render the grid', async () => {
+            render(Calendar)
+            await vi.waitFor(() => {
+                expect(getGrid()).not.toBeNull()
+            })
+        })
+
+        it('should render weekday headers', async () => {
+            render(Calendar)
+            await vi.waitFor(() => {
+                const headCells = getHeadCells()
+                expect(headCells.length).toBe(7)
+            })
+        })
+
+        it('should render days', async () => {
+            render(Calendar)
+            await vi.waitFor(() => {
+                const days = getDays()
+                expect(days.length).toBeGreaterThan(0)
+            })
+        })
+    })
+
+    // ==================== SIZES ====================
+
+    describe('sizes', () => {
+        it('should apply md size by default', async () => {
+            render(Calendar)
+            await vi.waitFor(() => {
+                const days = getDays()
+                expect(days.length).toBeGreaterThan(0)
+                expect((days[0] as HTMLElement).className).toContain('size-8')
+            })
+        })
+
+        it('should apply xs size', async () => {
+            render(Calendar, { size: 'xs' })
+            await vi.waitFor(() => {
+                const days = getDays()
+                expect(days.length).toBeGreaterThan(0)
+                expect((days[0] as HTMLElement).className).toContain('size-7')
+            })
+        })
+
+        it('should apply sm size', async () => {
+            render(Calendar, { size: 'sm' })
+            await vi.waitFor(() => {
+                const days = getDays()
+                expect(days.length).toBeGreaterThan(0)
+                expect((days[0] as HTMLElement).className).toContain('size-7')
+            })
+        })
+
+        it('should apply lg size', async () => {
+            render(Calendar, { size: 'lg' })
+            await vi.waitFor(() => {
+                const days = getDays()
+                expect(days.length).toBeGreaterThan(0)
+                expect((days[0] as HTMLElement).className).toContain('size-9')
+            })
+        })
+
+        it('should apply xl size', async () => {
+            render(Calendar, { size: 'xl' })
+            await vi.waitFor(() => {
+                const days = getDays()
+                expect(days.length).toBeGreaterThan(0)
+                expect((days[0] as HTMLElement).className).toContain('size-10')
+            })
+        })
+    })
+
+    // ==================== COLORS ====================
+
+    describe('colors', () => {
+        it('should apply primary color by default', async () => {
+            render(Calendar, { value: new CalendarDate(2024, 3, 15) })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+            })
+        })
+
+        it('should apply secondary color', async () => {
+            render(Calendar, { color: 'secondary', value: new CalendarDate(2024, 3, 15) })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+            })
+        })
+
+        it('should apply error color', async () => {
+            render(Calendar, { color: 'error', value: new CalendarDate(2024, 3, 15) })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+            })
+        })
+    })
+
+    // ==================== VARIANTS ====================
+
+    describe('variants', () => {
+        it('should apply solid variant by default', async () => {
+            render(Calendar)
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+            })
+        })
+
+        it('should apply outline variant', async () => {
+            render(Calendar, { variant: 'outline' })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+            })
+        })
+
+        it('should apply soft variant', async () => {
+            render(Calendar, { variant: 'soft' })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+            })
+        })
+
+        it('should apply subtle variant', async () => {
+            render(Calendar, { variant: 'subtle' })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+            })
+        })
+    })
+
+    // ==================== NAVIGATION CONTROLS ====================
+
+    describe('navigation controls', () => {
+        it('should show month controls by default', async () => {
+            render(Calendar)
+            await vi.waitFor(() => {
+                expect(getPrevButton()).not.toBeNull()
+                expect(getNextButton()).not.toBeNull()
+            })
+        })
+
+        it('should hide month controls when monthControls is false', async () => {
+            render(Calendar, { monthControls: false })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+            })
+        })
+
+        it('should show year controls when yearControls is true', async () => {
+            render(Calendar, { yearControls: true })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+                // Should have additional buttons for year navigation
+                const buttons = root!.querySelectorAll('button')
+                expect(buttons.length).toBeGreaterThanOrEqual(4)
+            })
+        })
+    })
+
+    // ==================== DISABLED STATE ====================
+
+    describe('disabled state', () => {
+        it('should apply disabled state', async () => {
+            render(Calendar, { disabled: true })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+                expect(root!.getAttribute('data-disabled')).not.toBeNull()
+            })
+        })
+
+        it('should disable specific dates', async () => {
+            const isDateDisabled = (date: DateValue) => date.day === 15
+            render(Calendar, {
+                placeholder: new CalendarDate(2024, 3, 1),
+                isDateDisabled
+            })
+            await vi.waitFor(() => {
+                const days = getDays()
+                let foundDisabled = false
+                days.forEach((day) => {
+                    if (day.textContent?.trim() === '15') {
+                        expect(day.getAttribute('data-disabled')).not.toBeNull()
+                        foundDisabled = true
+                    }
+                })
+                expect(foundDisabled).toBe(true)
+            })
+        })
+    })
+
+    // ==================== READONLY STATE ====================
+
+    describe('readonly state', () => {
+        it('should apply readonly state', async () => {
+            render(Calendar, { readonly: true })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+                expect(root!.getAttribute('data-readonly')).not.toBeNull()
+            })
+        })
+    })
+
+    // ==================== MULTIPLE MONTHS ====================
+
+    describe('multiple months', () => {
+        it('should render multiple months when numberOfMonths > 1', async () => {
+            render(Calendar, { numberOfMonths: 2 })
+            await vi.waitFor(() => {
+                const grids = document.querySelectorAll('[data-calendar-grid]')
+                expect(grids.length).toBe(2)
+            })
+        })
+    })
+
+    // ==================== FIXED WEEKS ====================
+
+    describe('fixed weeks', () => {
+        it('should always show 6 weeks when fixedWeeks is true', async () => {
+            render(Calendar, { fixedWeeks: true, placeholder: new CalendarDate(2024, 2, 1) })
+            await vi.waitFor(() => {
+                const rows = document.querySelectorAll('[data-calendar-grid-row]')
+                // Should have 6 weeks + 1 header row
+                expect(rows.length).toBe(7)
+            })
+        })
+    })
+
+    // ==================== WEEK STARTS ON ====================
+
+    describe('weekStartsOn', () => {
+        it('should start week on Sunday by default', async () => {
+            render(Calendar, { locale: 'en' })
+            await vi.waitFor(() => {
+                const headCells = getHeadCells()
+                expect(headCells.length).toBe(7)
+            })
+        })
+
+        it('should start week on Monday when weekStartsOn is 1', async () => {
+            render(Calendar, { weekStartsOn: 1 })
+            await vi.waitFor(() => {
+                const headCells = getHeadCells()
+                expect(headCells.length).toBe(7)
+            })
+        })
+    })
+
+    // ==================== LOCALE ====================
+
+    describe('locale', () => {
+        it('should use en locale by default', async () => {
+            render(Calendar, { placeholder: new CalendarDate(2024, 3, 15) })
+            await vi.waitFor(() => {
+                const heading = getHeading()
+                expect(heading).not.toBeNull()
+                expect(heading!.textContent).toContain('March')
+            })
+        })
+
+        it('should apply custom locale', async () => {
+            render(Calendar, { locale: 'vi', placeholder: new CalendarDate(2024, 3, 15) })
+            await vi.waitFor(() => {
+                const heading = getHeading()
+                expect(heading).not.toBeNull()
+            })
+        })
+    })
+
+    // ==================== VALUE BINDING ====================
+
+    describe('value binding', () => {
+        it('should accept value prop', async () => {
+            const value = new CalendarDate(2024, 3, 15)
+            render(Calendar, { value })
+            await vi.waitFor(() => {
+                const days = getDays()
+                let found = false
+                days.forEach((day) => {
+                    if (
+                        day.textContent?.trim() === '15' &&
+                        day.getAttribute('data-selected') !== null
+                    ) {
+                        found = true
+                    }
+                })
+                expect(found).toBe(true)
+            })
+        })
+
+        it('should call onValueChange when value changes', async () => {
+            const onValueChange = vi.fn()
+            render(Calendar, { onValueChange, placeholder: new CalendarDate(2024, 3, 1) })
+            await vi.waitFor(() => {
+                expect(getDays().length).toBeGreaterThan(0)
+            })
+            expect(onValueChange).toBeTypeOf('function')
+        })
+    })
+
+    // ==================== RANGE MODE ====================
+
+    describe('range mode', () => {
+        it('should render in range mode', async () => {
+            render(Calendar, { range: true })
+            await vi.waitFor(() => {
+                const root = document.querySelector(
+                    '[data-range-calendar-root]'
+                ) as HTMLElement | null
+                expect(root).not.toBeNull()
+            })
+        })
+
+        it('should accept range value', async () => {
+            const value = {
+                start: new CalendarDate(2024, 3, 10),
+                end: new CalendarDate(2024, 3, 20)
+            }
+            render(Calendar, { range: true, value })
+            await vi.waitFor(() => {
+                const root = document.querySelector(
+                    '[data-range-calendar-root]'
+                ) as HTMLElement | null
+                expect(root).not.toBeNull()
+            })
+        })
+    })
+
+    // ==================== MULTIPLE SELECTION ====================
+
+    describe('multiple selection', () => {
+        it('should render in multiple selection mode', async () => {
+            render(Calendar, { type: 'multiple' })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+            })
+        })
+
+        it('should accept multiple values', async () => {
+            const value = [new CalendarDate(2024, 3, 10), new CalendarDate(2024, 3, 20)]
+            render(Calendar, { type: 'multiple', value })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+            })
+        })
+    })
+
+    // ==================== MIN/MAX VALUES ====================
+
+    describe('min/max values', () => {
+        it('should respect minValue', async () => {
+            const minValue = new CalendarDate(2024, 3, 10)
+            render(Calendar, { minValue, placeholder: new CalendarDate(2024, 3, 1) })
+            await vi.waitFor(() => {
+                const days = getDays()
+                days.forEach((day) => {
+                    const dayNum = parseInt(day.textContent?.trim() || '0')
+                    if (dayNum > 0 && dayNum < 10) {
+                        expect(day.getAttribute('data-disabled')).not.toBeNull()
+                    }
+                })
+            })
+        })
+
+        it('should respect maxValue', async () => {
+            const maxValue = new CalendarDate(2024, 3, 20)
+            render(Calendar, { maxValue, placeholder: new CalendarDate(2024, 3, 1) })
+            await vi.waitFor(() => {
+                const days = getDays()
+                days.forEach((day) => {
+                    const dayNum = parseInt(day.textContent?.trim() || '0')
+                    if (dayNum > 20) {
+                        expect(day.getAttribute('data-disabled')).not.toBeNull()
+                    }
+                })
+            })
+        })
+    })
+
+    // ==================== UI SLOT OVERRIDES ====================
+
+    describe('ui slot overrides', () => {
+        it('should apply ui.root class', async () => {
+            render(Calendar, { ui: { root: 'custom-root' } })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+                expect(root!.className).toContain('custom-root')
+            })
+        })
+
+        it('should apply ui.header class', async () => {
+            render(Calendar, { ui: { header: 'custom-header' } })
+            await vi.waitFor(() => {
+                const header = getHeader()
+                expect(header).not.toBeNull()
+                expect(header!.className).toContain('custom-header')
+            })
+        })
+
+        it('should apply ui.heading class', async () => {
+            render(Calendar, { ui: { heading: 'custom-heading' } })
+            await vi.waitFor(() => {
+                const heading = getHeading()
+                expect(heading).not.toBeNull()
+                expect(heading!.className).toContain('custom-heading')
+            })
+        })
+
+        it('should apply ui.cellTrigger class', async () => {
+            render(Calendar, { ui: { cellTrigger: 'custom-cell-trigger' } })
+            await vi.waitFor(() => {
+                const days = getDays()
+                expect(days.length).toBeGreaterThan(0)
+                expect((days[0] as HTMLElement).className).toContain('custom-cell-trigger')
+            })
+        })
+    })
+
+    // ==================== VARIANT CLASSES ====================
+
+    describe('variant classes', () => {
+        it('should apply header base classes', async () => {
+            render(Calendar)
+            await vi.waitFor(() => {
+                const header = getHeader()
+                expect(header).not.toBeNull()
+                expect(header!.className).toContain('flex')
+                expect(header!.className).toContain('items-center')
+                expect(header!.className).toContain('justify-between')
+            })
+        })
+
+        it('should apply cellTrigger base classes', async () => {
+            render(Calendar)
+            await vi.waitFor(() => {
+                const days = getDays()
+                expect(days.length).toBeGreaterThan(0)
+                const day = days[0] as HTMLElement
+                expect(day.className).toContain('flex')
+                expect(day.className).toContain('items-center')
+                expect(day.className).toContain('justify-center')
+                expect(day.className).toContain('rounded-full')
+            })
+        })
+    })
+
+    // ==================== COMBINED FEATURES ====================
+
+    describe('combined features', () => {
+        it('should render with multiple months and year controls', async () => {
+            render(Calendar, { numberOfMonths: 2, yearControls: true })
+            await vi.waitFor(() => {
+                const grids = document.querySelectorAll('[data-calendar-grid]')
+                expect(grids.length).toBe(2)
+            })
+        })
+
+        it('should render range calendar with multiple months', async () => {
+            render(Calendar, { range: true, numberOfMonths: 2 })
+            await vi.waitFor(() => {
+                const root = document.querySelector(
+                    '[data-range-calendar-root]'
+                ) as HTMLElement | null
+                expect(root).not.toBeNull()
+                const grids = document.querySelectorAll('[data-range-calendar-grid]')
+                expect(grids.length).toBe(2)
+            })
+        })
+
+        it('should render with all styling props', async () => {
+            render(Calendar, {
+                color: 'secondary',
+                size: 'lg',
+                variant: 'outline',
+                ui: {
+                    root: 'custom-root',
+                    header: 'custom-header'
+                }
+            })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+                expect(root!.className).toContain('custom-root')
+            })
+        })
+    })
+})

--- a/src/lib/Calendar/Calendar.svelte.spec.ts
+++ b/src/lib/Calendar/Calendar.svelte.spec.ts
@@ -425,7 +425,8 @@ describe('Calendar', () => {
                 const days = getDays()
                 days.forEach((day) => {
                     const dayNum = parseInt(day.textContent?.trim() || '0')
-                    if (dayNum > 0 && dayNum < 10) {
+                    const isOutsideMonth = day.hasAttribute('data-outside-month')
+                    if (dayNum > 0 && dayNum < 10 && !isOutsideMonth) {
                         expect(day.getAttribute('data-disabled')).not.toBeNull()
                     }
                 })
@@ -439,7 +440,8 @@ describe('Calendar', () => {
                 const days = getDays()
                 days.forEach((day) => {
                     const dayNum = parseInt(day.textContent?.trim() || '0')
-                    if (dayNum > 20) {
+                    const isOutsideMonth = day.hasAttribute('data-outside-month')
+                    if (dayNum > 20 && !isOutsideMonth) {
                         expect(day.getAttribute('data-disabled')).not.toBeNull()
                     }
                 })

--- a/src/lib/Calendar/calendar.types.ts
+++ b/src/lib/Calendar/calendar.types.ts
@@ -2,240 +2,81 @@ import type { Snippet } from 'svelte'
 import type { DateValue } from '@internationalized/date'
 import type { ClassNameValue } from 'tailwind-merge'
 import type { CalendarSlots, CalendarVariantProps } from './calendar.variants.js'
-import type { CalendarDaySnippetProps, CalendarHeadingSnippetProps } from 'bits-ui'
 import type { DateRange, DateMatcher } from 'bits-ui'
 
 type OnChangeFn<T> = (value: T) => void
 
-// ============================================================================
-// Value Types
-// ============================================================================
-
-export type CalendarSingleValue = DateValue | undefined
-export type CalendarMultipleValue = DateValue[] | undefined
-export type CalendarRangeValue = DateRange | undefined
-export type CalendarValue = CalendarSingleValue | CalendarMultipleValue | CalendarRangeValue
-
-// ============================================================================
-// Slot Props Types
-// ============================================================================
-
-export interface CalendarHeadingSlotProps extends CalendarHeadingSnippetProps {
-    prevMonth: () => void
-    nextMonth: () => void
-    prevYear: () => void
-    nextYear: () => void
+export interface CalendarHeadingSlotProps {
+    value: string
 }
 
-export interface CalendarDaySlotProps extends CalendarDaySnippetProps {
-    date: DateValue
+export interface CalendarDaySlotProps {
+    day: DateValue
 }
 
-export interface CalendarWeekdaySlotProps {
-    weekday: string
+export interface CalendarWeekDaySlotProps {
+    day: string
 }
-
-// ============================================================================
-// Shared Calendar Root Props
-// ============================================================================
 
 type SharedCalendarRootProps = {
-    /**
-     * The placeholder date, used to control the view of the
-     * calendar when no value is present.
-     * @default the current date
-     */
+    /** @default the current date */
     placeholder?: DateValue
-
-    /**
-     * A callback function called when the placeholder value changes.
-     */
     onPlaceholderChange?: OnChangeFn<DateValue>
-
-    /**
-     * Whether or not users can deselect a date once selected.
-     * @default false
-     */
+    /** @default false */
     preventDeselect?: boolean
-
-    /**
-     * The minimum date that can be selected.
-     */
     minValue?: DateValue
-
-    /**
-     * The maximum date that can be selected.
-     */
     maxValue?: DateValue
-
-    /**
-     * Whether or not the calendar is disabled.
-     * @default false
-     */
+    /** @default false */
     disabled?: boolean
-
-    /**
-     * Controls paged navigation when numberOfMonths > 1.
-     * @default false
-     */
+    /** @default false */
     pagedNavigation?: boolean
-
-    /**
-     * The day of the week to start on (0=Sunday, 6=Saturday).
-     * @default 0
-     */
+    /** @default 0 */
     weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
-
-    /**
-     * Weekday format: 'narrow', 'short', or 'long'.
-     * @default 'short'
-     */
+    /** @default 'short' */
     weekdayFormat?: Intl.DateTimeFormatOptions['weekday']
-
-    /**
-     * A function that returns true if a date should be disabled.
-     */
     isDateDisabled?: DateMatcher
-
-    /**
-     * A function that returns true if a date should be marked unavailable.
-     */
     isDateUnavailable?: DateMatcher
-
-    /**
-     * Always display 6 weeks per month.
-     * @default false
-     */
+    /** @default true */
     fixedWeeks?: boolean
-
-    /**
-     * Number of months to display simultaneously.
-     * @default 1
-     */
+    /** @default 1 */
     numberOfMonths?: number
-
-    /**
-     * Accessibility label for the calendar.
-     */
     calendarLabel?: string
-
-    /**
-     * Locale for date formatting.
-     * @default 'en'
-     */
+    /** @default 'en' */
     locale?: string
-
-    /**
-     * Whether the calendar is readonly.
-     * @default false
-     */
+    /** @default false */
     readonly?: boolean
-
-    /**
-     * Whether to disable days outside the current month.
-     * @default false
-     */
+    /** @default false */
     disableDaysOutsideMonth?: boolean
 }
 
-// ============================================================================
-// Base UI Props (shared across all modes)
-// ============================================================================
-
 type BaseCalendarProps = {
-    /**
-     * Icon for navigating to the previous month.
-     * @default 'lucide:chevron-left'
-     */
+    /** @default 'lucide:chevron-left' */
     prevMonthIcon?: string
-
-    /**
-     * Icon for navigating to the next month.
-     * @default 'lucide:chevron-right'
-     */
+    /** @default 'lucide:chevron-right' */
     nextMonthIcon?: string
-
-    /**
-     * Icon for navigating to the previous year.
-     * @default 'lucide:chevrons-left'
-     */
+    /** @default 'lucide:chevrons-left' */
     prevYearIcon?: string
-
-    /**
-     * Icon for navigating to the next year.
-     * @default 'lucide:chevrons-right'
-     */
+    /** @default 'lucide:chevrons-right' */
     nextYearIcon?: string
-
-    /**
-     * Whether to show month navigation controls in the header.
-     * @default true
-     */
+    /** @default true */
     monthControls?: boolean
-
-    /**
-     * Whether to show year navigation controls in the header.
-     * @default false
-     */
+    /** @default true */
     yearControls?: boolean
-
-    /**
-     * Whether to display week numbers alongside the calendar.
-     * @default false
-     */
+    /** @default false */
     weekNumbers?: boolean
-
-    /**
-     * Color variant for the calendar.
-     * @default 'primary'
-     */
+    /** @default 'primary' */
     color?: NonNullable<CalendarVariantProps['color']>
-
-    /**
-     * Size variant for the calendar.
-     * @default 'md'
-     */
+    /** @default 'md' */
     size?: NonNullable<CalendarVariantProps['size']>
-
-    /**
-     * Visual style variant for the calendar.
-     * @default 'solid'
-     */
+    /** @default 'solid' */
     variant?: NonNullable<CalendarVariantProps['variant']>
-
-    /**
-     * Additional CSS classes for the root element.
-     */
     class?: ClassNameValue
-
-    /**
-     * Override styles for specific calendar slots.
-     */
     ui?: Partial<Record<CalendarSlots, ClassNameValue>>
-
-    /**
-     * Custom heading snippet for rendering the month/year display.
-     */
     heading?: Snippet<[CalendarHeadingSlotProps]>
-
-    /**
-     * Custom day snippet for rendering individual calendar days.
-     */
     day?: Snippet<[CalendarDaySlotProps]>
-
-    /**
-     * Custom weekday snippet for rendering weekday headers.
-     */
-    weekday?: Snippet<[CalendarWeekdaySlotProps]>
+    weekDay?: Snippet<[CalendarWeekDaySlotProps]>
 }
 
-// ============================================================================
-// Component Props
-// ============================================================================
-
-/**
- * Props for single date selection Calendar.
- */
 export type CalendarSingleProps = SharedCalendarRootProps &
     BaseCalendarProps & {
         range?: false
@@ -245,9 +86,6 @@ export type CalendarSingleProps = SharedCalendarRootProps &
         initialFocus?: boolean
     }
 
-/**
- * Props for multiple date selection Calendar.
- */
 export type CalendarMultipleProps = SharedCalendarRootProps &
     BaseCalendarProps & {
         range?: false
@@ -258,9 +96,6 @@ export type CalendarMultipleProps = SharedCalendarRootProps &
         maxDays?: number
     }
 
-/**
- * Props for date range selection Calendar.
- */
 export type CalendarRangeProps = SharedCalendarRootProps &
     BaseCalendarProps & {
         range: true
@@ -273,21 +108,4 @@ export type CalendarRangeProps = SharedCalendarRootProps &
         excludeDisabled?: boolean
     }
 
-/**
- * Props for the Calendar component.
- *
- * @example
- * ```svelte
- * <!-- Single date selection -->
- * <Calendar bind:value={selectedDate} />
- *
- * <!-- Multiple date selection -->
- * <Calendar type="multiple" bind:value={selectedDates} />
- *
- * <!-- Date range selection -->
- * <Calendar range bind:value={dateRange} />
- * ```
- *
- * @see https://bits-ui.com/docs/components/calendar
- */
 export type CalendarProps = CalendarSingleProps | CalendarMultipleProps | CalendarRangeProps

--- a/src/lib/Calendar/calendar.types.ts
+++ b/src/lib/Calendar/calendar.types.ts
@@ -1,0 +1,293 @@
+import type { Snippet } from 'svelte'
+import type { DateValue } from '@internationalized/date'
+import type { ClassNameValue } from 'tailwind-merge'
+import type { CalendarSlots, CalendarVariantProps } from './calendar.variants.js'
+import type { CalendarDaySnippetProps, CalendarHeadingSnippetProps } from 'bits-ui'
+import type { DateRange, DateMatcher } from 'bits-ui'
+
+type OnChangeFn<T> = (value: T) => void
+
+// ============================================================================
+// Value Types
+// ============================================================================
+
+export type CalendarSingleValue = DateValue | undefined
+export type CalendarMultipleValue = DateValue[] | undefined
+export type CalendarRangeValue = DateRange | undefined
+export type CalendarValue = CalendarSingleValue | CalendarMultipleValue | CalendarRangeValue
+
+// ============================================================================
+// Slot Props Types
+// ============================================================================
+
+export interface CalendarHeadingSlotProps extends CalendarHeadingSnippetProps {
+    prevMonth: () => void
+    nextMonth: () => void
+    prevYear: () => void
+    nextYear: () => void
+}
+
+export interface CalendarDaySlotProps extends CalendarDaySnippetProps {
+    date: DateValue
+}
+
+export interface CalendarWeekdaySlotProps {
+    weekday: string
+}
+
+// ============================================================================
+// Shared Calendar Root Props
+// ============================================================================
+
+type SharedCalendarRootProps = {
+    /**
+     * The placeholder date, used to control the view of the
+     * calendar when no value is present.
+     * @default the current date
+     */
+    placeholder?: DateValue
+
+    /**
+     * A callback function called when the placeholder value changes.
+     */
+    onPlaceholderChange?: OnChangeFn<DateValue>
+
+    /**
+     * Whether or not users can deselect a date once selected.
+     * @default false
+     */
+    preventDeselect?: boolean
+
+    /**
+     * The minimum date that can be selected.
+     */
+    minValue?: DateValue
+
+    /**
+     * The maximum date that can be selected.
+     */
+    maxValue?: DateValue
+
+    /**
+     * Whether or not the calendar is disabled.
+     * @default false
+     */
+    disabled?: boolean
+
+    /**
+     * Controls paged navigation when numberOfMonths > 1.
+     * @default false
+     */
+    pagedNavigation?: boolean
+
+    /**
+     * The day of the week to start on (0=Sunday, 6=Saturday).
+     * @default 0
+     */
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+
+    /**
+     * Weekday format: 'narrow', 'short', or 'long'.
+     * @default 'short'
+     */
+    weekdayFormat?: Intl.DateTimeFormatOptions['weekday']
+
+    /**
+     * A function that returns true if a date should be disabled.
+     */
+    isDateDisabled?: DateMatcher
+
+    /**
+     * A function that returns true if a date should be marked unavailable.
+     */
+    isDateUnavailable?: DateMatcher
+
+    /**
+     * Always display 6 weeks per month.
+     * @default false
+     */
+    fixedWeeks?: boolean
+
+    /**
+     * Number of months to display simultaneously.
+     * @default 1
+     */
+    numberOfMonths?: number
+
+    /**
+     * Accessibility label for the calendar.
+     */
+    calendarLabel?: string
+
+    /**
+     * Locale for date formatting.
+     * @default 'en'
+     */
+    locale?: string
+
+    /**
+     * Whether the calendar is readonly.
+     * @default false
+     */
+    readonly?: boolean
+
+    /**
+     * Whether to disable days outside the current month.
+     * @default false
+     */
+    disableDaysOutsideMonth?: boolean
+}
+
+// ============================================================================
+// Base UI Props (shared across all modes)
+// ============================================================================
+
+type BaseCalendarProps = {
+    /**
+     * Icon for navigating to the previous month.
+     * @default 'lucide:chevron-left'
+     */
+    prevMonthIcon?: string
+
+    /**
+     * Icon for navigating to the next month.
+     * @default 'lucide:chevron-right'
+     */
+    nextMonthIcon?: string
+
+    /**
+     * Icon for navigating to the previous year.
+     * @default 'lucide:chevrons-left'
+     */
+    prevYearIcon?: string
+
+    /**
+     * Icon for navigating to the next year.
+     * @default 'lucide:chevrons-right'
+     */
+    nextYearIcon?: string
+
+    /**
+     * Whether to show month navigation controls in the header.
+     * @default true
+     */
+    monthControls?: boolean
+
+    /**
+     * Whether to show year navigation controls in the header.
+     * @default false
+     */
+    yearControls?: boolean
+
+    /**
+     * Whether to display week numbers alongside the calendar.
+     * @default false
+     */
+    weekNumbers?: boolean
+
+    /**
+     * Color variant for the calendar.
+     * @default 'primary'
+     */
+    color?: NonNullable<CalendarVariantProps['color']>
+
+    /**
+     * Size variant for the calendar.
+     * @default 'md'
+     */
+    size?: NonNullable<CalendarVariantProps['size']>
+
+    /**
+     * Visual style variant for the calendar.
+     * @default 'solid'
+     */
+    variant?: NonNullable<CalendarVariantProps['variant']>
+
+    /**
+     * Additional CSS classes for the root element.
+     */
+    class?: ClassNameValue
+
+    /**
+     * Override styles for specific calendar slots.
+     */
+    ui?: Partial<Record<CalendarSlots, ClassNameValue>>
+
+    /**
+     * Custom heading snippet for rendering the month/year display.
+     */
+    heading?: Snippet<[CalendarHeadingSlotProps]>
+
+    /**
+     * Custom day snippet for rendering individual calendar days.
+     */
+    day?: Snippet<[CalendarDaySlotProps]>
+
+    /**
+     * Custom weekday snippet for rendering weekday headers.
+     */
+    weekday?: Snippet<[CalendarWeekdaySlotProps]>
+}
+
+// ============================================================================
+// Component Props
+// ============================================================================
+
+/**
+ * Props for single date selection Calendar.
+ */
+export type CalendarSingleProps = SharedCalendarRootProps &
+    BaseCalendarProps & {
+        range?: false
+        type?: 'single'
+        value?: DateValue
+        onValueChange?: OnChangeFn<DateValue | undefined>
+        initialFocus?: boolean
+    }
+
+/**
+ * Props for multiple date selection Calendar.
+ */
+export type CalendarMultipleProps = SharedCalendarRootProps &
+    BaseCalendarProps & {
+        range?: false
+        type: 'multiple'
+        value?: DateValue[]
+        onValueChange?: OnChangeFn<DateValue[]>
+        initialFocus?: boolean
+        maxDays?: number
+    }
+
+/**
+ * Props for date range selection Calendar.
+ */
+export type CalendarRangeProps = SharedCalendarRootProps &
+    BaseCalendarProps & {
+        range: true
+        value?: DateRange
+        onValueChange?: OnChangeFn<DateRange>
+        minDays?: number
+        maxDays?: number
+        onStartValueChange?: OnChangeFn<DateValue | undefined>
+        onEndValueChange?: OnChangeFn<DateValue | undefined>
+        excludeDisabled?: boolean
+    }
+
+/**
+ * Props for the Calendar component.
+ *
+ * @example
+ * ```svelte
+ * <!-- Single date selection -->
+ * <Calendar bind:value={selectedDate} />
+ *
+ * <!-- Multiple date selection -->
+ * <Calendar type="multiple" bind:value={selectedDates} />
+ *
+ * <!-- Date range selection -->
+ * <Calendar range bind:value={dateRange} />
+ * ```
+ *
+ * @see https://bits-ui.com/docs/components/calendar
+ */
+export type CalendarProps = CalendarSingleProps | CalendarMultipleProps | CalendarRangeProps

--- a/src/lib/Calendar/calendar.variants.ts
+++ b/src/lib/Calendar/calendar.variants.ts
@@ -1,0 +1,407 @@
+import { tv, type VariantProps } from 'tailwind-variants'
+
+export const calendarVariants = tv({
+    slots: {
+        root: '',
+        header: 'flex items-center justify-between',
+        body: 'flex flex-col space-y-4 pt-4 sm:flex-row sm:space-x-4 sm:space-y-0',
+        heading: 'text-center font-medium truncate mx-auto',
+        grid: 'w-full border-collapse select-none focus:outline-none',
+        gridRow: '',
+        gridWeekDaysRow: '',
+        gridBody: '',
+        headCell: 'rounded-md',
+        headCellWeek: 'rounded-md text-on-surface-variant',
+        cell: 'relative text-center',
+        cellTrigger: [
+            'm-0.5 relative flex items-center justify-center rounded-full whitespace-nowrap',
+            'focus-visible:ring-2 focus:outline-none',
+            'data-disabled:text-on-surface-variant',
+            'data-unavailable:line-through data-unavailable:text-on-surface-variant data-unavailable:pointer-events-none',
+            'data-today:font-semibold',
+            'data-[outside-month]:text-on-surface-variant',
+            'transition'
+        ],
+        cellWeek: 'relative text-center text-on-surface-variant',
+        navButton: [
+            'inline-flex items-center justify-center rounded-md',
+            'text-on-surface-variant hover:bg-surface-container-highest',
+            'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+            'disabled:opacity-50 disabled:pointer-events-none',
+            'transition-colors'
+        ],
+        navButtonIcon: 'shrink-0'
+    },
+    variants: {
+        color: {
+            primary: {
+                headCell: 'text-primary',
+                cellTrigger: 'focus-visible:ring-primary'
+            },
+            secondary: {
+                headCell: 'text-secondary',
+                cellTrigger: 'focus-visible:ring-secondary'
+            },
+            tertiary: {
+                headCell: 'text-tertiary',
+                cellTrigger: 'focus-visible:ring-tertiary'
+            },
+            success: {
+                headCell: 'text-success',
+                cellTrigger: 'focus-visible:ring-success'
+            },
+            warning: {
+                headCell: 'text-warning',
+                cellTrigger: 'focus-visible:ring-warning'
+            },
+            error: {
+                headCell: 'text-error',
+                cellTrigger: 'focus-visible:ring-error'
+            },
+            info: {
+                headCell: 'text-info',
+                cellTrigger: 'focus-visible:ring-info'
+            },
+            surface: {
+                headCell: 'text-on-surface',
+                cellTrigger: 'focus-visible:ring-inverse-surface'
+            }
+        },
+        variant: {
+            solid: '',
+            outline: '',
+            soft: '',
+            subtle: ''
+        },
+        size: {
+            xs: {
+                heading: 'text-xs',
+                cell: 'text-xs',
+                cellWeek: 'text-xs',
+                headCell: 'text-[10px]',
+                headCellWeek: 'text-[10px]',
+                cellTrigger: 'size-7',
+                body: 'space-y-2 pt-2',
+                navButton: 'size-6',
+                navButtonIcon: 'size-3'
+            },
+            sm: {
+                heading: 'text-xs',
+                headCell: 'text-xs',
+                headCellWeek: 'text-xs',
+                cellWeek: 'text-xs',
+                cell: 'text-xs',
+                cellTrigger: 'size-7',
+                navButton: 'size-7',
+                navButtonIcon: 'size-3.5'
+            },
+            md: {
+                heading: 'text-sm',
+                headCell: 'text-xs',
+                headCellWeek: 'text-xs',
+                cellWeek: 'text-xs',
+                cell: 'text-sm',
+                cellTrigger: 'size-8',
+                navButton: 'size-8',
+                navButtonIcon: 'size-4'
+            },
+            lg: {
+                heading: 'text-base',
+                headCell: 'text-base',
+                headCellWeek: 'text-base',
+                cellTrigger: 'size-9 text-base',
+                navButton: 'size-9',
+                navButtonIcon: 'size-4'
+            },
+            xl: {
+                heading: 'text-lg',
+                headCell: 'text-lg',
+                headCellWeek: 'text-lg',
+                cellTrigger: 'size-10 text-lg',
+                navButton: 'size-10',
+                navButtonIcon: 'size-5'
+            }
+        },
+        weekNumbers: {
+            true: {}
+        }
+    },
+    compoundVariants: [
+        // ========== SOLID VARIANTS ==========
+        {
+            color: 'primary',
+            variant: 'solid',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-primary data-[selected]:text-on-primary data-today:not-data-[selected]:text-primary data-[highlighted]:bg-primary/20 hover:not-data-[selected]:bg-primary/20'
+            }
+        },
+        {
+            color: 'secondary',
+            variant: 'solid',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-secondary data-[selected]:text-on-secondary data-today:not-data-[selected]:text-secondary data-[highlighted]:bg-secondary/20 hover:not-data-[selected]:bg-secondary/20'
+            }
+        },
+        {
+            color: 'tertiary',
+            variant: 'solid',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-tertiary data-[selected]:text-on-tertiary data-today:not-data-[selected]:text-tertiary data-[highlighted]:bg-tertiary/20 hover:not-data-[selected]:bg-tertiary/20'
+            }
+        },
+        {
+            color: 'success',
+            variant: 'solid',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-success data-[selected]:text-on-success data-today:not-data-[selected]:text-success data-[highlighted]:bg-success/20 hover:not-data-[selected]:bg-success/20'
+            }
+        },
+        {
+            color: 'warning',
+            variant: 'solid',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-warning data-[selected]:text-on-warning data-today:not-data-[selected]:text-warning data-[highlighted]:bg-warning/20 hover:not-data-[selected]:bg-warning/20'
+            }
+        },
+        {
+            color: 'error',
+            variant: 'solid',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-error data-[selected]:text-on-error data-today:not-data-[selected]:text-error data-[highlighted]:bg-error/20 hover:not-data-[selected]:bg-error/20'
+            }
+        },
+        {
+            color: 'info',
+            variant: 'solid',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-info data-[selected]:text-on-info data-today:not-data-[selected]:text-info data-[highlighted]:bg-info/20 hover:not-data-[selected]:bg-info/20'
+            }
+        },
+        {
+            color: 'surface',
+            variant: 'solid',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-inverse-surface data-[selected]:text-inverse-on-surface data-today:not-data-[selected]:text-on-surface data-[highlighted]:bg-inverse-surface/20 hover:not-data-[selected]:bg-inverse-surface/10'
+            }
+        },
+
+        // ========== OUTLINE VARIANTS ==========
+        {
+            color: 'primary',
+            variant: 'outline',
+            class: {
+                cellTrigger:
+                    'data-[selected]:ring data-[selected]:ring-inset data-[selected]:ring-primary/50 data-[selected]:text-primary data-today:not-data-[selected]:text-primary data-[highlighted]:bg-primary/10 hover:not-data-[selected]:bg-primary/10'
+            }
+        },
+        {
+            color: 'secondary',
+            variant: 'outline',
+            class: {
+                cellTrigger:
+                    'data-[selected]:ring data-[selected]:ring-inset data-[selected]:ring-secondary/50 data-[selected]:text-secondary data-today:not-data-[selected]:text-secondary data-[highlighted]:bg-secondary/10 hover:not-data-[selected]:bg-secondary/10'
+            }
+        },
+        {
+            color: 'tertiary',
+            variant: 'outline',
+            class: {
+                cellTrigger:
+                    'data-[selected]:ring data-[selected]:ring-inset data-[selected]:ring-tertiary/50 data-[selected]:text-tertiary data-today:not-data-[selected]:text-tertiary data-[highlighted]:bg-tertiary/10 hover:not-data-[selected]:bg-tertiary/10'
+            }
+        },
+        {
+            color: 'success',
+            variant: 'outline',
+            class: {
+                cellTrigger:
+                    'data-[selected]:ring data-[selected]:ring-inset data-[selected]:ring-success/50 data-[selected]:text-success data-today:not-data-[selected]:text-success data-[highlighted]:bg-success/10 hover:not-data-[selected]:bg-success/10'
+            }
+        },
+        {
+            color: 'warning',
+            variant: 'outline',
+            class: {
+                cellTrigger:
+                    'data-[selected]:ring data-[selected]:ring-inset data-[selected]:ring-warning/50 data-[selected]:text-warning data-today:not-data-[selected]:text-warning data-[highlighted]:bg-warning/10 hover:not-data-[selected]:bg-warning/10'
+            }
+        },
+        {
+            color: 'error',
+            variant: 'outline',
+            class: {
+                cellTrigger:
+                    'data-[selected]:ring data-[selected]:ring-inset data-[selected]:ring-error/50 data-[selected]:text-error data-today:not-data-[selected]:text-error data-[highlighted]:bg-error/10 hover:not-data-[selected]:bg-error/10'
+            }
+        },
+        {
+            color: 'info',
+            variant: 'outline',
+            class: {
+                cellTrigger:
+                    'data-[selected]:ring data-[selected]:ring-inset data-[selected]:ring-info/50 data-[selected]:text-info data-today:not-data-[selected]:text-info data-[highlighted]:bg-info/10 hover:not-data-[selected]:bg-info/10'
+            }
+        },
+        {
+            color: 'surface',
+            variant: 'outline',
+            class: {
+                cellTrigger:
+                    'data-[selected]:ring data-[selected]:ring-inset data-[selected]:ring-outline-variant data-[selected]:text-on-surface data-[selected]:bg-surface data-today:not-data-[selected]:text-on-surface data-[highlighted]:bg-inverse-surface/10 hover:not-data-[selected]:bg-inverse-surface/10'
+            }
+        },
+
+        // ========== SOFT VARIANTS ==========
+        {
+            color: 'primary',
+            variant: 'soft',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-primary/10 data-[selected]:text-primary data-today:not-data-[selected]:text-primary data-[highlighted]:bg-primary/20 hover:not-data-[selected]:bg-primary/20'
+            }
+        },
+        {
+            color: 'secondary',
+            variant: 'soft',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-secondary/10 data-[selected]:text-secondary data-today:not-data-[selected]:text-secondary data-[highlighted]:bg-secondary/20 hover:not-data-[selected]:bg-secondary/20'
+            }
+        },
+        {
+            color: 'tertiary',
+            variant: 'soft',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-tertiary/10 data-[selected]:text-tertiary data-today:not-data-[selected]:text-tertiary data-[highlighted]:bg-tertiary/20 hover:not-data-[selected]:bg-tertiary/20'
+            }
+        },
+        {
+            color: 'success',
+            variant: 'soft',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-success/10 data-[selected]:text-success data-today:not-data-[selected]:text-success data-[highlighted]:bg-success/20 hover:not-data-[selected]:bg-success/20'
+            }
+        },
+        {
+            color: 'warning',
+            variant: 'soft',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-warning/10 data-[selected]:text-warning data-today:not-data-[selected]:text-warning data-[highlighted]:bg-warning/20 hover:not-data-[selected]:bg-warning/20'
+            }
+        },
+        {
+            color: 'error',
+            variant: 'soft',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-error/10 data-[selected]:text-error data-today:not-data-[selected]:text-error data-[highlighted]:bg-error/20 hover:not-data-[selected]:bg-error/20'
+            }
+        },
+        {
+            color: 'info',
+            variant: 'soft',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-info/10 data-[selected]:text-info data-today:not-data-[selected]:text-info data-[highlighted]:bg-info/20 hover:not-data-[selected]:bg-info/20'
+            }
+        },
+        {
+            color: 'surface',
+            variant: 'soft',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-surface-container-highest data-[selected]:text-on-surface data-today:not-data-[selected]:text-on-surface data-[highlighted]:bg-inverse-surface/20 hover:not-data-[selected]:bg-inverse-surface/10'
+            }
+        },
+
+        // ========== SUBTLE VARIANTS ==========
+        {
+            color: 'primary',
+            variant: 'subtle',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-primary/10 data-[selected]:text-primary data-[selected]:ring data-[selected]:ring-inset data-[selected]:ring-primary/25 data-today:not-data-[selected]:text-primary data-[highlighted]:bg-primary/20 hover:not-data-[selected]:bg-primary/20'
+            }
+        },
+        {
+            color: 'secondary',
+            variant: 'subtle',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-secondary/10 data-[selected]:text-secondary data-[selected]:ring data-[selected]:ring-inset data-[selected]:ring-secondary/25 data-today:not-data-[selected]:text-secondary data-[highlighted]:bg-secondary/20 hover:not-data-[selected]:bg-secondary/20'
+            }
+        },
+        {
+            color: 'tertiary',
+            variant: 'subtle',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-tertiary/10 data-[selected]:text-tertiary data-[selected]:ring data-[selected]:ring-inset data-[selected]:ring-tertiary/25 data-today:not-data-[selected]:text-tertiary data-[highlighted]:bg-tertiary/20 hover:not-data-[selected]:bg-tertiary/20'
+            }
+        },
+        {
+            color: 'success',
+            variant: 'subtle',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-success/10 data-[selected]:text-success data-[selected]:ring data-[selected]:ring-inset data-[selected]:ring-success/25 data-today:not-data-[selected]:text-success data-[highlighted]:bg-success/20 hover:not-data-[selected]:bg-success/20'
+            }
+        },
+        {
+            color: 'warning',
+            variant: 'subtle',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-warning/10 data-[selected]:text-warning data-[selected]:ring data-[selected]:ring-inset data-[selected]:ring-warning/25 data-today:not-data-[selected]:text-warning data-[highlighted]:bg-warning/20 hover:not-data-[selected]:bg-warning/20'
+            }
+        },
+        {
+            color: 'error',
+            variant: 'subtle',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-error/10 data-[selected]:text-error data-[selected]:ring data-[selected]:ring-inset data-[selected]:ring-error/25 data-today:not-data-[selected]:text-error data-[highlighted]:bg-error/20 hover:not-data-[selected]:bg-error/20'
+            }
+        },
+        {
+            color: 'info',
+            variant: 'subtle',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-info/10 data-[selected]:text-info data-[selected]:ring data-[selected]:ring-inset data-[selected]:ring-info/25 data-today:not-data-[selected]:text-info data-[highlighted]:bg-info/20 hover:not-data-[selected]:bg-info/20'
+            }
+        },
+        {
+            color: 'surface',
+            variant: 'subtle',
+            class: {
+                cellTrigger:
+                    'data-[selected]:bg-surface-container-highest data-[selected]:text-on-surface data-[selected]:ring data-[selected]:ring-inset data-[selected]:ring-outline-variant data-today:not-data-[selected]:text-on-surface data-[highlighted]:bg-inverse-surface/20 hover:not-data-[selected]:bg-inverse-surface/10'
+            }
+        }
+    ],
+    defaultVariants: {
+        size: 'md',
+        color: 'primary',
+        variant: 'solid'
+    }
+})
+
+export type CalendarVariantProps = VariantProps<typeof calendarVariants>
+export type CalendarSlots = keyof ReturnType<typeof calendarVariants>
+
+export const calendarDefaults = {
+    defaultVariants: calendarVariants.defaultVariants,
+    slots: {} as Partial<Record<CalendarSlots, string>>
+}

--- a/src/lib/Calendar/index.ts
+++ b/src/lib/Calendar/index.ts
@@ -3,12 +3,5 @@ export type {
     CalendarProps,
     CalendarSingleProps,
     CalendarMultipleProps,
-    CalendarRangeProps,
-    CalendarValue,
-    CalendarSingleValue,
-    CalendarMultipleValue,
-    CalendarRangeValue,
-    CalendarHeadingSlotProps,
-    CalendarDaySlotProps,
-    CalendarWeekdaySlotProps
+    CalendarRangeProps
 } from './calendar.types.js'

--- a/src/lib/Calendar/index.ts
+++ b/src/lib/Calendar/index.ts
@@ -1,0 +1,14 @@
+export { default as Calendar } from './Calendar.svelte'
+export type {
+    CalendarProps,
+    CalendarSingleProps,
+    CalendarMultipleProps,
+    CalendarRangeProps,
+    CalendarValue,
+    CalendarSingleValue,
+    CalendarMultipleValue,
+    CalendarRangeValue,
+    CalendarHeadingSlotProps,
+    CalendarDaySlotProps,
+    CalendarWeekdaySlotProps
+} from './calendar.types.js'

--- a/src/lib/Popover/Popover.svelte.spec.ts
+++ b/src/lib/Popover/Popover.svelte.spec.ts
@@ -192,8 +192,8 @@ describe('Popover', () => {
                 const content = getContent()
                 expect(content).not.toBeNull()
                 expect(content!.className).toContain('z-50')
-                expect(content!.className).toContain('bg-inverse-surface')
-                expect(content!.className).toContain('text-inverse-on-surface')
+                expect(content!.className).toContain('bg-surface-container-lowest')
+                expect(content!.className).toContain('text-on-surface')
                 expect(content!.className).toContain('rounded-md')
             })
         })
@@ -203,7 +203,6 @@ describe('Popover', () => {
             await vi.waitFor(() => {
                 const arrow = getArrow()
                 expect(arrow).not.toBeNull()
-                expect(arrow!.className).toContain('fill-inverse-surface')
             })
         })
     })

--- a/src/lib/Popover/popover.variants.ts
+++ b/src/lib/Popover/popover.variants.ts
@@ -4,13 +4,11 @@ export const popoverVariants = tv({
     slots: {
         content: [
             'z-50',
-            'bg-inverse-surface text-inverse-on-surface',
-            'rounded-md',
-            '[--ui-border-color:rgb(255_255_255/0.1)]',
-            '[filter:drop-shadow(0_1px_2px_rgb(0_0_0/0.1))_drop-shadow(0_0_1px_var(--ui-border-color))]',
+            'bg-surface-container-lowest text-on-surface ring ring-surface-container-highest',
+            'rounded-md shadow-lg',
             'focus:outline-none pointer-events-auto'
         ],
-        arrow: 'fill-inverse-surface text-inverse-surface'
+        arrow: ''
     },
     variants: {
         side: {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -23,6 +23,7 @@ export * from './Accordion/index.js'
 export * from './Slideover/index.js'
 export * from './Popover/index.js'
 export * from './Breadcrumb/index.js'
+export * from './Calendar/index.js'
 
 // Configuration
 export { defineConfig } from './config.js'

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -33,7 +33,8 @@
         { href: '/accordion', label: 'Accordion', icon: 'lucide:chevrons-down-up' },
         { href: '/slideover', label: 'Slideover', icon: 'lucide:panel-right' },
         { href: '/popover', label: 'Popover', icon: 'lucide:message-circle' },
-        { href: '/breadcrumb', label: 'Breadcrumb', icon: 'lucide:chevrons-right' }
+        { href: '/breadcrumb', label: 'Breadcrumb', icon: 'lucide:chevrons-right' },
+        { href: '/calendar', label: 'Calendar', icon: 'lucide:calendar' }
     ]
 
     const docItems = [

--- a/src/routes/calendar/+page.svelte
+++ b/src/routes/calendar/+page.svelte
@@ -97,9 +97,7 @@
         >
             <div class="space-y-2">
                 <p class="text-xs font-medium text-on-surface-variant">Single Date</p>
-                <Popover
-                    bind:open={datePickerOpen}
-                >
+                <Popover bind:open={datePickerOpen}>
                     <Button variant="outline" color="surface" class="w-56 justify-start">
                         <span class="flex items-center gap-2">
                             <Icon name="lucide:calendar" class="size-4" />
@@ -113,17 +111,18 @@
                         </span>
                     </Button>
                     {#snippet content({ close })}
-                        <Calendar bind:value={datePickerValue} class="p-2" onValueChange={() => close()} />
+                        <Calendar
+                            bind:value={datePickerValue}
+                            class="p-2"
+                            onValueChange={() => close()}
+                        />
                     {/snippet}
                 </Popover>
             </div>
 
             <div class="space-y-2">
                 <p class="text-xs font-medium text-on-surface-variant">Date Range</p>
-                <Popover
-                    arrow
-                    bind:open={rangeDatePickerOpen}
-                >
+                <Popover arrow bind:open={rangeDatePickerOpen}>
                     <Button variant="outline" color="surface" class="w-72 justify-start">
                         <span class="flex items-center gap-2">
                             <Icon name="lucide:calendar" class="size-4" />
@@ -137,7 +136,12 @@
                         </span>
                     </Button>
                     {#snippet content()}
-                        <Calendar range bind:value={rangeDatePickerValue} class="p-2" numberOfMonths={2} />
+                        <Calendar
+                            range
+                            bind:value={rangeDatePickerValue}
+                            class="p-2"
+                            numberOfMonths={2}
+                        />
                     {/snippet}
                 </Popover>
             </div>

--- a/src/routes/calendar/+page.svelte
+++ b/src/routes/calendar/+page.svelte
@@ -121,6 +121,7 @@
             <div class="space-y-2">
                 <p class="text-xs font-medium text-on-surface-variant">Date Range</p>
                 <Popover
+                    arrow
                     bind:open={rangeDatePickerOpen}
                 >
                     <Button variant="outline" color="surface" class="w-72 justify-start">
@@ -136,7 +137,7 @@
                         </span>
                     </Button>
                     {#snippet content()}
-                        <Calendar range bind:value={rangeDatePickerValue} numberOfMonths={2} />
+                        <Calendar range bind:value={rangeDatePickerValue} class="p-2" numberOfMonths={2} />
                     {/snippet}
                 </Popover>
             </div>

--- a/src/routes/calendar/+page.svelte
+++ b/src/routes/calendar/+page.svelte
@@ -1,0 +1,461 @@
+<script lang="ts">
+    import { Calendar, Button, Popover, Icon } from '$lib/index.js'
+    import { CalendarDate, today, getLocalTimeZone } from '@internationalized/date'
+    import type { DateValue } from '@internationalized/date'
+    import type { DateRange } from 'bits-ui'
+
+    // Date picker (Button + Popover)
+    let datePickerValue: DateValue | undefined = $state(undefined)
+    let datePickerOpen = $state(false)
+
+    // Range date picker
+    let rangeDatePickerValue: DateRange | undefined = $state(undefined)
+    let rangeDatePickerOpen = $state(false)
+
+    function formatDate(date: DateValue | undefined): string {
+        if (!date) return 'Pick a date'
+        return date.toDate('UTC').toLocaleDateString('en-US', {
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric'
+        })
+    }
+
+    function formatRange(range: DateRange | undefined): string {
+        if (!range?.start) return 'Pick a date range'
+        const start = range.start
+            .toDate('UTC')
+            .toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+        if (!range.end) return `${start} - ...`
+        const end = range.end
+            .toDate('UTC')
+            .toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+        return `${start} - ${end}`
+    }
+
+    // Single value
+    let singleValue: DateValue | undefined = $state(undefined)
+
+    // Multiple values
+    let multipleValues: DateValue[] | undefined = $state([
+        new CalendarDate(2024, 3, 10),
+        new CalendarDate(2024, 3, 15),
+        new CalendarDate(2024, 3, 20)
+    ])
+
+    // Range value
+    let rangeValue: DateRange | undefined = $state({
+        start: new CalendarDate(2024, 3, 10),
+        end: new CalendarDate(2024, 3, 20)
+    })
+
+    // Disabled dates (weekends)
+    function isWeekend(date: DateValue): boolean {
+        const jsDate = date.toDate('UTC')
+        const day = jsDate.getDay()
+        return day === 0 || day === 6
+    }
+
+    // Unavailable dates
+    function isHoliday(date: DateValue): boolean {
+        return date.month === 3 && (date.day === 25 || date.day === 26)
+    }
+
+    const colors = [
+        'primary',
+        'secondary',
+        'tertiary',
+        'success',
+        'warning',
+        'error',
+        'info',
+        'surface'
+    ] as const
+    const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const
+    const variants = ['solid', 'outline', 'soft', 'subtle'] as const
+</script>
+
+<div class="space-y-12">
+    <header>
+        <h1 class="text-3xl font-bold text-on-surface">Calendar</h1>
+        <p class="mt-2 text-on-surface-variant">
+            A date selection component that supports single, multiple, and range selection modes.
+            Built on bits-ui Calendar and RangeCalendar primitives.
+        </p>
+    </header>
+
+    <!-- Date Picker (Button + Popover) -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Date Picker</h2>
+        <p class="text-sm text-on-surface-variant">
+            Combine <code class="text-primary">Calendar</code> with
+            <code class="text-primary">Button</code> and
+            <code class="text-primary">Popover</code> to create a date picker.
+        </p>
+        <div
+            class="flex flex-wrap items-start gap-6 rounded-lg border border-outline-variant bg-surface-container-low p-6"
+        >
+            <div class="space-y-2">
+                <p class="text-xs font-medium text-on-surface-variant">Single Date</p>
+                <Popover
+                    bind:open={datePickerOpen}
+                >
+                    <Button variant="outline" color="surface" class="w-56 justify-start">
+                        <span class="flex items-center gap-2">
+                            <Icon name="lucide:calendar" class="size-4" />
+                            <span
+                                class={datePickerValue
+                                    ? 'text-on-surface'
+                                    : 'text-on-surface-variant'}
+                            >
+                                {formatDate(datePickerValue)}
+                            </span>
+                        </span>
+                    </Button>
+                    {#snippet content({ close })}
+                        <Calendar bind:value={datePickerValue} class="p-2" onValueChange={() => close()} />
+                    {/snippet}
+                </Popover>
+            </div>
+
+            <div class="space-y-2">
+                <p class="text-xs font-medium text-on-surface-variant">Date Range</p>
+                <Popover
+                    bind:open={rangeDatePickerOpen}
+                >
+                    <Button variant="outline" color="surface" class="w-72 justify-start">
+                        <span class="flex items-center gap-2">
+                            <Icon name="lucide:calendar" class="size-4" />
+                            <span
+                                class={rangeDatePickerValue?.start
+                                    ? 'text-on-surface'
+                                    : 'text-on-surface-variant'}
+                            >
+                                {formatRange(rangeDatePickerValue)}
+                            </span>
+                        </span>
+                    </Button>
+                    {#snippet content()}
+                        <Calendar range bind:value={rangeDatePickerValue} numberOfMonths={2} />
+                    {/snippet}
+                </Popover>
+            </div>
+        </div>
+    </section>
+
+    <!-- Basic Usage -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Basic Usage</h2>
+        <p class="text-sm text-on-surface-variant">A simple calendar with single date selection.</p>
+        <div
+            class="flex flex-wrap items-start gap-6 rounded-lg border border-outline-variant bg-surface-container-low p-6"
+        >
+            <Calendar bind:value={singleValue} />
+            <div class="text-sm text-on-surface-variant">
+                <p>
+                    Selected: <code class="text-primary">{singleValue?.toString() ?? 'none'}</code>
+                </p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Colors -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Colors</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="text-primary">color</code> prop to change the selected day color.
+        </p>
+        <div
+            class="flex flex-wrap items-start gap-6 rounded-lg border border-outline-variant bg-surface-container-low p-6"
+        >
+            {#each colors as color (color)}
+                <div class="space-y-2">
+                    <p class="text-center text-xs font-medium text-on-surface-variant capitalize">
+                        {color}
+                    </p>
+                    <Calendar {color} value={today(getLocalTimeZone())} size="xs" />
+                </div>
+            {/each}
+        </div>
+    </section>
+
+    <!-- Variants -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Variants</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="text-primary">variant</code> prop to change the visual style.
+        </p>
+        <div
+            class="flex flex-wrap items-start gap-6 rounded-lg border border-outline-variant bg-surface-container-low p-6"
+        >
+            {#each variants as variant (variant)}
+                <div class="space-y-2">
+                    <p class="text-center text-xs font-medium text-on-surface-variant capitalize">
+                        {variant}
+                    </p>
+                    <Calendar {variant} value={today(getLocalTimeZone())} size="sm" />
+                </div>
+            {/each}
+        </div>
+    </section>
+
+    <!-- Sizes -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Sizes</h2>
+        <p class="text-sm text-on-surface-variant">
+            Control the calendar size with the <code class="text-primary">size</code> prop.
+        </p>
+        <div
+            class="flex flex-wrap items-start gap-6 rounded-lg border border-outline-variant bg-surface-container-low p-6"
+        >
+            {#each sizes as size (size)}
+                <div class="space-y-2">
+                    <p class="text-center text-xs font-medium text-on-surface-variant uppercase">
+                        {size}
+                    </p>
+                    <Calendar {size} />
+                </div>
+            {/each}
+        </div>
+    </section>
+
+    <!-- Multiple Selection -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Multiple Selection</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="text-primary">type="multiple"</code> to allow selecting multiple dates.
+        </p>
+        <div
+            class="flex flex-wrap items-start gap-6 rounded-lg border border-outline-variant bg-surface-container-low p-6"
+        >
+            <Calendar
+                type="multiple"
+                bind:value={multipleValues}
+                placeholder={new CalendarDate(2024, 3, 1)}
+            />
+            <div class="text-sm text-on-surface-variant">
+                <p class="font-medium">Selected dates:</p>
+                {#if multipleValues?.length}
+                    <ul class="mt-1 list-inside list-disc">
+                        {#each multipleValues as date (date.toString())}
+                            <li><code class="text-primary">{date.toString()}</code></li>
+                        {/each}
+                    </ul>
+                {:else}
+                    <p class="text-on-surface-variant/60">No dates selected</p>
+                {/if}
+            </div>
+        </div>
+    </section>
+
+    <!-- Range Selection -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Range Selection</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="text-primary">range</code> prop to enable date range selection.
+        </p>
+        <div
+            class="flex flex-wrap items-start gap-6 rounded-lg border border-outline-variant bg-surface-container-low p-6"
+        >
+            <Calendar
+                range
+                bind:value={rangeValue}
+                placeholder={new CalendarDate(2024, 3, 1)}
+                numberOfMonths={2}
+            />
+            <div class="text-sm text-on-surface-variant">
+                <p>
+                    Start: <code class="text-primary"
+                        >{rangeValue?.start?.toString() ?? 'none'}</code
+                    >
+                </p>
+                <p>
+                    End: <code class="text-primary">{rangeValue?.end?.toString() ?? 'none'}</code>
+                </p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Multiple Months -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Multiple Months</h2>
+        <p class="text-sm text-on-surface-variant">
+            Display multiple months with the <code class="text-primary">numberOfMonths</code> prop.
+        </p>
+        <div
+            class="flex flex-wrap items-start gap-6 rounded-lg border border-outline-variant bg-surface-container-low p-6"
+        >
+            <Calendar numberOfMonths={2} />
+        </div>
+    </section>
+
+    <!-- Year Navigation -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Year Navigation</h2>
+        <p class="text-sm text-on-surface-variant">
+            Enable year navigation controls with <code class="text-primary">yearControls</code>.
+        </p>
+        <div
+            class="flex flex-wrap items-start gap-6 rounded-lg border border-outline-variant bg-surface-container-low p-6"
+        >
+            <Calendar yearControls />
+        </div>
+    </section>
+
+    <!-- Fixed Weeks -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Fixed Weeks</h2>
+        <p class="text-sm text-on-surface-variant">
+            Always display 6 weeks with <code class="text-primary">fixedWeeks</code> for consistent height.
+        </p>
+        <div
+            class="flex flex-wrap items-start gap-6 rounded-lg border border-outline-variant bg-surface-container-low p-6"
+        >
+            <div class="space-y-2">
+                <p class="text-xs font-medium text-on-surface-variant">Fixed Weeks</p>
+                <Calendar fixedWeeks />
+            </div>
+            <div class="space-y-2">
+                <p class="text-xs font-medium text-on-surface-variant">Default</p>
+                <Calendar />
+            </div>
+        </div>
+    </section>
+
+    <!-- Disabled Dates -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Disabled Dates</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="text-primary">isDateDisabled</code> to disable specific dates (weekends in
+            this example).
+        </p>
+        <div
+            class="flex flex-wrap items-start gap-6 rounded-lg border border-outline-variant bg-surface-container-low p-6"
+        >
+            <Calendar isDateDisabled={isWeekend} />
+        </div>
+    </section>
+
+    <!-- Unavailable Dates -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Unavailable Dates</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="text-primary">isDateUnavailable</code> to mark dates as unavailable (users
+            can still focus them).
+        </p>
+        <div
+            class="flex flex-wrap items-start gap-6 rounded-lg border border-outline-variant bg-surface-container-low p-6"
+        >
+            <Calendar isDateUnavailable={isHoliday} placeholder={new CalendarDate(2024, 3, 1)} />
+        </div>
+    </section>
+
+    <!-- Min/Max Values -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Min/Max Values</h2>
+        <p class="text-sm text-on-surface-variant">
+            Restrict selection to a date range with <code class="text-primary">minValue</code> and
+            <code class="text-primary">maxValue</code>.
+        </p>
+        <div
+            class="flex flex-wrap items-start gap-6 rounded-lg border border-outline-variant bg-surface-container-low p-6"
+        >
+            <Calendar
+                minValue={new CalendarDate(2024, 3, 5)}
+                maxValue={new CalendarDate(2024, 3, 25)}
+                placeholder={new CalendarDate(2024, 3, 1)}
+            />
+        </div>
+    </section>
+
+    <!-- Disabled -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Disabled</h2>
+        <p class="text-sm text-on-surface-variant">
+            Disable the entire calendar with the <code class="text-primary">disabled</code> prop.
+        </p>
+        <div
+            class="flex flex-wrap items-start gap-6 rounded-lg border border-outline-variant bg-surface-container-low p-6"
+        >
+            <Calendar disabled />
+        </div>
+    </section>
+
+    <!-- Readonly -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Readonly</h2>
+        <p class="text-sm text-on-surface-variant">
+            Make the calendar readonly (navigable but not selectable) with <code
+                class="text-primary">readonly</code
+            >.
+        </p>
+        <div
+            class="flex flex-wrap items-start gap-6 rounded-lg border border-outline-variant bg-surface-container-low p-6"
+        >
+            <Calendar readonly value={today(getLocalTimeZone())} />
+        </div>
+    </section>
+
+    <!-- Locale -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Locale</h2>
+        <p class="text-sm text-on-surface-variant">
+            Change the locale with the <code class="text-primary">locale</code> prop.
+        </p>
+        <div
+            class="flex flex-wrap items-start gap-6 rounded-lg border border-outline-variant bg-surface-container-low p-6"
+        >
+            <div class="space-y-2">
+                <p class="text-xs font-medium text-on-surface-variant">English (default)</p>
+                <Calendar locale="en" size="sm" />
+            </div>
+            <div class="space-y-2">
+                <p class="text-xs font-medium text-on-surface-variant">Vietnamese</p>
+                <Calendar locale="vi" size="sm" />
+            </div>
+            <div class="space-y-2">
+                <p class="text-xs font-medium text-on-surface-variant">Japanese</p>
+                <Calendar locale="ja" size="sm" />
+            </div>
+        </div>
+    </section>
+
+    <!-- Week Starts On -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Week Starts On</h2>
+        <p class="text-sm text-on-surface-variant">
+            Control the first day of the week with <code class="text-primary">weekStartsOn</code>.
+        </p>
+        <div
+            class="flex flex-wrap items-start gap-6 rounded-lg border border-outline-variant bg-surface-container-low p-6"
+        >
+            <div class="space-y-2">
+                <p class="text-xs font-medium text-on-surface-variant">Sunday (0)</p>
+                <Calendar weekStartsOn={0} size="sm" />
+            </div>
+            <div class="space-y-2">
+                <p class="text-xs font-medium text-on-surface-variant">Monday (1)</p>
+                <Calendar weekStartsOn={1} size="sm" />
+            </div>
+        </div>
+    </section>
+
+    <!-- UI Slot Overrides -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">UI Slot Overrides</h2>
+        <p class="text-sm text-on-surface-variant">
+            Customize individual parts with the <code class="text-primary">ui</code> prop.
+        </p>
+        <div
+            class="flex flex-wrap items-start gap-6 rounded-lg border border-outline-variant bg-surface-container-low p-6"
+        >
+            <Calendar
+                ui={{
+                    root: 'shadow-xl',
+                    heading: 'text-primary',
+                    headCell: 'text-primary/60'
+                }}
+            />
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
## Summary
- Add Calendar component supporting single, multiple, and range date selection modes built on bits-ui primitives
- Implement variants (solid, outline, soft, subtle) × 8 colors matching Nuxt UI v4 theme structure
- Add date picker demo combining Calendar with Button + Popover
- Add `@internationalized/date` dependency for date value types

## New files
- `src/lib/Calendar/Calendar.svelte` — main component wrapping bits-ui Calendar & RangeCalendar
- `src/lib/Calendar/calendar.types.ts` — TypeScript type definitions (single/multiple/range union)
- `src/lib/Calendar/calendar.variants.ts` — tailwind-variants theme following Nuxt UI v4 structure
- `src/lib/Calendar/Calendar.svelte.spec.ts` — test suite
- `src/routes/calendar/+page.svelte` — demo page with all features

## Features
- Single, multiple, and range date selection
- 8 colors × 4 variants (solid, outline, soft, subtle)
- 5 sizes (xs–xl)
- Month & year navigation controls
- Locale, weekStartsOn, fixedWeeks, weekNumbers support
- Min/max values, disabled/unavailable dates
- Customizable via `ui` slot overrides and snippets (heading, day, weekday)
- Date picker pattern: Button + Popover + Calendar

## Test plan
- [ ] Verify single date selection works
- [ ] Verify multiple date selection with `type="multiple"`
- [ ] Verify range selection with `range` prop
- [ ] Test date picker (Button + Popover) opens/closes correctly
- [ ] Test all color/variant/size combinations render correctly
- [ ] Test disabled, readonly, locale, weekStartsOn props