### PR TITLE
feat: add Tabs component with animated indicator, variants, and demo page

### DIFF
--- a/src/lib/Tabs/Tabs.svelte
+++ b/src/lib/Tabs/Tabs.svelte
@@ -1,0 +1,189 @@
+<script lang="ts" module>
+    import type { TabsProps, TabsItem } from './tabs.types.js'
+
+    export type Props = TabsProps
+</script>
+
+<script lang="ts">
+    import { Tabs } from 'bits-ui'
+    import { tick, untrack } from 'svelte'
+    import { tabsVariants, tabsDefaults } from './tabs.variants.js'
+    import { getComponentConfig } from '../config.js'
+    import Icon from '../Icon/Icon.svelte'
+
+    const config = getComponentConfig('tabs', tabsDefaults)
+
+    let {
+        items = [],
+        value = $bindable(),
+        defaultValue,
+        onValueChange,
+        variant = config.defaultVariants.variant ?? 'pill',
+        color = config.defaultVariants.color ?? 'primary',
+        size = config.defaultVariants.size ?? 'md',
+        orientation = config.defaultVariants.orientation ?? 'horizontal',
+        activationMode = 'automatic',
+        disabled = false,
+        loop = true,
+        content: showContent = true,
+        ui,
+        class: className,
+        leading,
+        label: labelSlot,
+        trailing,
+        body: bodySlot
+    }: Props = $props()
+
+    // Initialize value if not provided (intentionally reads initial values only)
+    if (value === undefined) {
+        value = untrack(
+            () => defaultValue ?? (items.length > 0 ? (items[0].value ?? '0') : undefined)
+        )
+    }
+
+    let listEl: HTMLElement | null = $state(null)
+    let indicatorStyle = $state('')
+
+    const variantSlots = $derived(tabsVariants({ variant, color, size, orientation }))
+
+    const classes = $derived.by(() => ({
+        root: variantSlots.root({ class: [config.slots.root, className, ui?.root] }),
+        list: variantSlots.list({ class: [config.slots.list, ui?.list] }),
+        indicator: variantSlots.indicator({
+            class: [config.slots.indicator, ui?.indicator]
+        }),
+        trigger: variantSlots.trigger({ class: [config.slots.trigger, ui?.trigger] }),
+        leadingIcon: variantSlots.leadingIcon({
+            class: [config.slots.leadingIcon, ui?.leadingIcon]
+        }),
+        label: variantSlots.label({ class: [config.slots.label, ui?.label] }),
+        content: variantSlots.content({ class: [config.slots.content, ui?.content] })
+    }))
+
+    let rafId = 0
+
+    function getItemValue(item: TabsItem, index: number): string {
+        return item.value ?? String(index)
+    }
+
+    function getTriggerClass(item: TabsItem) {
+        if (!item.ui?.trigger && !item.class) return classes.trigger
+        return variantSlots.trigger({
+            class: [config.slots.trigger, ui?.trigger, item.ui?.trigger, item.class]
+        })
+    }
+
+    function getIconClass(item: TabsItem) {
+        if (!item.ui?.leadingIcon) return classes.leadingIcon
+        return variantSlots.leadingIcon({
+            class: [config.slots.leadingIcon, ui?.leadingIcon, item.ui?.leadingIcon]
+        })
+    }
+
+    function getLabelClass(item: TabsItem) {
+        if (!item.ui?.label) return classes.label
+        return variantSlots.label({
+            class: [config.slots.label, ui?.label, item.ui?.label]
+        })
+    }
+
+    function updateIndicator() {
+        if (!listEl) return
+        const activeTrigger = listEl.querySelector('[data-state="active"]') as HTMLElement
+        if (!activeTrigger) {
+            indicatorStyle = 'opacity: 0;'
+            return
+        }
+
+        if (orientation === 'horizontal') {
+            indicatorStyle = `left: ${activeTrigger.offsetLeft}px; width: ${activeTrigger.offsetWidth}px;`
+        } else {
+            indicatorStyle = `top: ${activeTrigger.offsetTop}px; height: ${activeTrigger.offsetHeight}px;`
+        }
+    }
+
+    function scheduleIndicatorUpdate() {
+        cancelAnimationFrame(rafId)
+        rafId = requestAnimationFrame(updateIndicator)
+    }
+
+    function handleValueChange(newValue: string) {
+        value = newValue
+        onValueChange?.(newValue)
+    }
+
+    // Update indicator on mount and when dependencies change
+    $effect(() => {
+        void value
+        void orientation
+        void items
+        tick().then(updateIndicator)
+    })
+
+    // Handle resize with rAF debouncing
+    $effect(() => {
+        if (!listEl) return
+
+        const observer = new ResizeObserver(scheduleIndicatorUpdate)
+        observer.observe(listEl)
+
+        return () => {
+            observer.disconnect()
+            cancelAnimationFrame(rafId)
+        }
+    })
+</script>
+
+<Tabs.Root
+    {value}
+    onValueChange={handleValueChange}
+    {orientation}
+    {activationMode}
+    {disabled}
+    {loop}
+    class={classes.root}
+>
+    <Tabs.List bind:ref={listEl} class={classes.list}>
+        <div class={classes.indicator} style={indicatorStyle}></div>
+
+        {#each items as item, index (item.value ?? index)}
+            {@const itemValue = getItemValue(item, index)}
+            {@const active = value === itemValue}
+            <Tabs.Trigger value={itemValue} disabled={item.disabled} class={getTriggerClass(item)}>
+                {#if leading}
+                    {@render leading({ item, index, active })}
+                {:else if item.icon}
+                    <Icon name={item.icon} class={getIconClass(item)} />
+                {/if}
+
+                {#if item.label || labelSlot}
+                    <span class={getLabelClass(item)}>
+                        {#if labelSlot}
+                            {@render labelSlot({ item, index, active })}
+                        {:else}
+                            {item.label}
+                        {/if}
+                    </span>
+                {/if}
+
+                {#if trailing}
+                    {@render trailing({ item, index, active })}
+                {/if}
+            </Tabs.Trigger>
+        {/each}
+    </Tabs.List>
+
+    {#if showContent}
+        {#each items as item, index (item.value ?? index)}
+            {@const itemValue = getItemValue(item, index)}
+            {@const active = value === itemValue}
+            <Tabs.Content value={itemValue} class={classes.content}>
+                {#if bodySlot}
+                    {@render bodySlot({ item, index, active })}
+                {:else if item.content}
+                    {item.content}
+                {/if}
+            </Tabs.Content>
+        {/each}
+    {/if}
+</Tabs.Root>

--- a/src/lib/Tabs/index.ts
+++ b/src/lib/Tabs/index.ts
@@ -1,0 +1,2 @@
+export { default as Tabs } from './Tabs.svelte'
+export type { TabsProps, TabsItem } from './tabs.types.js'

--- a/src/lib/Tabs/tabs.svelte.spec.ts
+++ b/src/lib/Tabs/tabs.svelte.spec.ts
@@ -1,0 +1,478 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-svelte'
+import { page } from 'vitest/browser'
+import Tabs from './Tabs.svelte'
+
+describe('Tabs', () => {
+    const sampleItems = [
+        { label: 'Tab 1', content: 'Content 1', value: 'tab1' },
+        { label: 'Tab 2', content: 'Content 2', value: 'tab2' },
+        { label: 'Tab 3', content: 'Content 3', value: 'tab3' }
+    ]
+
+    const getRoot = () => document.querySelector('[data-tabs-root]') as HTMLElement | null
+    const getList = () => document.querySelector('[data-tabs-list]') as HTMLElement | null
+    const getTriggers = () => document.querySelectorAll('[data-tabs-trigger]')
+    const getContents = () => document.querySelectorAll('[data-tabs-content]')
+
+    // ==================== RENDERING ====================
+
+    describe('rendering', () => {
+        it('should render without crashing', () => {
+            const { container } = render(Tabs, { items: sampleItems })
+            expect(container).not.toBeNull()
+        })
+
+        it('should render all tab triggers', async () => {
+            render(Tabs, { items: sampleItems })
+            await vi.waitFor(() => {
+                expect(getTriggers().length).toBe(3)
+            })
+        })
+
+        it('should render tab labels', async () => {
+            render(Tabs, { items: sampleItems })
+            await expect.element(page.getByText('Tab 1')).toBeVisible()
+            await expect.element(page.getByText('Tab 2')).toBeVisible()
+            await expect.element(page.getByText('Tab 3')).toBeVisible()
+        })
+
+        it('should render root with correct class', async () => {
+            render(Tabs, { items: sampleItems })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+                expect(root!.className).toContain('flex')
+                expect(root!.className).toContain('w-full')
+            })
+        })
+
+        it('should render tab list', async () => {
+            render(Tabs, { items: sampleItems })
+            await vi.waitFor(() => {
+                const list = getList()
+                expect(list).not.toBeNull()
+                expect(list!.className).toContain('inline-flex')
+            })
+        })
+
+        it('should render indicator element', async () => {
+            render(Tabs, { items: sampleItems })
+            await vi.waitFor(() => {
+                const list = getList()
+                expect(list).not.toBeNull()
+                const indicator = list!.querySelector('.transition-all')
+                expect(indicator).not.toBeNull()
+            })
+        })
+    })
+
+    // ==================== DEFAULT VALUE ====================
+
+    describe('default value', () => {
+        it('should select first tab by default', async () => {
+            render(Tabs, { items: sampleItems })
+            await expect.element(page.getByText('Content 1')).toBeVisible()
+        })
+
+        it('should select tab specified by value', async () => {
+            render(Tabs, { items: sampleItems, value: 'tab2' })
+            await expect.element(page.getByText('Content 2')).toBeVisible()
+        })
+
+        it('should select tab specified by defaultValue', async () => {
+            render(Tabs, { items: sampleItems, defaultValue: 'tab3' })
+            await expect.element(page.getByText('Content 3')).toBeVisible()
+        })
+
+        it('should use index as value when not provided', async () => {
+            const items = [
+                { label: 'First', content: 'First content' },
+                { label: 'Second', content: 'Second content' }
+            ]
+            render(Tabs, { items, value: '1' })
+            await expect.element(page.getByText('Second content')).toBeVisible()
+        })
+    })
+
+    // ==================== TAB SWITCHING ====================
+
+    describe('tab switching', () => {
+        it('should switch tab on click', async () => {
+            render(Tabs, { items: sampleItems })
+            await expect.element(page.getByText('Content 1')).toBeVisible()
+
+            await page.getByText('Tab 2').click()
+            await expect.element(page.getByText('Content 2')).toBeVisible()
+        })
+
+        it('should update active trigger state on click', async () => {
+            render(Tabs, { items: sampleItems })
+
+            await page.getByText('Tab 2').click()
+            await vi.waitFor(() => {
+                const triggers = getTriggers()
+                expect(triggers[1].getAttribute('data-state')).toBe('active')
+                expect(triggers[0].getAttribute('data-state')).toBe('inactive')
+            })
+        })
+
+        it('should show only one active content at a time', async () => {
+            render(Tabs, { items: sampleItems })
+
+            await page.getByText('Tab 1').click()
+            await expect.element(page.getByText('Content 1')).toBeVisible()
+
+            await page.getByText('Tab 2').click()
+            await expect.element(page.getByText('Content 2')).toBeVisible()
+
+            await vi.waitFor(() => {
+                const triggers = getTriggers()
+                const activeTriggers = Array.from(triggers).filter(
+                    (t) => t.getAttribute('data-state') === 'active'
+                )
+                expect(activeTriggers.length).toBe(1)
+            })
+        })
+    })
+
+    // ==================== DISABLED STATE ====================
+
+    describe('disabled state', () => {
+        it('should disable entire tabs', async () => {
+            render(Tabs, { items: sampleItems, disabled: true })
+            await vi.waitFor(() => {
+                const triggers = getTriggers()
+                triggers.forEach((trigger) => {
+                    expect(
+                        trigger.hasAttribute('disabled') ||
+                            trigger.getAttribute('data-disabled') !== null
+                    ).toBe(true)
+                })
+            })
+        })
+
+        it('should disable individual tab', async () => {
+            const itemsWithDisabled = [
+                { label: 'Tab 1', content: 'Content 1', value: 'tab1' },
+                { label: 'Tab 2', content: 'Content 2', value: 'tab2', disabled: true },
+                { label: 'Tab 3', content: 'Content 3', value: 'tab3' }
+            ]
+            render(Tabs, { items: itemsWithDisabled })
+            await vi.waitFor(() => {
+                const triggers = getTriggers()
+                const disabledTrigger = triggers[1]
+                expect(
+                    disabledTrigger.hasAttribute('disabled') ||
+                        disabledTrigger.getAttribute('data-disabled') !== null
+                ).toBe(true)
+            })
+        })
+    })
+
+    // ==================== CALLBACKS ====================
+
+    describe('callbacks', () => {
+        it('should call onValueChange when tab is clicked', async () => {
+            const onValueChange = vi.fn()
+            render(Tabs, { items: sampleItems, onValueChange })
+            await page.getByText('Tab 2').click()
+            await vi.waitFor(() => {
+                expect(onValueChange).toHaveBeenCalledWith('tab2')
+            })
+        })
+    })
+
+    // ==================== ICONS ====================
+
+    describe('icons', () => {
+        it('should render leading icon when provided', async () => {
+            const itemsWithIcon = [
+                { label: 'Home', content: 'Home content', value: 'home', icon: 'lucide:home' }
+            ]
+            render(Tabs, { items: itemsWithIcon })
+            await vi.waitFor(() => {
+                const triggers = getTriggers()
+                const icons = triggers[0].querySelectorAll('svg')
+                expect(icons.length).toBeGreaterThanOrEqual(1)
+            })
+        })
+    })
+
+    // ==================== CONTENT PROP ====================
+
+    describe('content prop', () => {
+        it('should not render content panels when content is false', async () => {
+            render(Tabs, { items: sampleItems, content: false })
+            await vi.waitFor(() => {
+                expect(getTriggers().length).toBe(3)
+                expect(getContents().length).toBe(0)
+            })
+        })
+
+        it('should render content panels when content is true', async () => {
+            render(Tabs, { items: sampleItems, content: true })
+            await vi.waitFor(() => {
+                const contents = getContents()
+                expect(contents.length).toBeGreaterThan(0)
+            })
+        })
+    })
+
+    // ==================== VARIANT CLASSES ====================
+
+    describe('variant classes', () => {
+        it('should apply pill variant classes', async () => {
+            render(Tabs, { items: sampleItems, variant: 'pill' })
+            await vi.waitFor(() => {
+                const list = getList()
+                expect(list).not.toBeNull()
+                expect(list!.className).toContain('bg-surface-container')
+                expect(list!.className).toContain('rounded-lg')
+            })
+        })
+
+        it('should apply link variant classes', async () => {
+            render(Tabs, { items: sampleItems, variant: 'link' })
+            await vi.waitFor(() => {
+                const list = getList()
+                expect(list).not.toBeNull()
+                expect(list!.className).toContain('border-b')
+            })
+        })
+
+        it('should apply trigger classes', async () => {
+            render(Tabs, { items: sampleItems })
+            await vi.waitFor(() => {
+                const triggers = getTriggers()
+                const trigger = triggers[0] as HTMLElement
+                expect(trigger.className).toContain('inline-flex')
+                expect(trigger.className).toContain('items-center')
+                expect(trigger.className).toContain('font-medium')
+            })
+        })
+
+        it('should apply horizontal orientation by default', async () => {
+            render(Tabs, { items: sampleItems })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+                expect(root!.className).toContain('flex-col')
+
+                const list = getList()
+                expect(list!.className).toContain('flex-row')
+            })
+        })
+
+        it('should apply vertical orientation classes', async () => {
+            render(Tabs, { items: sampleItems, orientation: 'vertical' })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+                expect(root!.className).toContain('flex-row')
+
+                const list = getList()
+                expect(list!.className).toContain('flex-col')
+            })
+        })
+    })
+
+    // ==================== SIZE VARIANTS ====================
+
+    describe('size variants', () => {
+        it('should apply xs size classes', async () => {
+            render(Tabs, { items: sampleItems, size: 'xs' })
+            await vi.waitFor(() => {
+                const trigger = getTriggers()[0] as HTMLElement
+                expect(trigger.className).toContain('text-xs')
+            })
+        })
+
+        it('should apply md size classes', async () => {
+            render(Tabs, { items: sampleItems, size: 'md' })
+            await vi.waitFor(() => {
+                const trigger = getTriggers()[0] as HTMLElement
+                expect(trigger.className).toContain('text-sm')
+            })
+        })
+
+        it('should apply xl size classes', async () => {
+            render(Tabs, { items: sampleItems, size: 'xl' })
+            await vi.waitFor(() => {
+                const trigger = getTriggers()[0] as HTMLElement
+                expect(trigger.className).toContain('text-base')
+            })
+        })
+    })
+
+    // ==================== UI SLOT OVERRIDES ====================
+
+    describe('ui slot overrides', () => {
+        it('should apply ui.root class', async () => {
+            render(Tabs, {
+                items: sampleItems,
+                ui: { root: 'custom-root' }
+            })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+                expect(root!.className).toContain('custom-root')
+            })
+        })
+
+        it('should apply ui.list class', async () => {
+            render(Tabs, {
+                items: sampleItems,
+                ui: { list: 'custom-list' }
+            })
+            await vi.waitFor(() => {
+                const list = getList()
+                expect(list).not.toBeNull()
+                expect(list!.className).toContain('custom-list')
+            })
+        })
+
+        it('should apply ui.trigger class', async () => {
+            render(Tabs, {
+                items: sampleItems,
+                ui: { trigger: 'custom-trigger' }
+            })
+            await vi.waitFor(() => {
+                const triggers = getTriggers()
+                triggers.forEach((trigger) => {
+                    expect((trigger as HTMLElement).className).toContain('custom-trigger')
+                })
+            })
+        })
+
+        it('should apply item-level class override', async () => {
+            const itemsWithClass = [
+                { label: 'Tab 1', content: 'Content 1', class: 'my-custom-tab' }
+            ]
+            render(Tabs, { items: itemsWithClass })
+            await vi.waitFor(() => {
+                const triggers = getTriggers()
+                expect((triggers[0] as HTMLElement).className).toContain('my-custom-tab')
+            })
+        })
+
+        it('should apply item-level ui.trigger override', async () => {
+            const itemsWithUi = [
+                {
+                    label: 'Tab 1',
+                    content: 'Content 1',
+                    ui: { trigger: 'item-trigger-custom' }
+                }
+            ]
+            render(Tabs, { items: itemsWithUi })
+            await vi.waitFor(() => {
+                const triggers = getTriggers()
+                expect((triggers[0] as HTMLElement).className).toContain('item-trigger-custom')
+            })
+        })
+    })
+
+    // ==================== ORIENTATION ====================
+
+    describe('orientation', () => {
+        it('should render with horizontal orientation by default', async () => {
+            render(Tabs, { items: sampleItems })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+                expect(root!.getAttribute('data-orientation')).toBe('horizontal')
+            })
+        })
+
+        it('should render with vertical orientation', async () => {
+            render(Tabs, { items: sampleItems, orientation: 'vertical' })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+                expect(root!.getAttribute('data-orientation')).toBe('vertical')
+            })
+        })
+    })
+
+    // ==================== COMBINED FEATURES ====================
+
+    describe('combined features', () => {
+        it('should render with icons and custom values', async () => {
+            const items = [
+                {
+                    label: 'Home',
+                    content: 'Home content',
+                    icon: 'lucide:home',
+                    value: 'home'
+                },
+                {
+                    label: 'Settings',
+                    content: 'Settings content',
+                    icon: 'lucide:settings',
+                    value: 'settings'
+                }
+            ]
+            render(Tabs, { items, value: 'settings' })
+            await expect.element(page.getByText('Settings content')).toBeVisible()
+        })
+
+        it('should render with all ui overrides', async () => {
+            render(Tabs, {
+                items: sampleItems,
+                ui: {
+                    root: 'root-custom',
+                    list: 'list-custom',
+                    trigger: 'trigger-custom',
+                    content: 'content-custom',
+                    label: 'label-custom',
+                    leadingIcon: 'leading-custom',
+                    indicator: 'indicator-custom'
+                }
+            })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+                expect(root!.className).toContain('root-custom')
+
+                const list = getList()
+                expect(list!.className).toContain('list-custom')
+
+                const triggers = getTriggers()
+                expect((triggers[0] as HTMLElement).className).toContain('trigger-custom')
+            })
+        })
+
+        it('should render disabled items alongside active ones', async () => {
+            const items = [
+                { label: 'Tab 1', content: 'Content 1', value: 'tab1' },
+                { label: 'Tab 2', content: 'Content 2', value: 'tab2', disabled: true },
+                { label: 'Tab 3', content: 'Content 3', value: 'tab3' }
+            ]
+            render(Tabs, { items })
+
+            await page.getByText('Tab 3').click()
+            await expect.element(page.getByText('Content 3')).toBeVisible()
+
+            await vi.waitFor(() => {
+                const triggers = getTriggers()
+                expect(triggers[2].getAttribute('data-state')).toBe('active')
+            })
+        })
+
+        it('should render link variant with vertical orientation', async () => {
+            render(Tabs, {
+                items: sampleItems,
+                variant: 'link',
+                orientation: 'vertical'
+            })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root!.className).toContain('flex-row')
+
+                const list = getList()
+                expect(list!.className).toContain('border-e')
+                expect(list!.className).toContain('flex-col')
+            })
+        })
+    })
+})

--- a/src/lib/Tabs/tabs.types.ts
+++ b/src/lib/Tabs/tabs.types.ts
@@ -1,0 +1,268 @@
+import type { Snippet } from 'svelte'
+import type { ClassNameValue } from 'tailwind-merge'
+import type { TabsSlots, TabsVariantProps } from './tabs.variants.js'
+
+// ============================================================================
+// Item Types
+// ============================================================================
+
+/**
+ * Configuration for an individual tab item.
+ *
+ * @example
+ * ```ts
+ * const item: TabsItem = {
+ *   label: 'Account',
+ *   icon: 'lucide:user',
+ *   value: 'account',
+ *   content: 'Manage your account settings here.'
+ * }
+ * ```
+ */
+export interface TabsItem {
+    /**
+     * The visible text displayed in the tab trigger.
+     */
+    label?: string
+
+    /**
+     * Icon displayed before the label (leading position).
+     * Supports any Iconify icon name (e.g., 'lucide:home', 'mdi:account').
+     */
+    icon?: string
+
+    /**
+     * Unique identifier for this tab.
+     * Used to control which tab is active via the `value` prop.
+     * @default String(index) - Falls back to the item's index as a string
+     */
+    value?: string
+
+    /**
+     * Whether this specific tab trigger is disabled.
+     * Disabled tabs cannot be activated by the user.
+     * @default false
+     */
+    disabled?: boolean
+
+    /**
+     * The text content shown in the tab panel when this tab is active.
+     * For complex content, use the `body` snippet instead.
+     */
+    content?: string
+
+    /**
+     * Named slot identifier for custom content rendering.
+     * When provided, allows using dynamic snippet slots for this item.
+     */
+    slot?: string
+
+    /**
+     * Additional CSS classes applied to this item's trigger element.
+     */
+    class?: ClassNameValue
+
+    /**
+     * Override classes for specific slots within this item's trigger.
+     * Allows fine-grained styling control per item.
+     */
+    ui?: Partial<Pick<Record<TabsSlots, ClassNameValue>, 'trigger' | 'leadingIcon' | 'label'>>
+}
+
+// ============================================================================
+// Slot Props Types
+// ============================================================================
+
+/**
+ * Props passed to tabs snippet slots.
+ * Provides context about the current item and its state.
+ */
+export interface TabsSlotProps {
+    /** The current tab item data */
+    item: TabsItem
+    /** Zero-based index of the item in the items array */
+    index: number
+    /** Whether this tab is currently active */
+    active: boolean
+}
+
+// ============================================================================
+// Component Props
+// ============================================================================
+
+/**
+ * Props for the Tabs component.
+ *
+ * Wraps bits-ui's Tabs primitives with enhanced styling,
+ * data-driven rendering, and animated indicator support.
+ *
+ * @example
+ * ```svelte
+ * <Tabs
+ *   items={tabItems}
+ *   bind:value={activeTab}
+ *   variant="pill"
+ *   color="primary"
+ * />
+ * ```
+ *
+ * @see https://bits-ui.com/docs/components/tabs
+ */
+export interface TabsProps {
+    // -------------------------------------------------------------------------
+    // Content
+    // -------------------------------------------------------------------------
+
+    /**
+     * Array of tab items to render.
+     * Each item can have a label, icon, content, and optional styling overrides.
+     */
+    items?: TabsItem[]
+
+    // -------------------------------------------------------------------------
+    // State
+    // -------------------------------------------------------------------------
+
+    /**
+     * The currently active tab value.
+     * Use `bind:value` for two-way binding.
+     * @default First item's value or '0'
+     */
+    value?: string
+
+    /**
+     * The default active tab value when uncontrolled.
+     * Used as the initial value when `value` is not provided.
+     */
+    defaultValue?: string
+
+    /**
+     * Callback fired when the active tab changes.
+     * Receives the new active tab value.
+     */
+    onValueChange?: (value: string) => void
+
+    // -------------------------------------------------------------------------
+    // Styling
+    // -------------------------------------------------------------------------
+
+    /**
+     * Visual style variant for the tabs.
+     * - `'pill'`: Rounded background indicator with shadow
+     * - `'link'`: Thin line indicator (bottom for horizontal, side for vertical)
+     * @default 'pill'
+     */
+    variant?: NonNullable<TabsVariantProps['variant']>
+
+    /**
+     * Color theme for the active tab indicator and text.
+     * @default 'primary'
+     */
+    color?: NonNullable<TabsVariantProps['color']>
+
+    /**
+     * Size variant controlling padding, text size, and icon dimensions.
+     * @default 'md'
+     */
+    size?: NonNullable<TabsVariantProps['size']>
+
+    /**
+     * Layout orientation of the tabs.
+     * - `'horizontal'`: Tabs arranged in a row, content below
+     * - `'vertical'`: Tabs arranged in a column, content to the side
+     * @default 'horizontal'
+     */
+    orientation?: NonNullable<TabsVariantProps['orientation']>
+
+    // -------------------------------------------------------------------------
+    // Behavior
+    // -------------------------------------------------------------------------
+
+    /**
+     * Controls how tabs are activated.
+     * - `'automatic'`: Tab activates on focus (arrow key navigation)
+     * - `'manual'`: Tab activates on explicit click/enter
+     * @default 'automatic'
+     */
+    activationMode?: 'automatic' | 'manual'
+
+    /**
+     * Whether all tabs are disabled.
+     * @default false
+     */
+    disabled?: boolean
+
+    /**
+     * Whether keyboard navigation wraps around at the edges.
+     * @default true
+     */
+    loop?: boolean
+
+    /**
+     * Whether to render content panels for each tab.
+     * Set to `false` when using tabs purely for navigation.
+     * @default true
+     */
+    content?: boolean
+
+    // -------------------------------------------------------------------------
+    // Styling Overrides
+    // -------------------------------------------------------------------------
+
+    /**
+     * Additional CSS classes for the root tabs container.
+     */
+    class?: ClassNameValue
+
+    /**
+     * Override classes for tabs component slots.
+     * Allows customization of root, list, indicator, trigger, content,
+     * leadingIcon, and label elements.
+     *
+     * @example
+     * ```ts
+     * ui={{
+     *   list: 'bg-surface-container-high',
+     *   trigger: 'font-semibold',
+     *   content: 'p-4'
+     * }}
+     * ```
+     */
+    ui?: Partial<Record<TabsSlots, ClassNameValue>>
+
+    // -------------------------------------------------------------------------
+    // Slots (Snippets)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Custom snippet for the leading section of all tab triggers.
+     * Replaces the default leading icon when provided.
+     *
+     * @param props - Contains `{ item, index, active }`
+     */
+    leading?: Snippet<[TabsSlotProps]>
+
+    /**
+     * Custom snippet for the label section of all tab triggers.
+     * Replaces the default `item.label` text when provided.
+     *
+     * @param props - Contains `{ item, index, active }`
+     */
+    label?: Snippet<[TabsSlotProps]>
+
+    /**
+     * Custom snippet for the trailing section of all tab triggers.
+     * Rendered after the label.
+     *
+     * @param props - Contains `{ item, index, active }`
+     */
+    trailing?: Snippet<[TabsSlotProps]>
+
+    /**
+     * Custom snippet for tab content body.
+     * Replaces `item.content` text when provided.
+     *
+     * @param props - Contains `{ item, index, active }`
+     */
+    body?: Snippet<[TabsSlotProps]>
+}

--- a/src/lib/Tabs/tabs.variants.ts
+++ b/src/lib/Tabs/tabs.variants.ts
@@ -1,0 +1,257 @@
+import { tv, type VariantProps } from 'tailwind-variants'
+
+export const tabsVariants = tv({
+    slots: {
+        root: 'flex w-full',
+        list: 'relative inline-flex items-center shrink-0',
+        indicator: 'absolute transition-all duration-200',
+        trigger: [
+            'relative inline-flex items-center justify-center whitespace-nowrap',
+            'font-medium cursor-pointer select-none',
+            'focus-visible:outline-none focus-visible:ring-2',
+            'disabled:cursor-not-allowed disabled:opacity-50',
+            'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
+            'transition-colors'
+        ],
+        leadingIcon: 'shrink-0',
+        label: 'truncate',
+        content: 'focus:outline-none'
+    },
+    variants: {
+        variant: {
+            pill: '',
+            link: ''
+        },
+        color: {
+            primary: '',
+            secondary: '',
+            tertiary: '',
+            success: '',
+            warning: '',
+            error: '',
+            info: '',
+            surface: ''
+        },
+        size: {
+            xs: {
+                trigger: 'px-2 py-1 text-xs gap-1',
+                leadingIcon: 'size-3'
+            },
+            sm: {
+                trigger: 'px-2.5 py-1.5 text-xs gap-1.5',
+                leadingIcon: 'size-3.5'
+            },
+            md: {
+                trigger: 'px-3 py-1.5 text-sm gap-1.5',
+                leadingIcon: 'size-4'
+            },
+            lg: {
+                trigger: 'px-3 py-2 text-sm gap-2',
+                leadingIcon: 'size-5'
+            },
+            xl: {
+                trigger: 'px-3 py-2 text-base gap-2',
+                leadingIcon: 'size-5'
+            }
+        },
+        orientation: {
+            horizontal: {
+                root: 'flex-col',
+                list: 'flex-row',
+                trigger: 'flex-1',
+                content: 'mt-2'
+            },
+            vertical: {
+                root: 'flex-row gap-2',
+                list: 'flex-col',
+                content: 'flex-1 min-w-0'
+            }
+        }
+    },
+    compoundVariants: [
+        // ========== PILL + ORIENTATION ==========
+        {
+            variant: 'pill',
+            orientation: 'horizontal',
+            class: {
+                list: 'bg-surface-container rounded-lg p-1',
+                trigger: 'rounded-md z-[1]',
+                indicator: 'rounded-md shadow-sm inset-y-1'
+            }
+        },
+        {
+            variant: 'pill',
+            orientation: 'vertical',
+            class: {
+                list: 'bg-surface-container rounded-lg p-1',
+                trigger: 'rounded-md z-[1] justify-start',
+                indicator: 'rounded-md shadow-sm inset-x-1'
+            }
+        },
+
+        // ========== LINK + ORIENTATION ==========
+        {
+            variant: 'link',
+            orientation: 'horizontal',
+            class: {
+                list: 'border-b border-outline-variant',
+                indicator: '-bottom-px h-0.5 rounded-full'
+            }
+        },
+        {
+            variant: 'link',
+            orientation: 'vertical',
+            class: {
+                list: 'border-e border-outline-variant',
+                trigger: 'justify-start',
+                indicator: '-end-px w-0.5 rounded-full'
+            }
+        },
+
+        // ========== PILL + COLOR ==========
+        {
+            variant: 'pill',
+            color: 'primary',
+            class: {
+                indicator: 'bg-primary',
+                trigger: 'data-[state=active]:text-on-primary focus-visible:ring-primary'
+            }
+        },
+        {
+            variant: 'pill',
+            color: 'secondary',
+            class: {
+                indicator: 'bg-secondary',
+                trigger: 'data-[state=active]:text-on-secondary focus-visible:ring-secondary'
+            }
+        },
+        {
+            variant: 'pill',
+            color: 'tertiary',
+            class: {
+                indicator: 'bg-tertiary',
+                trigger: 'data-[state=active]:text-on-tertiary focus-visible:ring-tertiary'
+            }
+        },
+        {
+            variant: 'pill',
+            color: 'success',
+            class: {
+                indicator: 'bg-success',
+                trigger: 'data-[state=active]:text-on-success focus-visible:ring-success'
+            }
+        },
+        {
+            variant: 'pill',
+            color: 'warning',
+            class: {
+                indicator: 'bg-warning',
+                trigger: 'data-[state=active]:text-on-warning focus-visible:ring-warning'
+            }
+        },
+        {
+            variant: 'pill',
+            color: 'error',
+            class: {
+                indicator: 'bg-error',
+                trigger: 'data-[state=active]:text-on-error focus-visible:ring-error'
+            }
+        },
+        {
+            variant: 'pill',
+            color: 'info',
+            class: {
+                indicator: 'bg-info',
+                trigger: 'data-[state=active]:text-on-info focus-visible:ring-info'
+            }
+        },
+        {
+            variant: 'pill',
+            color: 'surface',
+            class: {
+                indicator: 'bg-surface-container-lowest shadow-sm',
+                trigger: 'data-[state=active]:text-on-surface focus-visible:ring-outline'
+            }
+        },
+
+        // ========== LINK + COLOR ==========
+        {
+            variant: 'link',
+            color: 'primary',
+            class: {
+                indicator: 'bg-primary',
+                trigger: 'data-[state=active]:text-primary focus-visible:ring-primary'
+            }
+        },
+        {
+            variant: 'link',
+            color: 'secondary',
+            class: {
+                indicator: 'bg-secondary',
+                trigger: 'data-[state=active]:text-secondary focus-visible:ring-secondary'
+            }
+        },
+        {
+            variant: 'link',
+            color: 'tertiary',
+            class: {
+                indicator: 'bg-tertiary',
+                trigger: 'data-[state=active]:text-tertiary focus-visible:ring-tertiary'
+            }
+        },
+        {
+            variant: 'link',
+            color: 'success',
+            class: {
+                indicator: 'bg-success',
+                trigger: 'data-[state=active]:text-success focus-visible:ring-success'
+            }
+        },
+        {
+            variant: 'link',
+            color: 'warning',
+            class: {
+                indicator: 'bg-warning',
+                trigger: 'data-[state=active]:text-warning focus-visible:ring-warning'
+            }
+        },
+        {
+            variant: 'link',
+            color: 'error',
+            class: {
+                indicator: 'bg-error',
+                trigger: 'data-[state=active]:text-error focus-visible:ring-error'
+            }
+        },
+        {
+            variant: 'link',
+            color: 'info',
+            class: {
+                indicator: 'bg-info',
+                trigger: 'data-[state=active]:text-info focus-visible:ring-info'
+            }
+        },
+        {
+            variant: 'link',
+            color: 'surface',
+            class: {
+                indicator: 'bg-on-surface-variant',
+                trigger: 'data-[state=active]:text-on-surface focus-visible:ring-outline'
+            }
+        }
+    ],
+    defaultVariants: {
+        variant: 'pill',
+        color: 'primary',
+        size: 'md',
+        orientation: 'horizontal'
+    }
+})
+
+export type TabsVariantProps = VariantProps<typeof tabsVariants>
+export type TabsSlots = keyof ReturnType<typeof tabsVariants>
+
+export const tabsDefaults = {
+    defaultVariants: tabsVariants.defaultVariants,
+    slots: {} as Partial<Record<TabsSlots, string>>
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -25,6 +25,7 @@ export * from './Popover/index.js'
 export * from './Breadcrumb/index.js'
 export * from './Calendar/index.js'
 export * from './DropdownMenu/index.js'
+export * from './Tabs/index.js'
 
 // Configuration
 export { defineConfig } from './config.js'

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -35,7 +35,8 @@
         { href: '/popover', label: 'Popover', icon: 'lucide:message-circle' },
         { href: '/breadcrumb', label: 'Breadcrumb', icon: 'lucide:chevrons-right' },
         { href: '/calendar', label: 'Calendar', icon: 'lucide:calendar' },
-        { href: '/dropdown-menu', label: 'Dropdown Menu', icon: 'lucide:chevron-down-square' }
+        { href: '/dropdown-menu', label: 'Dropdown Menu', icon: 'lucide:chevron-down-square' },
+        { href: '/tabs', label: 'Tabs', icon: 'lucide:panel-top' }
     ]
 
     const docItems = [

--- a/src/routes/tabs/+page.svelte
+++ b/src/routes/tabs/+page.svelte
@@ -420,10 +420,7 @@
                 <p class="mb-2 text-xs font-medium">
                     <code class="rounded bg-surface-container-highest px-1.5 py-0.5">ui.list</code>
                 </p>
-                <Tabs
-                    items={basicItems}
-                    ui={{ list: 'bg-surface-container-highest rounded-xl' }}
-                />
+                <Tabs items={basicItems} ui={{ list: 'bg-surface-container-highest rounded-xl' }} />
             </div>
 
             <!-- ui.indicator -->
@@ -459,8 +456,7 @@
             <!-- ui.label -->
             <div class="rounded-lg bg-surface-container-high p-4">
                 <p class="mb-2 text-xs font-medium">
-                    <code class="rounded bg-surface-container-highest px-1.5 py-0.5">ui.label</code
-                    >
+                    <code class="rounded bg-surface-container-highest px-1.5 py-0.5">ui.label</code>
                 </p>
                 <Tabs items={basicItems} ui={{ label: 'italic underline' }} />
             </div>

--- a/src/routes/tabs/+page.svelte
+++ b/src/routes/tabs/+page.svelte
@@ -1,0 +1,781 @@
+<script lang="ts">
+    import { Tabs, Badge, Button, Icon, Separator } from '$lib/index.js'
+    import type { TabsItem } from '$lib/index.js'
+
+    // --- Basic items ---
+    const basicItems: TabsItem[] = [
+        {
+            label: 'Account',
+            content: 'Manage your account settings, profile information, and preferences.',
+            value: 'account'
+        },
+        {
+            label: 'Password',
+            content:
+                'Change your password, enable two-factor authentication, and manage security keys.',
+            value: 'password'
+        },
+        {
+            label: 'Notifications',
+            content: 'Configure email, push, and SMS notification preferences.',
+            value: 'notifications'
+        }
+    ]
+
+    // --- Items with icons ---
+    const iconItems: TabsItem[] = [
+        {
+            label: 'Profile',
+            icon: 'lucide:user',
+            content: 'Update your profile picture, display name, and bio.',
+            value: 'profile'
+        },
+        {
+            label: 'Security',
+            icon: 'lucide:shield',
+            content: 'Manage two-factor authentication, sessions, and security logs.',
+            value: 'security'
+        },
+        {
+            label: 'Billing',
+            icon: 'lucide:credit-card',
+            content: 'View invoices, update payment methods, and manage your subscription.',
+            value: 'billing'
+        },
+        {
+            label: 'Integrations',
+            icon: 'lucide:plug',
+            content: 'Connect third-party services and manage API keys.',
+            value: 'integrations'
+        }
+    ]
+
+    // --- Disabled items ---
+    const disabledItems: TabsItem[] = [
+        { label: 'General', content: 'General settings available to all users.', value: 'general' },
+        {
+            label: 'Advanced',
+            content: 'Advanced settings require a premium subscription.',
+            value: 'advanced',
+            disabled: true
+        },
+        { label: 'About', content: 'Application version and license information.', value: 'about' }
+    ]
+
+    // --- Many items ---
+    const manyItems: TabsItem[] = [
+        { label: 'Overview', content: 'Project overview and summary.', value: 'overview' },
+        { label: 'Tasks', content: 'Manage project tasks and assignments.', value: 'tasks' },
+        { label: 'Files', content: 'Browse and manage project files.', value: 'files' },
+        { label: 'Members', content: 'View and manage team members.', value: 'members' },
+        { label: 'Settings', content: 'Configure project settings.', value: 'settings' },
+        { label: 'Activity', content: 'View project activity log.', value: 'activity' }
+    ]
+
+    // --- Colors ---
+    const colors = [
+        'primary',
+        'secondary',
+        'tertiary',
+        'success',
+        'warning',
+        'error',
+        'info',
+        'surface'
+    ] as const
+
+    // --- Controlled value ---
+    let controlledValue = $state<string>('account')
+
+    // --- Callback demo ---
+    let lastChange = $state<string>('')
+</script>
+
+<div class="space-y-8">
+    <div class="space-y-2">
+        <h1 class="text-2xl font-bold">Tabs</h1>
+        <p class="text-on-surface-variant">
+            A set of layered panels of content, where only one panel is visible at a time. Built on
+            top of bits-ui Tabs.
+        </p>
+    </div>
+
+    <!-- ==================== BASIC ==================== -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Basic Usage</h2>
+        <p class="text-sm text-on-surface-variant">
+            Pass an array of items with <code
+                class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">label</code
+            >,
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">value</code>,
+            and
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">content</code>
+            properties.
+        </p>
+        <div class="rounded-lg bg-surface-container-high p-4">
+            <Tabs items={basicItems} />
+        </div>
+    </section>
+
+    <!-- ==================== VARIANTS ==================== -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Variants</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >variant="pill"</code
+            >
+            for a rounded background indicator, or
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >variant="link"</code
+            > for a thin line indicator.
+        </p>
+        <div class="grid gap-4 md:grid-cols-2">
+            <div class="rounded-lg bg-surface-container-high p-4">
+                <p class="mb-3 text-sm font-medium">Pill (default)</p>
+                <Tabs items={basicItems} variant="pill" />
+            </div>
+            <div class="rounded-lg bg-surface-container-high p-4">
+                <p class="mb-3 text-sm font-medium">Link</p>
+                <Tabs items={basicItems} variant="link" />
+            </div>
+        </div>
+    </section>
+
+    <!-- ==================== COLORS ==================== -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Colors</h2>
+        <p class="text-sm text-on-surface-variant">
+            The <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">color</code
+            > prop controls the indicator and active text color.
+        </p>
+
+        <div class="space-y-4">
+            <div>
+                <p class="mb-3 text-sm font-medium">Pill variant</p>
+                <div class="grid gap-4 md:grid-cols-2">
+                    {#each colors as color (color)}
+                        <div class="rounded-lg bg-surface-container-high p-4">
+                            <p class="mb-2 text-xs font-medium capitalize">{color}</p>
+                            <Tabs items={basicItems} {color} variant="pill" content={false} />
+                        </div>
+                    {/each}
+                </div>
+            </div>
+
+            <div>
+                <p class="mb-3 text-sm font-medium">Link variant</p>
+                <div class="grid gap-4 md:grid-cols-2">
+                    {#each colors as color (color)}
+                        <div class="rounded-lg bg-surface-container-high p-4">
+                            <p class="mb-2 text-xs font-medium capitalize">{color}</p>
+                            <Tabs items={basicItems} {color} variant="link" content={false} />
+                        </div>
+                    {/each}
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- ==================== SIZES ==================== -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Sizes</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >size</code
+            > prop to control padding, text size, and icon dimensions.
+        </p>
+        <div class="space-y-4">
+            {#each ['xs', 'sm', 'md', 'lg', 'xl'] as const as size (size)}
+                <div class="rounded-lg bg-surface-container-high p-4">
+                    <p class="mb-2 text-xs font-medium uppercase">{size}</p>
+                    <Tabs items={basicItems} {size} content={false} />
+                </div>
+            {/each}
+        </div>
+    </section>
+
+    <!-- ==================== WITH ICONS ==================== -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">With Icons</h2>
+        <p class="text-sm text-on-surface-variant">
+            Add leading icons via the <code
+                class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">icon</code
+            > property on each item.
+        </p>
+        <div class="grid gap-4 md:grid-cols-2">
+            <div class="rounded-lg bg-surface-container-high p-4">
+                <p class="mb-3 text-sm font-medium">Pill variant</p>
+                <Tabs items={iconItems} />
+            </div>
+            <div class="rounded-lg bg-surface-container-high p-4">
+                <p class="mb-3 text-sm font-medium">Link variant</p>
+                <Tabs items={iconItems} variant="link" />
+            </div>
+        </div>
+    </section>
+
+    <!-- ==================== ORIENTATION ==================== -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Orientation</h2>
+        <p class="text-sm text-on-surface-variant">
+            Set <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >orientation</code
+            > to change the layout direction. Use ←→ for horizontal, ↑↓ for vertical keyboard navigation.
+        </p>
+        <div class="grid gap-4 lg:grid-cols-2">
+            <div class="rounded-lg bg-surface-container-high p-4">
+                <p class="mb-3 text-sm font-medium">Vertical - Pill</p>
+                <Tabs items={iconItems} orientation="vertical" />
+            </div>
+            <div class="rounded-lg bg-surface-container-high p-4">
+                <p class="mb-3 text-sm font-medium">Vertical - Link</p>
+                <Tabs items={iconItems} orientation="vertical" variant="link" />
+            </div>
+        </div>
+    </section>
+
+    <!-- ==================== DISABLED ==================== -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Disabled State</h2>
+        <p class="text-sm text-on-surface-variant">
+            Disable the entire tabs component or individual items.
+        </p>
+        <div class="grid gap-4 md:grid-cols-2">
+            <div class="rounded-lg bg-surface-container-high p-4">
+                <p class="mb-3 text-sm font-medium">Entire tabs disabled</p>
+                <Tabs items={basicItems} disabled />
+            </div>
+            <div class="rounded-lg bg-surface-container-high p-4">
+                <p class="mb-3 text-sm font-medium">Individual tab disabled</p>
+                <Tabs items={disabledItems} />
+            </div>
+        </div>
+    </section>
+
+    <!-- ==================== CONTROLLED ==================== -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Controlled Value</h2>
+        <p class="text-sm text-on-surface-variant">
+            Bind the <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >value</code
+            > prop to control which tab is active.
+        </p>
+        <div class="rounded-lg bg-surface-container-high p-4">
+            <p class="mb-3 text-sm font-medium">
+                Active tab: <Badge variant="soft" color="info" label={controlledValue} />
+            </p>
+            <div class="mb-3 flex gap-2">
+                {#each basicItems as item (item.value)}
+                    <Button
+                        size="xs"
+                        variant={controlledValue === item.value ? 'solid' : 'outline'}
+                        label={item.label}
+                        onclick={() => (controlledValue = item.value ?? '')}
+                    />
+                {/each}
+            </div>
+            <Tabs items={basicItems} bind:value={controlledValue} />
+        </div>
+    </section>
+
+    <!-- ==================== CALLBACK ==================== -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Value Change Callback</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >onValueChange</code
+            > to react to tab changes.
+        </p>
+        <div class="rounded-lg bg-surface-container-high p-4">
+            <p class="mb-3 text-sm">
+                Last change: <Badge
+                    variant="soft"
+                    color={lastChange ? 'success' : 'surface'}
+                    label={lastChange || 'None'}
+                />
+            </p>
+            <Tabs items={basicItems} onValueChange={(v) => (lastChange = `Switched to: ${v}`)} />
+        </div>
+    </section>
+
+    <!-- ==================== NO CONTENT ==================== -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Navigation Only (No Content)</h2>
+        <p class="text-sm text-on-surface-variant">
+            Set <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >content={'{false}'}</code
+            > to render tabs without content panels. Useful for navigation.
+        </p>
+        <div class="rounded-lg bg-surface-container-high p-4">
+            <Tabs items={manyItems} content={false} />
+        </div>
+    </section>
+
+    <Separator />
+
+    <!-- ==================== CUSTOM SLOTS ==================== -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Custom Slots</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use snippets for custom rendering: <code
+                class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">leading</code
+            >,
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">label</code>,
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">trailing</code
+            >,
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">body</code>.
+        </p>
+        <div class="grid gap-4 lg:grid-cols-2">
+            <!-- Leading slot -->
+            <div class="rounded-lg bg-surface-container-high p-4">
+                <p class="mb-3 text-sm font-medium">Custom leading</p>
+                <Tabs items={basicItems} variant="link">
+                    {#snippet leading({ active })}
+                        <div
+                            class="flex size-6 items-center justify-center rounded-full {active
+                                ? 'bg-primary text-on-primary'
+                                : 'bg-surface-container-highest'}"
+                        >
+                            <Icon name={active ? 'lucide:check' : 'lucide:circle'} size="14" />
+                        </div>
+                    {/snippet}
+                </Tabs>
+            </div>
+
+            <!-- Label slot -->
+            <div class="rounded-lg bg-surface-container-high p-4">
+                <p class="mb-3 text-sm font-medium">Custom label</p>
+                <Tabs items={basicItems}>
+                    {#snippet label({ item })}
+                        <span class="flex items-center gap-1.5">
+                            {item.label}
+                            {#if item.value === 'account'}
+                                <Badge size="xs" variant="soft" color="primary" label="New" />
+                            {/if}
+                        </span>
+                    {/snippet}
+                </Tabs>
+            </div>
+
+            <!-- Trailing slot -->
+            <div class="rounded-lg bg-surface-container-high p-4">
+                <p class="mb-3 text-sm font-medium">Custom trailing</p>
+                <Tabs items={basicItems} variant="link">
+                    {#snippet trailing({ item })}
+                        {#if item.value === 'notifications'}
+                            <Badge size="xs" variant="soft" color="error" label="3" />
+                        {/if}
+                    {/snippet}
+                </Tabs>
+            </div>
+
+            <!-- Body slot -->
+            <div class="rounded-lg bg-surface-container-high p-4">
+                <p class="mb-3 text-sm font-medium">Custom body</p>
+                <Tabs items={basicItems}>
+                    {#snippet body({ item })}
+                        <div class="flex items-start gap-3 rounded-lg bg-surface-container p-4">
+                            <Icon
+                                name="lucide:info"
+                                size="18"
+                                class="mt-0.5 shrink-0 text-primary"
+                            />
+                            <div>
+                                <p class="text-sm font-medium">{item.label}</p>
+                                <p class="text-sm text-on-surface-variant">{item.content}</p>
+                            </div>
+                        </div>
+                    {/snippet}
+                </Tabs>
+            </div>
+        </div>
+    </section>
+
+    <Separator />
+
+    <!-- ==================== UI OVERRIDES ==================== -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">UI Prop (Style Overrides)</h2>
+        <p class="text-sm text-on-surface-variant">
+            Override slot styles via the <code
+                class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">ui</code
+            >
+            prop. Available slots: root, list, indicator, trigger, content, label, leadingIcon.
+        </p>
+
+        <div class="grid gap-4 lg:grid-cols-2">
+            <!-- ui.root -->
+            <div class="rounded-lg bg-surface-container-high p-4">
+                <p class="mb-2 text-xs font-medium">
+                    <code class="rounded bg-surface-container-highest px-1.5 py-0.5">ui.root</code>
+                </p>
+                <Tabs
+                    items={basicItems}
+                    ui={{ root: 'border border-outline-variant rounded-xl p-3' }}
+                />
+            </div>
+
+            <!-- ui.list -->
+            <div class="rounded-lg bg-surface-container-high p-4">
+                <p class="mb-2 text-xs font-medium">
+                    <code class="rounded bg-surface-container-highest px-1.5 py-0.5">ui.list</code>
+                </p>
+                <Tabs
+                    items={basicItems}
+                    ui={{ list: 'bg-surface-container-highest rounded-xl' }}
+                />
+            </div>
+
+            <!-- ui.indicator -->
+            <div class="rounded-lg bg-surface-container-high p-4">
+                <p class="mb-2 text-xs font-medium">
+                    <code class="rounded bg-surface-container-highest px-1.5 py-0.5"
+                        >ui.indicator</code
+                    >
+                </p>
+                <Tabs items={basicItems} ui={{ indicator: 'rounded-full' }} />
+            </div>
+
+            <!-- ui.trigger -->
+            <div class="rounded-lg bg-surface-container-high p-4">
+                <p class="mb-2 text-xs font-medium">
+                    <code class="rounded bg-surface-container-highest px-1.5 py-0.5"
+                        >ui.trigger</code
+                    >
+                </p>
+                <Tabs items={basicItems} ui={{ trigger: 'font-bold uppercase tracking-wide' }} />
+            </div>
+
+            <!-- ui.leadingIcon -->
+            <div class="rounded-lg bg-surface-container-high p-4">
+                <p class="mb-2 text-xs font-medium">
+                    <code class="rounded bg-surface-container-highest px-1.5 py-0.5"
+                        >ui.leadingIcon</code
+                    >
+                </p>
+                <Tabs items={iconItems} ui={{ leadingIcon: 'size-6 text-warning' }} />
+            </div>
+
+            <!-- ui.label -->
+            <div class="rounded-lg bg-surface-container-high p-4">
+                <p class="mb-2 text-xs font-medium">
+                    <code class="rounded bg-surface-container-highest px-1.5 py-0.5">ui.label</code
+                    >
+                </p>
+                <Tabs items={basicItems} ui={{ label: 'italic underline' }} />
+            </div>
+
+            <!-- ui.content -->
+            <div class="rounded-lg bg-surface-container-high p-4 lg:col-span-2">
+                <p class="mb-2 text-xs font-medium">
+                    <code class="rounded bg-surface-container-highest px-1.5 py-0.5"
+                        >ui.content</code
+                    >
+                </p>
+                <Tabs
+                    items={basicItems}
+                    ui={{
+                        content:
+                            'mt-3 p-4 bg-surface-container rounded-lg border border-outline-variant'
+                    }}
+                />
+            </div>
+        </div>
+    </section>
+
+    <!-- ==================== PER-ITEM OVERRIDES ==================== -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Per-Item Style Overrides</h2>
+        <p class="text-sm text-on-surface-variant">
+            Each item can have its own <code
+                class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">ui</code
+            >
+            and
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">class</code>
+            overrides.
+        </p>
+        <div class="rounded-lg bg-surface-container-high p-4">
+            <Tabs
+                items={[
+                    { label: 'Normal', content: 'Standard tab styling.', value: 'normal' },
+                    {
+                        label: 'Highlighted',
+                        content: 'This tab has custom styling.',
+                        value: 'highlight',
+                        class: 'font-bold'
+                    },
+                    {
+                        label: 'Custom',
+                        content: 'Another custom styled tab.',
+                        value: 'custom',
+                        ui: { trigger: 'italic' }
+                    }
+                ]}
+                variant="link"
+            />
+        </div>
+    </section>
+
+    <Separator />
+
+    <!-- ==================== REAL WORLD: SETTINGS ==================== -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Real World Example: Settings Page</h2>
+        <div class="rounded-lg bg-surface-container-high p-4">
+            <div class="mb-4">
+                <h3 class="font-semibold text-on-surface">Settings</h3>
+                <p class="text-sm text-on-surface-variant">
+                    Manage your account settings and preferences.
+                </p>
+            </div>
+            <Tabs items={iconItems} variant="link" color="primary">
+                {#snippet body({ item })}
+                    <div class="space-y-4 rounded-lg bg-surface-container p-4">
+                        {#if item.value === 'profile'}
+                            <div class="flex items-center gap-4">
+                                <div
+                                    class="flex size-16 items-center justify-center rounded-full bg-primary/10"
+                                >
+                                    <Icon name="lucide:user" size="32" class="text-primary" />
+                                </div>
+                                <div class="flex-1">
+                                    <h4 class="font-semibold">John Doe</h4>
+                                    <p class="text-sm text-on-surface-variant">
+                                        john.doe@example.com
+                                    </p>
+                                </div>
+                                <Button
+                                    size="sm"
+                                    variant="outline"
+                                    leadingIcon="lucide:pencil"
+                                    label="Edit"
+                                />
+                            </div>
+                        {:else if item.value === 'security'}
+                            <div class="space-y-3">
+                                <div
+                                    class="flex items-center justify-between rounded-lg bg-surface-container-highest p-3"
+                                >
+                                    <div class="flex items-center gap-3">
+                                        <Icon
+                                            name="lucide:shield-check"
+                                            size="20"
+                                            class="text-success"
+                                        />
+                                        <div>
+                                            <p class="text-sm font-medium">
+                                                Two-Factor Authentication
+                                            </p>
+                                            <p class="text-xs text-on-surface-variant">
+                                                Add an extra layer of security
+                                            </p>
+                                        </div>
+                                    </div>
+                                    <Badge
+                                        variant="soft"
+                                        color="success"
+                                        size="xs"
+                                        label="Enabled"
+                                    />
+                                </div>
+                                <div
+                                    class="flex items-center justify-between rounded-lg bg-surface-container-highest p-3"
+                                >
+                                    <div class="flex items-center gap-3">
+                                        <Icon name="lucide:key" size="20" class="text-warning" />
+                                        <div>
+                                            <p class="text-sm font-medium">Password</p>
+                                            <p class="text-xs text-on-surface-variant">
+                                                Last changed 30 days ago
+                                            </p>
+                                        </div>
+                                    </div>
+                                    <Button size="xs" variant="outline" label="Change" />
+                                </div>
+                            </div>
+                        {:else if item.value === 'billing'}
+                            <div class="grid grid-cols-3 gap-3">
+                                <div
+                                    class="rounded-lg bg-surface-container-highest p-3 text-center"
+                                >
+                                    <p class="text-2xl font-bold text-primary">Pro</p>
+                                    <p class="text-xs text-on-surface-variant">Current Plan</p>
+                                </div>
+                                <div
+                                    class="rounded-lg bg-surface-container-highest p-3 text-center"
+                                >
+                                    <p class="text-2xl font-bold text-success">$29</p>
+                                    <p class="text-xs text-on-surface-variant">Monthly</p>
+                                </div>
+                                <div
+                                    class="rounded-lg bg-surface-container-highest p-3 text-center"
+                                >
+                                    <p class="text-2xl font-bold text-on-surface">Mar 15</p>
+                                    <p class="text-xs text-on-surface-variant">Next Billing</p>
+                                </div>
+                            </div>
+                        {:else}
+                            <div class="space-y-2">
+                                <div
+                                    class="flex items-center justify-between rounded-lg bg-surface-container-highest p-3"
+                                >
+                                    <div class="flex items-center gap-3">
+                                        <Icon name="lucide:github" size="20" />
+                                        <span class="text-sm font-medium">GitHub</span>
+                                    </div>
+                                    <Badge
+                                        variant="soft"
+                                        color="success"
+                                        size="xs"
+                                        label="Connected"
+                                    />
+                                </div>
+                                <div
+                                    class="flex items-center justify-between rounded-lg bg-surface-container-highest p-3"
+                                >
+                                    <div class="flex items-center gap-3">
+                                        <Icon name="lucide:slack" size="20" />
+                                        <span class="text-sm font-medium">Slack</span>
+                                    </div>
+                                    <Button size="xs" variant="outline" label="Connect" />
+                                </div>
+                            </div>
+                        {/if}
+                    </div>
+                {/snippet}
+            </Tabs>
+        </div>
+    </section>
+
+    <!-- ==================== REAL WORLD: DASHBOARD ==================== -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Real World Example: Dashboard Tabs</h2>
+        <div class="rounded-lg bg-surface-container-high p-4">
+            <Tabs
+                items={[
+                    { label: 'Overview', icon: 'lucide:layout-dashboard', value: 'overview' },
+                    { label: 'Analytics', icon: 'lucide:bar-chart-3', value: 'analytics' },
+                    { label: 'Reports', icon: 'lucide:file-text', value: 'reports' }
+                ]}
+                variant="pill"
+                color="primary"
+            >
+                {#snippet body({ item })}
+                    {#if item.value === 'overview'}
+                        <div class="grid gap-3 sm:grid-cols-3">
+                            <div class="rounded-lg bg-surface-container p-4">
+                                <div class="flex items-center gap-2">
+                                    <Icon name="lucide:users" size="18" class="text-primary" />
+                                    <span class="text-sm text-on-surface-variant">Users</span>
+                                </div>
+                                <p class="mt-2 text-2xl font-bold">12,345</p>
+                                <p class="text-xs text-success">+12.5% from last month</p>
+                            </div>
+                            <div class="rounded-lg bg-surface-container p-4">
+                                <div class="flex items-center gap-2">
+                                    <Icon
+                                        name="lucide:dollar-sign"
+                                        size="18"
+                                        class="text-success"
+                                    />
+                                    <span class="text-sm text-on-surface-variant">Revenue</span>
+                                </div>
+                                <p class="mt-2 text-2xl font-bold">$48,290</p>
+                                <p class="text-xs text-success">+8.2% from last month</p>
+                            </div>
+                            <div class="rounded-lg bg-surface-container p-4">
+                                <div class="flex items-center gap-2">
+                                    <Icon
+                                        name="lucide:shopping-cart"
+                                        size="18"
+                                        class="text-warning"
+                                    />
+                                    <span class="text-sm text-on-surface-variant">Orders</span>
+                                </div>
+                                <p class="mt-2 text-2xl font-bold">1,890</p>
+                                <p class="text-xs text-error">-3.1% from last month</p>
+                            </div>
+                        </div>
+                    {:else if item.value === 'analytics'}
+                        <div
+                            class="flex flex-col items-center justify-center rounded-lg bg-surface-container p-8"
+                        >
+                            <Icon
+                                name="lucide:bar-chart-3"
+                                size="48"
+                                class="text-on-surface-variant/30"
+                            />
+                            <p class="mt-3 text-sm text-on-surface-variant">
+                                Analytics charts would be rendered here
+                            </p>
+                        </div>
+                    {:else}
+                        <div class="space-y-2">
+                            {#each ['Monthly Revenue Report', 'User Growth Report', 'Conversion Funnel Report'] as report (report)}
+                                <div
+                                    class="flex items-center justify-between rounded-lg bg-surface-container p-3"
+                                >
+                                    <div class="flex items-center gap-3">
+                                        <Icon
+                                            name="lucide:file-text"
+                                            size="18"
+                                            class="text-on-surface-variant"
+                                        />
+                                        <span class="text-sm">{report}</span>
+                                    </div>
+                                    <Button
+                                        size="xs"
+                                        variant="ghost"
+                                        leadingIcon="lucide:download"
+                                        label="Download"
+                                    />
+                                </div>
+                            {/each}
+                        </div>
+                    {/if}
+                {/snippet}
+            </Tabs>
+        </div>
+    </section>
+
+    <!-- ==================== REAL WORLD: VERTICAL SIDEBAR ==================== -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Real World Example: Vertical Settings</h2>
+        <div class="rounded-lg bg-surface-container-high p-4">
+            <Tabs
+                items={[
+                    {
+                        label: 'General',
+                        icon: 'lucide:settings',
+                        value: 'general',
+                        content:
+                            'Configure general application settings like language, timezone, and display preferences.'
+                    },
+                    {
+                        label: 'Appearance',
+                        icon: 'lucide:palette',
+                        value: 'appearance',
+                        content:
+                            'Customize the look and feel of the application including themes, fonts, and layout.'
+                    },
+                    {
+                        label: 'Privacy',
+                        icon: 'lucide:lock',
+                        value: 'privacy',
+                        content:
+                            'Control your privacy settings, data sharing preferences, and cookie consent.'
+                    },
+                    {
+                        label: 'Notifications',
+                        icon: 'lucide:bell',
+                        value: 'notifications',
+                        content: 'Manage email, push, and in-app notification preferences.'
+                    }
+                ]}
+                orientation="vertical"
+                variant="pill"
+                color="primary"
+            />
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
## Summary

Add a new `Tabs` component wrapping bits-ui Tabs primitives with animated sliding indicator, variant-based styling via `tailwind-variants`, and full customization support through `ui` slot overrides.

## Features

### Variants & Theming
- **2 variants**: `pill` (rounded background indicator with shadow) and `link` (thin underline/side-line indicator)
- **8 colors**: primary, secondary, tertiary, success, warning, error, info, surface
- **5 sizes**: xs, sm, md, lg, xl — controls padding, font size, icon dimensions
- **2 orientations**: horizontal (row layout, bottom indicator) and vertical (column layout, side indicator)

### Animated Indicator
- Absolutely positioned indicator that smoothly slides between active triggers using CSS `transition-all`
- Position calculated from active trigger's `offsetLeft`/`offsetTop` and `offsetWidth`/`offsetHeight`
- Responds to resize via `ResizeObserver` (rAF-debounced to prevent excessive DOM queries)
- Link variant indicator positioned at `-bottom-px` / `-end-px` to properly cover the border line

### Props
| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `items` | `TabsItem[]` | `[]` | Array of tab items (label, icon, value, content, disabled) |
| `value` | `string` | First item | Active tab value (`bind:value` for two-way binding) |
| `defaultValue` | `string` | — | Initial value for uncontrolled mode |
| `onValueChange` | `(value: string) => void` | — | Callback on tab change |
| `variant` | `'pill' \| 'link'` | `'pill'` | Visual style variant |
| `color` | 8 options | `'primary'` | Indicator and active text color |
| `size` | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Size variant |
| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Layout direction |
| `activationMode` | `'automatic' \| 'manual'` | `'automatic'` | Keyboard activation behavior |
| `disabled` | `boolean` | `false` | Disable all tabs |
| `loop` | `boolean` | `true` | Wrap keyboard navigation |
| `content` | `boolean` | `true` | Render content panels (false for navigation-only) |
| `class` | `ClassNameValue` | — | Root container classes |
| `ui` | `Partial<Record<TabsSlots, ClassNameValue>>` | — | Per-slot style overrides (root, list, indicator, trigger, leadingIcon, label, content) |

### Snippet Slots
- `leading` — Custom leading section (replaces default icon)
- `label` — Custom label rendering
- `trailing` — Custom trailing section (e.g., badges, counts)
- `body` — Custom content panel rendering

All slots receive `{ item, index, active }` context.

### Per-Item Customization
Each `TabsItem` supports `class` and `ui` overrides (`trigger`, `leadingIcon`, `label`) for fine-grained per-tab styling.

## Performance Optimizations
- **Single indicator update per value change** — removed duplicate `tick().then(updateIndicator)` from `handleValueChange`; `$effect` handles it
- **rAF-debounced ResizeObserver** — collapses rapid resize events into 1 DOM query per frame
- **Short-circuit per-item class computation** — `getTriggerClass`/`getIconClass`/`getLabelClass` return pre-computed `classes.*` when item has no overrides, skipping `variantSlots.*()` calls
- **Proper cleanup** — `cancelAnimationFrame` + `observer.disconnect` on unmount

## Files Changed (8 files, +1978 lines)
- `src/lib/Tabs/Tabs.svelte` — Component implementation
- `src/lib/Tabs/tabs.types.ts` — TypeScript interfaces (TabsItem, TabsSlotProps, TabsProps)
- `src/lib/Tabs/tabs.variants.ts` — tailwind-variants definitions with 16 compound variants
- `src/lib/Tabs/index.ts` — Public exports
- `src/lib/Tabs/tabs.svelte.spec.ts` — 38 tests (rendering, switching, disabled, callbacks, icons, content, variants, sizes, ui overrides, orientation, combined)
- `src/lib/index.ts` — Added Tabs export
- `src/routes/+layout.svelte` — Added Tabs to sidebar navigation
- `src/routes/tabs/+page.svelte` — Comprehensive demo page (basic, variants, colors, sizes, icons, orientation, disabled, controlled, callback, no-content, custom slots, per-slot ui overrides, per-item overrides, real-world examples)

## Test Plan
- [x] 38 unit tests passing (vitest + vitest-browser-svelte)
- [x] `svelte-check` — 0 errors
- [ ] Visual review: pill/link variants, all 8 colors, 5 sizes, horizontal/vertical
- [ ] Verify indicator animation on tab switch and window resize
- [ ] Verify keyboard navigation (arrow keys, loop, activationMode)
- [ ] Verify disabled state (global + per-item)