### PR TITLE
feat: add ContextMenu component with animated indicator, variants, and demo page

### DIFF
--- a/src/lib/ContextMenu/ContextMenu.svelte
+++ b/src/lib/ContextMenu/ContextMenu.svelte
@@ -86,7 +86,6 @@
     // for every action item with the same color in a single render cycle
     type ColorKey = NonNullable<ContextMenuVariantProps['color']>
 
-    // eslint-disable-next-line svelte/require-svelte-collections -- intentionally non-reactive cache
     const getColorVariant = $derived.by(() => {
         const cache: Partial<Record<ColorKey, ReturnType<typeof contextMenuVariants>>> = {}
         return (color: ColorKey) => {

--- a/src/lib/ContextMenu/ContextMenu.svelte
+++ b/src/lib/ContextMenu/ContextMenu.svelte
@@ -1,0 +1,335 @@
+<script lang="ts" module>
+    import type {
+        ContextMenuProps,
+        ContextMenuItem,
+        ContextMenuItemAction
+    } from './context-menu.types.js'
+
+    export type Props = ContextMenuProps
+</script>
+
+<script lang="ts">
+    import { ContextMenu } from 'bits-ui'
+    import {
+        contextMenuVariants,
+        contextMenuDefaults,
+        type ContextMenuVariantProps
+    } from './context-menu.variants.js'
+    import { getComponentConfig, iconsDefaults } from '../config.js'
+    import Icon from '../Icon/Icon.svelte'
+    import Kbd from '../Kbd/Kbd.svelte'
+
+    const config = getComponentConfig('contextMenu', contextMenuDefaults)
+
+    let {
+        open = $bindable(false),
+        onOpenChange,
+        items = [],
+        radioGroups = [],
+        checkedIcon = iconsDefaults.check,
+        submenuIcon = iconsDefaults.chevronRight,
+        sideOffset = 4,
+        alignOffset = 0,
+        avoidCollisions = true,
+        collisionBoundary,
+        collisionPadding = 8,
+        hideWhenDetached = false,
+        onEscapeKeydown,
+        onInteractOutside,
+        onCloseAutoFocus,
+        forceMount,
+        loop = true,
+        transition = config.defaultVariants.transition ?? true,
+        portal = true,
+        size = config.defaultVariants.size ?? 'md',
+        ui,
+        class: className,
+        children,
+        header,
+        footer,
+        item: itemSlot,
+        itemLeading,
+        itemLabel,
+        itemTrailing,
+        content: contentSlot
+    }: Props = $props()
+
+    const hasRadioItems = $derived(items.some((i) => i.type === 'radio'))
+    const firstRadioGroup = $derived(radioGroups[0])
+
+    // Compute variant classes once per transition/size/ui change
+    const variantSlots = $derived(contextMenuVariants({ transition, size }))
+
+    function resolveSlot(slot: keyof ReturnType<typeof contextMenuVariants>) {
+        return variantSlots[slot]({
+            class: [config.slots[slot], ui?.[slot]]
+        })
+    }
+
+    const classes = $derived({
+        content: resolveSlot('content'),
+        group: resolveSlot('group'),
+        separator: resolveSlot('separator'),
+        label: resolveSlot('label'),
+        item: resolveSlot('item'),
+        itemIcon: resolveSlot('itemIcon'),
+        itemLabel: resolveSlot('itemLabel'),
+        itemKbd: resolveSlot('itemKbd'),
+        subTrigger: resolveSlot('subTrigger'),
+        subTriggerIcon: resolveSlot('subTriggerIcon'),
+        subContent: resolveSlot('subContent'),
+        checkboxIndicator: resolveSlot('checkboxIndicator'),
+        radioIndicator: resolveSlot('radioIndicator')
+    })
+
+    // Cache color variant computations per color — avoids re-calling contextMenuVariants
+    // for every action item with the same color in a single render cycle
+    type ColorKey = NonNullable<ContextMenuVariantProps['color']>
+
+    // eslint-disable-next-line svelte/require-svelte-collections -- intentionally non-reactive cache
+    const getColorVariant = $derived.by(() => {
+        const cache: Partial<Record<ColorKey, ReturnType<typeof contextMenuVariants>>> = {}
+        return (color: ColorKey) => {
+            cache[color] ??= contextMenuVariants({ size, color })
+            return cache[color]
+        }
+    })
+
+    function close() {
+        open = false
+    }
+
+    function handleOpenChange(value: boolean) {
+        open = value
+        onOpenChange?.(value)
+    }
+
+    function getItemClasses(item: ContextMenuItemAction) {
+        const colorVariant = getColorVariant(item.color ?? 'default')
+        return {
+            item: colorVariant.item({ class: [config.slots.item, ui?.item, item.class] }),
+            itemIcon: colorVariant.itemIcon({ class: [config.slots.itemIcon, ui?.itemIcon] })
+        }
+    }
+
+    // Collision props shared between Content and SubContent
+    const collisionProps = $derived({
+        sideOffset,
+        alignOffset,
+        avoidCollisions,
+        collisionBoundary,
+        collisionPadding
+    })
+</script>
+
+{#snippet renderKbds(kbds: ContextMenuItemAction['kbds'])}
+    {#if kbds?.length}
+        <span class={classes.itemKbd}>
+            {#each kbds as kbd, i (i)}
+                {#if typeof kbd === 'string'}
+                    <Kbd value={kbd} size="sm" variant="subtle" />
+                {:else}
+                    <Kbd {...kbd} size={kbd.size ?? 'sm'} variant={kbd.variant ?? 'subtle'} />
+                {/if}
+            {/each}
+        </span>
+    {/if}
+{/snippet}
+
+{#snippet renderItem(item: ContextMenuItem, index: number)}
+    {#if item.type === 'separator'}
+        <ContextMenu.Separator class={classes.separator} />
+    {:else if item.type === 'label'}
+        <ContextMenu.GroupHeading class={classes.label}>{item.label}</ContextMenu.GroupHeading>
+    {:else if !item.type || item.type === 'item'}
+        {@const cls = getItemClasses(item as ContextMenuItemAction)}
+        <ContextMenu.Item
+            disabled={item.disabled}
+            closeOnSelect={(item as ContextMenuItemAction).closeOnSelect}
+            onSelect={(item as ContextMenuItemAction).onSelect}
+            class={cls.item}
+        >
+            {#if itemLeading}
+                {@render itemLeading({ item, index })}
+            {:else if item.icon}
+                <Icon name={item.icon} class={cls.itemIcon} />
+            {/if}
+
+            {#if itemLabel}
+                {@render itemLabel({ item, index })}
+            {:else if item.label}
+                <span class={classes.itemLabel}>{item.label}</span>
+            {/if}
+
+            {#if itemTrailing}
+                {@render itemTrailing({ item, index })}
+            {:else}
+                {@render renderKbds((item as ContextMenuItemAction).kbds)}
+            {/if}
+        </ContextMenu.Item>
+    {:else if item.type === 'checkbox'}
+        <ContextMenu.CheckboxItem
+            checked={item.checked}
+            disabled={item.disabled}
+            closeOnSelect={item.closeOnSelect}
+            onCheckedChange={item.onCheckedChange}
+            class={[classes.item, item.class]}
+        >
+            {#if itemLeading}
+                {@render itemLeading({ item, index })}
+            {:else}
+                <span class={classes.checkboxIndicator}>
+                    {#if item.checked}
+                        <Icon name={checkedIcon} class={classes.checkboxIndicator} />
+                    {/if}
+                </span>
+            {/if}
+
+            {#if itemLabel}
+                {@render itemLabel({ item, index })}
+            {:else if item.label}
+                <span class={classes.itemLabel}>{item.label}</span>
+            {/if}
+
+            {#if itemTrailing}
+                {@render itemTrailing({ item, index })}
+            {:else}
+                {@render renderKbds(item.kbds)}
+            {/if}
+        </ContextMenu.CheckboxItem>
+    {:else if item.type === 'radio'}
+        <ContextMenu.RadioItem
+            value={item.value}
+            disabled={item.disabled}
+            closeOnSelect={item.closeOnSelect}
+            class={[classes.item, item.class]}
+        >
+            {#if itemLeading}
+                {@render itemLeading({ item, index })}
+            {:else}
+                <span class={classes.radioIndicator}>
+                    {#if firstRadioGroup?.value === item.value}
+                        <Icon name={checkedIcon} class={classes.radioIndicator} />
+                    {/if}
+                </span>
+            {/if}
+
+            {#if itemLabel}
+                {@render itemLabel({ item, index })}
+            {:else if item.label}
+                <span class={classes.itemLabel}>{item.label}</span>
+            {/if}
+
+            {#if itemTrailing}
+                {@render itemTrailing({ item, index })}
+            {:else}
+                {@render renderKbds(item.kbds)}
+            {/if}
+        </ContextMenu.RadioItem>
+    {:else if item.type === 'sub'}
+        <ContextMenu.Sub open={item.open} onOpenChange={item.onOpenChange}>
+            <ContextMenu.SubTrigger
+                disabled={item.disabled}
+                class={[classes.subTrigger, item.class]}
+            >
+                {#if itemLeading}
+                    {@render itemLeading({ item, index })}
+                {:else if item.icon}
+                    <Icon name={item.icon} class={classes.itemIcon} />
+                {/if}
+
+                {#if itemLabel}
+                    {@render itemLabel({ item, index })}
+                {:else if item.label}
+                    <span class={classes.itemLabel}>{item.label}</span>
+                {/if}
+
+                <Icon name={submenuIcon} class={classes.subTriggerIcon} />
+            </ContextMenu.SubTrigger>
+
+            <ContextMenu.SubContent {...collisionProps} class={classes.subContent}>
+                <div class={classes.group}>
+                    {#each item.items as subItem, subIndex (subIndex)}
+                        {@render renderItem(subItem, subIndex)}
+                    {/each}
+                </div>
+            </ContextMenu.SubContent>
+        </ContextMenu.Sub>
+    {/if}
+{/snippet}
+
+{#snippet renderItems(menuItems: ContextMenuItem[])}
+    {#if hasRadioItems && firstRadioGroup}
+        <ContextMenu.RadioGroup
+            value={firstRadioGroup.value}
+            onValueChange={firstRadioGroup.onValueChange}
+        >
+            {#each menuItems as item, index (index)}
+                {@render renderItem(item, index)}
+            {/each}
+        </ContextMenu.RadioGroup>
+    {:else}
+        {#each menuItems as item, index (index)}
+            {@render renderItem(item, index)}
+        {/each}
+    {/if}
+{/snippet}
+
+{#snippet contextMenuContentEl()}
+    <ContextMenu.Content
+        {...collisionProps}
+        {hideWhenDetached}
+        {onEscapeKeydown}
+        {onInteractOutside}
+        {onCloseAutoFocus}
+        {forceMount}
+        {loop}
+        class={classes.content}
+    >
+        {#if contentSlot}
+            {@render contentSlot({ open, close })}
+        {:else}
+            {#if header}
+                {@render header({ close })}
+            {/if}
+
+            <ContextMenu.Group class={classes.group}>
+                {#if itemSlot}
+                    {#each items as item, index (index)}
+                        {#if item.type === 'separator'}
+                            <ContextMenu.Separator class={classes.separator} />
+                        {:else if item.type === 'label'}
+                            <ContextMenu.GroupHeading class={classes.label}
+                                >{item.label}</ContextMenu.GroupHeading
+                            >
+                        {:else}
+                            {@render itemSlot({ item, index })}
+                        {/if}
+                    {/each}
+                {:else}
+                    {@render renderItems(items)}
+                {/if}
+            </ContextMenu.Group>
+
+            {#if footer}
+                {@render footer({ close })}
+            {/if}
+        {/if}
+    </ContextMenu.Content>
+{/snippet}
+
+<ContextMenu.Root bind:open onOpenChange={handleOpenChange}>
+    {#if children}
+        <ContextMenu.Trigger class={className as string}>
+            {@render children({ open })}
+        </ContextMenu.Trigger>
+    {/if}
+
+    {#if portal}
+        <ContextMenu.Portal>
+            {@render contextMenuContentEl()}
+        </ContextMenu.Portal>
+    {:else}
+        {@render contextMenuContentEl()}
+    {/if}
+</ContextMenu.Root>

--- a/src/lib/ContextMenu/ContextMenu.svelte.spec.ts
+++ b/src/lib/ContextMenu/ContextMenu.svelte.spec.ts
@@ -1,0 +1,621 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-svelte'
+import { page } from 'vitest/browser'
+import ContextMenu from './ContextMenu.svelte'
+import type { ContextMenuItem, ContextMenuRadioGroup } from './context-menu.types.js'
+
+describe('ContextMenu', () => {
+    const basicItems: ContextMenuItem[] = [
+        { label: 'Item 1', icon: 'lucide:file' },
+        { label: 'Item 2', icon: 'lucide:folder' },
+        { label: 'Item 3' }
+    ]
+
+    const getContent = () =>
+        document.querySelector('[data-context-menu-content]') as HTMLElement | null
+    const getItems = () => document.querySelectorAll('[data-context-menu-item]')
+    const getSeparators = () => document.querySelectorAll('[data-context-menu-separator]')
+    const getGroupHeadings = () => document.querySelectorAll('[data-context-menu-group-heading]')
+    const getCheckboxItems = () => document.querySelectorAll('[data-context-menu-checkbox-item]')
+    const getRadioItems = () => document.querySelectorAll('[data-context-menu-radio-item]')
+    const getSubTriggers = () => document.querySelectorAll('[data-context-menu-sub-trigger]')
+
+    // ==================== RENDERING ====================
+
+    describe('rendering', () => {
+        it('should render without crashing', () => {
+            const { container } = render(ContextMenu)
+            expect(container).not.toBeNull()
+        })
+
+        it('should not render content when closed', () => {
+            render(ContextMenu, { items: basicItems })
+            expect(getContent()).toBeNull()
+        })
+
+        it('should render content when open', async () => {
+            render(ContextMenu, { open: true, items: basicItems })
+            await vi.waitFor(() => {
+                expect(getContent()).not.toBeNull()
+            })
+        })
+
+        it('should render all items', async () => {
+            render(ContextMenu, { open: true, items: basicItems })
+            await vi.waitFor(() => {
+                expect(getItems().length).toBe(3)
+            })
+        })
+
+        it('should render item labels', async () => {
+            render(ContextMenu, { open: true, items: basicItems })
+            await expect.element(page.getByText('Item 1')).toBeVisible()
+            await expect.element(page.getByText('Item 2')).toBeVisible()
+            await expect.element(page.getByText('Item 3')).toBeVisible()
+        })
+
+        it('should render item icons', async () => {
+            render(ContextMenu, { open: true, items: basicItems })
+            await vi.waitFor(() => {
+                const items = getItems()
+                const firstItem = items[0] as HTMLElement
+                const icon = firstItem.querySelector('svg')
+                expect(icon).not.toBeNull()
+            })
+        })
+    })
+
+    // ==================== SIZES ====================
+
+    describe('sizes', () => {
+        it('should apply md size by default', async () => {
+            render(ContextMenu, { open: true, items: basicItems })
+            await vi.waitFor(() => {
+                const items = getItems()
+                const item = items[0] as HTMLElement
+                expect(item.className).toContain('py-1.5')
+            })
+        })
+
+        it('should apply xs size', async () => {
+            render(ContextMenu, { open: true, items: basicItems, size: 'xs' })
+            await vi.waitFor(() => {
+                const items = getItems()
+                const item = items[0] as HTMLElement
+                expect(item.className).toContain('text-xs')
+            })
+        })
+
+        it('should apply sm size', async () => {
+            render(ContextMenu, { open: true, items: basicItems, size: 'sm' })
+            await vi.waitFor(() => {
+                const items = getItems()
+                const item = items[0] as HTMLElement
+                expect(item.className).toContain('py-1')
+            })
+        })
+
+        it('should apply lg size', async () => {
+            render(ContextMenu, { open: true, items: basicItems, size: 'lg' })
+            await vi.waitFor(() => {
+                const items = getItems()
+                const item = items[0] as HTMLElement
+                expect(item.className).toContain('py-2')
+            })
+        })
+
+        it('should apply xl size', async () => {
+            render(ContextMenu, { open: true, items: basicItems, size: 'xl' })
+            await vi.waitFor(() => {
+                const items = getItems()
+                const item = items[0] as HTMLElement
+                expect(item.className).toContain('py-2.5')
+            })
+        })
+    })
+
+    // ==================== ITEM TYPES ====================
+
+    describe('item types', () => {
+        describe('separator', () => {
+            it('should render separator items', async () => {
+                const items: ContextMenuItem[] = [
+                    { label: 'Item 1' },
+                    { type: 'separator' },
+                    { label: 'Item 2' }
+                ]
+                render(ContextMenu, { open: true, items })
+                await vi.waitFor(() => {
+                    expect(getSeparators().length).toBe(1)
+                })
+            })
+        })
+
+        describe('label', () => {
+            it('should render label items as group headings', async () => {
+                const items: ContextMenuItem[] = [
+                    { type: 'label', label: 'Group Label' },
+                    { label: 'Item 1' }
+                ]
+                render(ContextMenu, { open: true, items })
+                await expect.element(page.getByText('Group Label')).toBeVisible()
+            })
+        })
+
+        describe('checkbox', () => {
+            it('should render checkbox items', async () => {
+                const items: ContextMenuItem[] = [
+                    { type: 'checkbox', label: 'Checkbox 1', checked: false },
+                    { type: 'checkbox', label: 'Checkbox 2', checked: true }
+                ]
+                render(ContextMenu, { open: true, items })
+                await vi.waitFor(() => {
+                    expect(getCheckboxItems().length).toBe(2)
+                })
+            })
+
+            it('should show check icon when checked', async () => {
+                const items: ContextMenuItem[] = [
+                    { type: 'checkbox', label: 'Checked Item', checked: true }
+                ]
+                render(ContextMenu, { open: true, items })
+                await vi.waitFor(() => {
+                    const checkboxItem = getCheckboxItems()[0] as HTMLElement
+                    const icon = checkboxItem.querySelector('svg')
+                    expect(icon).not.toBeNull()
+                })
+            })
+
+            it('should accept onCheckedChange callback prop', async () => {
+                const onCheckedChange = vi.fn()
+                const items: ContextMenuItem[] = [
+                    {
+                        type: 'checkbox',
+                        label: 'Checkbox',
+                        checked: false,
+                        closeOnSelect: false,
+                        onCheckedChange
+                    }
+                ]
+                render(ContextMenu, { open: true, items })
+                await vi.waitFor(() => {
+                    expect(getCheckboxItems().length).toBe(1)
+                })
+                expect(onCheckedChange).toBeTypeOf('function')
+            })
+        })
+
+        describe('radio', () => {
+            it('should render radio items', async () => {
+                const items: ContextMenuItem[] = [
+                    { type: 'radio', label: 'Option 1', value: 'opt1' },
+                    { type: 'radio', label: 'Option 2', value: 'opt2' }
+                ]
+                const radioGroups: ContextMenuRadioGroup[] = [{ name: 'options', value: 'opt1' }]
+                render(ContextMenu, { open: true, items, radioGroups })
+                await vi.waitFor(() => {
+                    expect(getRadioItems().length).toBe(2)
+                })
+            })
+
+            it('should show check icon for selected radio item', async () => {
+                const items: ContextMenuItem[] = [
+                    { type: 'radio', label: 'Option 1', value: 'opt1' },
+                    { type: 'radio', label: 'Option 2', value: 'opt2' }
+                ]
+                const radioGroups: ContextMenuRadioGroup[] = [{ name: 'options', value: 'opt1' }]
+                render(ContextMenu, { open: true, items, radioGroups })
+                await vi.waitFor(() => {
+                    const radioItems = getRadioItems()
+                    const selectedItem = radioItems[0] as HTMLElement
+                    const icon = selectedItem.querySelector('svg')
+                    expect(icon).not.toBeNull()
+                })
+            })
+
+            it('should accept onValueChange callback in radioGroups', async () => {
+                const onValueChange = vi.fn()
+                const items: ContextMenuItem[] = [
+                    { type: 'radio', label: 'Option 1', value: 'opt1', closeOnSelect: false },
+                    { type: 'radio', label: 'Option 2', value: 'opt2', closeOnSelect: false }
+                ]
+                const radioGroups: ContextMenuRadioGroup[] = [
+                    { name: 'options', value: 'opt1', onValueChange }
+                ]
+                render(ContextMenu, { open: true, items, radioGroups })
+                await vi.waitFor(() => {
+                    expect(getRadioItems().length).toBe(2)
+                })
+                expect(onValueChange).toBeTypeOf('function')
+            })
+        })
+
+        describe('submenu', () => {
+            it('should render submenu trigger', async () => {
+                const items: ContextMenuItem[] = [
+                    {
+                        type: 'sub',
+                        label: 'More Options',
+                        items: [{ label: 'Sub Item 1' }, { label: 'Sub Item 2' }]
+                    }
+                ]
+                render(ContextMenu, { open: true, items })
+                await vi.waitFor(() => {
+                    expect(getSubTriggers().length).toBe(1)
+                })
+                await expect.element(page.getByText('More Options')).toBeVisible()
+            })
+
+            it('should render submenu icon', async () => {
+                const items: ContextMenuItem[] = [
+                    {
+                        type: 'sub',
+                        label: 'More Options',
+                        icon: 'lucide:settings',
+                        items: [{ label: 'Sub Item 1' }]
+                    }
+                ]
+                render(ContextMenu, { open: true, items })
+                await vi.waitFor(() => {
+                    const subTrigger = getSubTriggers()[0] as HTMLElement
+                    const icons = subTrigger.querySelectorAll('svg')
+                    expect(icons.length).toBeGreaterThanOrEqual(1)
+                })
+            })
+        })
+    })
+
+    // ==================== DISABLED STATE ====================
+
+    describe('disabled state', () => {
+        it('should disable individual items', async () => {
+            const items: ContextMenuItem[] = [
+                { label: 'Enabled Item' },
+                { label: 'Disabled Item', disabled: true }
+            ]
+            render(ContextMenu, { open: true, items })
+            await vi.waitFor(() => {
+                const menuItems = getItems()
+                const disabledItem = menuItems[1] as HTMLElement
+                expect(disabledItem.getAttribute('data-disabled')).not.toBeNull()
+            })
+        })
+
+        it('should apply disabled styles', async () => {
+            const items: ContextMenuItem[] = [{ label: 'Disabled Item', disabled: true }]
+            render(ContextMenu, { open: true, items })
+            await vi.waitFor(() => {
+                const item = getItems()[0] as HTMLElement
+                expect(item.className).toContain('data-[disabled]:opacity-50')
+            })
+        })
+    })
+
+    // ==================== CLOSE ON SELECT ====================
+
+    describe('closeOnSelect', () => {
+        it('should render items with default closeOnSelect behavior', async () => {
+            const items: ContextMenuItem[] = [{ label: 'Click Me' }]
+            render(ContextMenu, { open: true, items })
+            await vi.waitFor(() => {
+                const item = getItems()[0] as HTMLElement
+                expect(item).not.toBeNull()
+            })
+        })
+    })
+
+    // ==================== COLORED ITEMS ====================
+
+    describe('colored items', () => {
+        it('should apply error color to item', async () => {
+            const items: ContextMenuItem[] = [{ label: 'Delete', color: 'error' }]
+            render(ContextMenu, { open: true, items })
+            await vi.waitFor(() => {
+                const item = getItems()[0] as HTMLElement
+                expect(item.className).toContain('text-error')
+            })
+        })
+
+        it('should apply warning color to item', async () => {
+            const items: ContextMenuItem[] = [{ label: 'Archive', color: 'warning' }]
+            render(ContextMenu, { open: true, items })
+            await vi.waitFor(() => {
+                const item = getItems()[0] as HTMLElement
+                expect(item.className).toContain('text-warning')
+            })
+        })
+
+        it('should apply primary color to item', async () => {
+            const items: ContextMenuItem[] = [{ label: 'Primary', color: 'primary' }]
+            render(ContextMenu, { open: true, items })
+            await vi.waitFor(() => {
+                const item = getItems()[0] as HTMLElement
+                expect(item.className).toContain('text-primary')
+            })
+        })
+
+        it('should apply highlighted color classes for error item', async () => {
+            const items: ContextMenuItem[] = [{ label: 'Delete', color: 'error' }]
+            render(ContextMenu, { open: true, items })
+            await vi.waitFor(() => {
+                const item = getItems()[0] as HTMLElement
+                expect(item.className).toContain('data-[highlighted]:bg-error-container')
+                expect(item.className).toContain('data-[highlighted]:text-on-error-container')
+            })
+        })
+
+        it('should apply error color to item icon', async () => {
+            const items: ContextMenuItem[] = [
+                { label: 'Delete', icon: 'lucide:trash-2', color: 'error' }
+            ]
+            render(ContextMenu, { open: true, items })
+            await vi.waitFor(() => {
+                const item = getItems()[0] as HTMLElement
+                const iconWrapper = item.querySelector('svg')?.parentElement
+                expect(iconWrapper).not.toBeNull()
+                expect(iconWrapper!.className).toContain('text-error')
+            })
+        })
+    })
+
+    // ==================== KEYBOARD SHORTCUTS ====================
+
+    describe('keyboard shortcuts', () => {
+        it('should render keyboard shortcuts', async () => {
+            const items: ContextMenuItem[] = [{ label: 'Save', kbds: ['meta', 's'] }]
+            render(ContextMenu, { open: true, items })
+            await vi.waitFor(() => {
+                const item = getItems()[0] as HTMLElement
+                const kbds = item.querySelectorAll('kbd')
+                expect(kbds.length).toBe(2)
+            })
+        })
+    })
+
+    // ==================== CALLBACKS ====================
+
+    describe('callbacks', () => {
+        it('should call onOpenChange when menu opens', async () => {
+            const onOpenChange = vi.fn()
+            render(ContextMenu, { open: true, items: basicItems, onOpenChange })
+            await vi.waitFor(() => {
+                expect(getContent()).not.toBeNull()
+            })
+            expect(onOpenChange).toBeTypeOf('function')
+        })
+
+        it('should accept onSelect callback on items', async () => {
+            const onSelect = vi.fn()
+            const items: ContextMenuItem[] = [{ label: 'Click Me', onSelect, closeOnSelect: false }]
+            render(ContextMenu, { open: true, items })
+            await vi.waitFor(() => {
+                expect(getItems().length).toBe(1)
+            })
+            expect(onSelect).toBeTypeOf('function')
+        })
+    })
+
+    // ==================== PORTAL ====================
+
+    describe('portal', () => {
+        it('should render in portal by default', async () => {
+            const { container } = render(ContextMenu, { open: true, items: basicItems })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(container.contains(content)).toBe(false)
+                expect(document.body.contains(content)).toBe(true)
+            })
+        })
+    })
+
+    // ==================== TRANSITION ====================
+
+    describe('transition', () => {
+        it('should apply transition animation classes by default', async () => {
+            render(ContextMenu, { open: true, items: basicItems })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toMatch(/animate-/)
+            })
+        })
+
+        it('should not apply transition classes when transition is false', async () => {
+            render(ContextMenu, { open: true, items: basicItems, transition: false })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).not.toMatch(/animate-\[fade/)
+            })
+        })
+    })
+
+    // ==================== VARIANT CLASSES ====================
+
+    describe('variant classes', () => {
+        it('should apply content base classes', async () => {
+            render(ContextMenu, { open: true, items: basicItems })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('z-50')
+                expect(content!.className).toContain('bg-surface-container-low')
+                expect(content!.className).toContain('text-on-surface')
+                expect(content!.className).toContain('rounded-md')
+            })
+        })
+
+        it('should apply item hover classes', async () => {
+            render(ContextMenu, { open: true, items: basicItems })
+            await vi.waitFor(() => {
+                const item = getItems()[0] as HTMLElement
+                expect(item.className).toContain('data-[highlighted]:bg-surface-container-highest')
+            })
+        })
+
+        it('should apply separator classes', async () => {
+            const items: ContextMenuItem[] = [
+                { label: 'Item 1' },
+                { type: 'separator' },
+                { label: 'Item 2' }
+            ]
+            render(ContextMenu, { open: true, items })
+            await vi.waitFor(() => {
+                const separator = getSeparators()[0] as HTMLElement
+                expect(separator.className).toContain('bg-outline-variant')
+            })
+        })
+    })
+
+    // ==================== UI SLOT OVERRIDES ====================
+
+    describe('ui slot overrides', () => {
+        it('should apply ui.content class', async () => {
+            render(ContextMenu, {
+                open: true,
+                items: basicItems,
+                ui: { content: 'custom-content' }
+            })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('custom-content')
+            })
+        })
+
+        it('should apply ui.item class', async () => {
+            render(ContextMenu, {
+                open: true,
+                items: basicItems,
+                ui: { item: 'custom-item' }
+            })
+            await vi.waitFor(() => {
+                const items = getItems()
+                items.forEach((item) => {
+                    expect((item as HTMLElement).className).toContain('custom-item')
+                })
+            })
+        })
+
+        it('should apply ui.separator class', async () => {
+            const items: ContextMenuItem[] = [
+                { label: 'Item 1' },
+                { type: 'separator' },
+                { label: 'Item 2' }
+            ]
+            render(ContextMenu, {
+                open: true,
+                items,
+                ui: { separator: 'custom-separator' }
+            })
+            await vi.waitFor(() => {
+                const separator = getSeparators()[0] as HTMLElement
+                expect(separator.className).toContain('custom-separator')
+            })
+        })
+
+        it('should apply ui.label class', async () => {
+            const items: ContextMenuItem[] = [
+                { type: 'label', label: 'Group' },
+                { label: 'Item 1' }
+            ]
+            render(ContextMenu, {
+                open: true,
+                items,
+                ui: { label: 'custom-label' }
+            })
+            await vi.waitFor(() => {
+                const heading = getGroupHeadings()[0] as HTMLElement
+                expect(heading.className).toContain('custom-label')
+            })
+        })
+
+        it('should apply item-level class override', async () => {
+            const items: ContextMenuItem[] = [{ label: 'Item 1', class: 'my-custom-class' }]
+            render(ContextMenu, { open: true, items })
+            await vi.waitFor(() => {
+                const item = getItems()[0] as HTMLElement
+                expect(item.className).toContain('my-custom-class')
+            })
+        })
+    })
+
+    // ==================== COMBINED FEATURES ====================
+
+    describe('combined features', () => {
+        it('should render all item types together', async () => {
+            const items: ContextMenuItem[] = [
+                { type: 'label', label: 'Actions' },
+                { label: 'Edit', icon: 'lucide:pencil' },
+                { type: 'separator' },
+                { type: 'checkbox', label: 'Show Hidden', checked: true },
+                { type: 'separator' },
+                { type: 'radio', label: 'Light', value: 'light' },
+                { type: 'radio', label: 'Dark', value: 'dark' },
+                { type: 'separator' },
+                {
+                    type: 'sub',
+                    label: 'More',
+                    items: [{ label: 'Sub Item' }]
+                }
+            ]
+            const radioGroups: ContextMenuRadioGroup[] = [{ name: 'theme', value: 'light' }]
+            render(ContextMenu, { open: true, items, radioGroups })
+
+            await vi.waitFor(() => {
+                expect(getItems().length).toBeGreaterThanOrEqual(1)
+                expect(getCheckboxItems().length).toBe(1)
+                expect(getRadioItems().length).toBe(2)
+                expect(getSubTriggers().length).toBe(1)
+                expect(getSeparators().length).toBe(3)
+                expect(getGroupHeadings().length).toBe(1)
+            })
+        })
+
+        it('should render with all ui overrides', async () => {
+            render(ContextMenu, {
+                open: true,
+                items: basicItems,
+                ui: {
+                    content: 'content-custom',
+                    group: 'group-custom',
+                    item: 'item-custom',
+                    itemIcon: 'icon-custom',
+                    itemLabel: 'label-custom'
+                }
+            })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('content-custom')
+
+                const items = getItems()
+                expect((items[0] as HTMLElement).className).toContain('item-custom')
+            })
+        })
+
+        it('should render colored items with icons and kbds', async () => {
+            const items: ContextMenuItem[] = [
+                { label: 'Edit', icon: 'lucide:pencil' },
+                { type: 'separator' },
+                { label: 'Archive', icon: 'lucide:archive', color: 'warning', kbds: ['meta', 'a'] },
+                { label: 'Delete', icon: 'lucide:trash-2', color: 'error', kbds: ['delete'] }
+            ]
+            render(ContextMenu, { open: true, items })
+
+            await vi.waitFor(() => {
+                const menuItems = getItems()
+                expect(menuItems.length).toBe(3)
+                expect(getSeparators().length).toBe(1)
+
+                const archiveItem = menuItems[1] as HTMLElement
+                expect(archiveItem.className).toContain('text-warning')
+
+                const deleteItem = menuItems[2] as HTMLElement
+                expect(deleteItem.className).toContain('text-error')
+                expect(deleteItem.querySelectorAll('kbd').length).toBe(1)
+            })
+        })
+    })
+})

--- a/src/lib/ContextMenu/context-menu.types.ts
+++ b/src/lib/ContextMenu/context-menu.types.ts
@@ -2,10 +2,7 @@ import type { Snippet } from 'svelte'
 import type { ClassNameValue } from 'tailwind-merge'
 import type { ContextMenuSlots, ContextMenuVariantProps } from './context-menu.variants.js'
 import type { KbdProps } from '../Kbd/kbd.types.js'
-import type {
-    ContextMenuRootPropsWithoutHTML,
-    ContextMenuContentPropsWithoutHTML
-} from 'bits-ui'
+import type { ContextMenuRootPropsWithoutHTML, ContextMenuContentPropsWithoutHTML } from 'bits-ui'
 
 // ============================================================================
 // Item Types

--- a/src/lib/ContextMenu/context-menu.types.ts
+++ b/src/lib/ContextMenu/context-menu.types.ts
@@ -1,0 +1,347 @@
+import type { Snippet } from 'svelte'
+import type { ClassNameValue } from 'tailwind-merge'
+import type { ContextMenuSlots, ContextMenuVariantProps } from './context-menu.variants.js'
+import type { KbdProps } from '../Kbd/kbd.types.js'
+import type {
+    ContextMenuRootPropsWithoutHTML,
+    ContextMenuContentPropsWithoutHTML
+} from 'bits-ui'
+
+// ============================================================================
+// Item Types
+// ============================================================================
+
+/**
+ * Base item properties shared across all item types.
+ */
+interface ContextMenuItemBase {
+    /**
+     * The visible text displayed in the menu item.
+     */
+    label?: string
+
+    /**
+     * Icon displayed before the label (leading position).
+     * Supports any Iconify icon name (e.g., 'lucide:home', 'mdi:account').
+     */
+    icon?: string
+
+    /**
+     * Whether this item is disabled.
+     * @default false
+     */
+    disabled?: boolean
+
+    /**
+     * Keyboard shortcut(s) displayed on the trailing side.
+     * Can be an array of key strings or KbdProps objects.
+     * @example ['meta', 'k'] or [{ value: 'meta' }, { value: 'k' }]
+     */
+    kbds?: (string | Pick<KbdProps, 'value' | 'size' | 'variant' | 'color'>)[]
+
+    /**
+     * Additional CSS classes applied to this item.
+     */
+    class?: ClassNameValue
+}
+
+/**
+ * Standard clickable menu item.
+ */
+export interface ContextMenuItemAction extends ContextMenuItemBase {
+    type?: 'item'
+
+    /**
+     * Callback fired when the item is selected.
+     */
+    onSelect?: () => void
+
+    /**
+     * Whether to close the menu after selection.
+     * @default true
+     */
+    closeOnSelect?: boolean
+
+    /**
+     * Color variant for the item (useful for destructive actions).
+     */
+    color?: ContextMenuVariantProps['color']
+}
+
+/**
+ * Checkbox menu item for toggling boolean state.
+ */
+export interface ContextMenuItemCheckbox extends ContextMenuItemBase {
+    type: 'checkbox'
+
+    /**
+     * Whether the checkbox is checked.
+     */
+    checked?: boolean
+
+    /**
+     * Callback fired when the checkbox state changes.
+     */
+    onCheckedChange?: (checked: boolean) => void
+
+    /**
+     * Whether to close the menu after selection.
+     * @default true
+     */
+    closeOnSelect?: boolean
+}
+
+/**
+ * Radio menu item for single selection within a group.
+ */
+export interface ContextMenuItemRadio extends ContextMenuItemBase {
+    type: 'radio'
+
+    /**
+     * Unique value for this radio item within its group.
+     */
+    value: string
+
+    /**
+     * Whether to close the menu after selection.
+     * @default true
+     */
+    closeOnSelect?: boolean
+}
+
+/**
+ * Visual separator between menu items.
+ */
+export interface ContextMenuItemSeparator {
+    type: 'separator'
+}
+
+/**
+ * Group label/heading for organizing items.
+ */
+export interface ContextMenuItemLabel {
+    type: 'label'
+
+    /**
+     * The text displayed as the group label.
+     */
+    label: string
+}
+
+/**
+ * Submenu item that opens a nested context menu.
+ */
+export interface ContextMenuItemSub extends ContextMenuItemBase {
+    type: 'sub'
+
+    /**
+     * Nested items in the submenu.
+     */
+    items: ContextMenuItem[]
+
+    /**
+     * Submenu open state (for controlled behavior).
+     */
+    open?: boolean
+
+    /**
+     * Callback when submenu open state changes.
+     */
+    onOpenChange?: (open: boolean) => void
+}
+
+/**
+ * Union type for all possible context menu items.
+ */
+export type ContextMenuItem =
+    | ContextMenuItemAction
+    | ContextMenuItemCheckbox
+    | ContextMenuItemRadio
+    | ContextMenuItemSeparator
+    | ContextMenuItemLabel
+    | ContextMenuItemSub
+
+/**
+ * Configuration for a radio group within the context menu.
+ */
+export interface ContextMenuRadioGroup {
+    /**
+     * Unique identifier for the radio group.
+     */
+    name: string
+
+    /**
+     * Currently selected value in the group.
+     */
+    value?: string
+
+    /**
+     * Callback fired when the selected value changes.
+     */
+    onValueChange?: (value: string) => void
+}
+
+// ============================================================================
+// Slot Props Types
+// ============================================================================
+
+/**
+ * Props passed to context menu item snippet slots.
+ */
+export interface ContextMenuItemSlotProps {
+    /** The current context menu item data */
+    item: ContextMenuItem
+    /** Zero-based index of the item */
+    index: number
+    /** Whether the item is currently highlighted/focused */
+    highlighted?: boolean
+}
+
+// ============================================================================
+// Component Props
+// ============================================================================
+
+type RootProps = Pick<ContextMenuRootPropsWithoutHTML, 'open' | 'onOpenChange'>
+
+type ContentProps = Pick<
+    ContextMenuContentPropsWithoutHTML,
+    | 'sideOffset'
+    | 'alignOffset'
+    | 'avoidCollisions'
+    | 'collisionBoundary'
+    | 'collisionPadding'
+    | 'hideWhenDetached'
+    | 'onEscapeKeydown'
+    | 'onInteractOutside'
+    | 'onCloseAutoFocus'
+    | 'forceMount'
+    | 'loop'
+>
+
+/**
+ * Props for the ContextMenu component.
+ *
+ * @example
+ * ```svelte
+ * <ContextMenu items={menuItems}>
+ *   <div class="p-8 border">Right-click here</div>
+ * </ContextMenu>
+ * ```
+ *
+ * @see https://bits-ui.com/docs/components/context-menu
+ */
+export interface ContextMenuProps extends RootProps, ContentProps {
+    // -------------------------------------------------------------------------
+    // Content
+    // -------------------------------------------------------------------------
+
+    /**
+     * Array of menu items to render.
+     * Each item can be an action, checkbox, radio, separator, label, or submenu.
+     */
+    items?: ContextMenuItem[]
+
+    /**
+     * Radio groups configuration for managing radio item selections.
+     * @example [{ name: 'theme', value: 'dark', onValueChange: (v) => theme = v }]
+     */
+    radioGroups?: ContextMenuRadioGroup[]
+
+    /**
+     * Icon displayed when a checkbox item is checked.
+     * @default 'lucide:check'
+     */
+    checkedIcon?: string
+
+    /**
+     * Icon displayed for submenu indicators.
+     * @default 'lucide:chevron-right'
+     */
+    submenuIcon?: string
+
+    // -------------------------------------------------------------------------
+    // Behavior
+    // -------------------------------------------------------------------------
+
+    /**
+     * Animate the context menu on open and close.
+     * @default true
+     */
+    transition?: ContextMenuVariantProps['transition']
+
+    /**
+     * Render the context menu content in a portal.
+     * @default true
+     */
+    portal?: boolean
+
+    /**
+     * Size variant for the context menu.
+     * @default 'md'
+     */
+    size?: ContextMenuVariantProps['size']
+
+    // -------------------------------------------------------------------------
+    // Styling
+    // -------------------------------------------------------------------------
+
+    /**
+     * Additional CSS class for the trigger wrapper.
+     */
+    class?: ClassNameValue
+
+    /**
+     * Override classes for context menu slots.
+     */
+    ui?: Partial<Record<ContextMenuSlots, ClassNameValue>>
+
+    // -------------------------------------------------------------------------
+    // Slots (Snippets)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Default slot content used as the right-click trigger area.
+     * Right-clicking this element opens the context menu.
+     */
+    children?: Snippet<[{ open: boolean }]>
+
+    /**
+     * Custom content to render at the top of the context menu.
+     */
+    header?: Snippet<[{ close: () => void }]>
+
+    /**
+     * Custom content to render at the bottom of the context menu.
+     */
+    footer?: Snippet<[{ close: () => void }]>
+
+    /**
+     * Custom snippet for rendering individual items.
+     * When provided, replaces the default item rendering.
+     */
+    item?: Snippet<[ContextMenuItemSlotProps]>
+
+    /**
+     * Custom snippet for the leading section of items.
+     * Replaces the default icon when provided.
+     */
+    itemLeading?: Snippet<[ContextMenuItemSlotProps]>
+
+    /**
+     * Custom snippet for the label section of items.
+     * Replaces the default label text when provided.
+     */
+    itemLabel?: Snippet<[ContextMenuItemSlotProps]>
+
+    /**
+     * Custom snippet for the trailing section of items.
+     * Replaces the default keyboard shortcuts when provided.
+     */
+    itemTrailing?: Snippet<[ContextMenuItemSlotProps]>
+
+    /**
+     * Custom context menu content.
+     * When provided, replaces the default items rendering entirely.
+     */
+    content?: Snippet<[{ open: boolean; close: () => void }]>
+}

--- a/src/lib/ContextMenu/context-menu.variants.ts
+++ b/src/lib/ContextMenu/context-menu.variants.ts
@@ -1,0 +1,183 @@
+import { tv, type VariantProps } from 'tailwind-variants'
+
+export const contextMenuVariants = tv({
+    slots: {
+        content: [
+            'z-50 min-w-48',
+            'bg-surface-container-low text-on-surface',
+            'rounded-md',
+            'ring ring-outline-variant/50',
+            'shadow-lg',
+            'focus:outline-none',
+            'overflow-hidden'
+        ],
+        group: 'p-1',
+        separator: '-mx-1 my-1 h-px bg-outline-variant',
+        label: 'px-2 py-1.5 text-xs font-semibold text-on-surface-variant',
+        item: [
+            'relative flex items-center gap-2 w-full rounded-sm px-2 cursor-pointer select-none',
+            'focus:outline-none',
+            'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+            'data-[highlighted]:bg-surface-container-highest'
+        ],
+        itemIcon: 'shrink-0',
+        itemLabel: 'flex-1 truncate',
+        itemKbd: 'ml-auto flex items-center gap-0.5',
+        itemIndicator: 'shrink-0',
+        subTrigger: [
+            'relative flex items-center gap-2 w-full rounded-sm px-2 cursor-pointer select-none',
+            'focus:outline-none',
+            'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+            'data-[highlighted]:bg-surface-container-highest',
+            'data-[state=open]:bg-surface-container-highest'
+        ],
+        subTriggerIcon: 'ml-auto shrink-0',
+        subContent: [
+            'z-50 min-w-48',
+            'bg-surface-container-low text-on-surface',
+            'rounded-md',
+            'ring ring-outline-variant/50',
+            'shadow-lg',
+            'focus:outline-none',
+            'overflow-hidden'
+        ],
+        checkboxIndicator: 'shrink-0',
+        radioIndicator: 'shrink-0'
+    },
+    variants: {
+        transition: {
+            true: {
+                content:
+                    'data-[state=open]:animate-[fade-in_150ms_ease-out,scale-in_150ms_ease-out] data-[state=closed]:animate-[fade-out_100ms_ease-in,scale-out_100ms_ease-in]',
+                subContent:
+                    'data-[state=open]:animate-[fade-in_150ms_ease-out,scale-in_150ms_ease-out] data-[state=closed]:animate-[fade-out_100ms_ease-in,scale-out_100ms_ease-in]'
+            }
+        },
+        size: {
+            xs: {
+                item: 'py-1 text-xs',
+                subTrigger: 'py-1 text-xs',
+                itemIcon: 'size-3',
+                subTriggerIcon: 'size-3',
+                checkboxIndicator: 'size-3',
+                radioIndicator: 'size-3',
+                label: 'text-[10px]'
+            },
+            sm: {
+                item: 'py-1.5 text-xs',
+                subTrigger: 'py-1.5 text-xs',
+                itemIcon: 'size-3.5',
+                subTriggerIcon: 'size-3.5',
+                checkboxIndicator: 'size-3.5',
+                radioIndicator: 'size-3.5',
+                label: 'text-[11px]'
+            },
+            md: {
+                item: 'py-1.5 text-sm',
+                subTrigger: 'py-1.5 text-sm',
+                itemIcon: 'size-4',
+                subTriggerIcon: 'size-4',
+                checkboxIndicator: 'size-4',
+                radioIndicator: 'size-4'
+            },
+            lg: {
+                item: 'py-2 text-sm',
+                subTrigger: 'py-2 text-sm',
+                itemIcon: 'size-5',
+                subTriggerIcon: 'size-5',
+                checkboxIndicator: 'size-5',
+                radioIndicator: 'size-5'
+            },
+            xl: {
+                item: 'py-2.5 text-base',
+                subTrigger: 'py-2.5 text-base',
+                itemIcon: 'size-5',
+                subTriggerIcon: 'size-5',
+                checkboxIndicator: 'size-5',
+                radioIndicator: 'size-5'
+            }
+        },
+        color: {
+            default: {},
+            primary: {},
+            secondary: {},
+            tertiary: {},
+            success: {},
+            warning: {},
+            error: {},
+            info: {},
+            surface: {}
+        }
+    },
+    compoundVariants: [
+        {
+            color: 'error',
+            class: {
+                item: 'text-error data-[highlighted]:bg-error-container data-[highlighted]:text-on-error-container',
+                itemIcon: 'text-error'
+            }
+        },
+        {
+            color: 'success',
+            class: {
+                item: 'text-success data-[highlighted]:bg-success-container data-[highlighted]:text-on-success-container',
+                itemIcon: 'text-success'
+            }
+        },
+        {
+            color: 'warning',
+            class: {
+                item: 'text-warning data-[highlighted]:bg-warning-container data-[highlighted]:text-on-warning-container',
+                itemIcon: 'text-warning'
+            }
+        },
+        {
+            color: 'info',
+            class: {
+                item: 'text-info data-[highlighted]:bg-info-container data-[highlighted]:text-on-info-container',
+                itemIcon: 'text-info'
+            }
+        },
+        {
+            color: 'primary',
+            class: {
+                item: 'text-primary data-[highlighted]:bg-primary-container data-[highlighted]:text-on-primary-container',
+                itemIcon: 'text-primary'
+            }
+        },
+        {
+            color: 'secondary',
+            class: {
+                item: 'text-secondary data-[highlighted]:bg-secondary-container data-[highlighted]:text-on-secondary-container',
+                itemIcon: 'text-secondary'
+            }
+        },
+        {
+            color: 'tertiary',
+            class: {
+                item: 'text-tertiary data-[highlighted]:bg-tertiary-container data-[highlighted]:text-on-tertiary-container',
+                itemIcon: 'text-tertiary'
+            }
+        },
+        {
+            color: 'surface',
+            class: {
+                item: 'text-on-surface-variant data-[highlighted]:bg-surface-container-highest data-[highlighted]:text-on-surface',
+                itemIcon: 'text-on-surface-variant'
+            }
+        }
+    ],
+    defaultVariants: {
+        transition: true,
+        size: 'md',
+        color: 'default'
+    }
+})
+
+export type ContextMenuVariantProps = VariantProps<typeof contextMenuVariants>
+export type ContextMenuSlots = keyof ReturnType<typeof contextMenuVariants>
+
+export const contextMenuDefaults = {
+    defaultVariants: contextMenuVariants.defaultVariants,
+    slots: {} as Partial<Record<ContextMenuSlots, string>>
+}

--- a/src/lib/ContextMenu/index.ts
+++ b/src/lib/ContextMenu/index.ts
@@ -1,0 +1,6 @@
+export { default as ContextMenu } from './ContextMenu.svelte'
+export type {
+    ContextMenuProps,
+    ContextMenuItem,
+    ContextMenuRadioGroup
+} from './context-menu.types.js'

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -25,6 +25,7 @@ export * from './Popover/index.js'
 export * from './Breadcrumb/index.js'
 export * from './Calendar/index.js'
 export * from './DropdownMenu/index.js'
+export * from './ContextMenu/index.js'
 export * from './Tabs/index.js'
 
 // Configuration

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -36,7 +36,8 @@
         { href: '/breadcrumb', label: 'Breadcrumb', icon: 'lucide:chevrons-right' },
         { href: '/calendar', label: 'Calendar', icon: 'lucide:calendar' },
         { href: '/dropdown-menu', label: 'Dropdown Menu', icon: 'lucide:chevron-down-square' },
-        { href: '/tabs', label: 'Tabs', icon: 'lucide:panel-top' }
+        { href: '/tabs', label: 'Tabs', icon: 'lucide:panel-top' },
+        { href: '/context-menu', label: 'Context Menu', icon: 'lucide:mouse-pointer' }
     ]
 
     const docItems = [

--- a/src/routes/context-menu/+page.svelte
+++ b/src/routes/context-menu/+page.svelte
@@ -1,0 +1,383 @@
+<script lang="ts">
+    import {
+        ContextMenu,
+        Separator,
+        type ContextMenuItem,
+        type ContextMenuRadioGroup
+    } from '$lib/index.js'
+
+    let showStatusBar = $state(true)
+    let showActivityBar = $state(false)
+    let showPanel = $state(true)
+    let selectedTheme = $state('system')
+
+    // Basic menu items
+    const basicItems: ContextMenuItem[] = [
+        { label: 'Back', icon: 'lucide:arrow-left', kbds: ['alt', 'left'] },
+        { label: 'Forward', icon: 'lucide:arrow-right', kbds: ['alt', 'right'], disabled: true },
+        { label: 'Reload', icon: 'lucide:refresh-cw', kbds: ['meta', 'r'] },
+        { type: 'separator' },
+        { label: 'Save As...', icon: 'lucide:save', kbds: ['meta', 's'] },
+        { label: 'Print...', icon: 'lucide:printer', kbds: ['meta', 'p'] },
+        { type: 'separator' },
+        { label: 'View Source', icon: 'lucide:code', kbds: ['meta', 'u'] },
+        { label: 'Inspect', icon: 'lucide:search', kbds: ['meta', 'shift', 'i'] }
+    ]
+
+    // Items with different colors
+    const coloredItems: ContextMenuItem[] = [
+        { label: 'Edit', icon: 'lucide:pencil' },
+        { label: 'Duplicate', icon: 'lucide:copy' },
+        { type: 'separator' },
+        { label: 'Archive', icon: 'lucide:archive', color: 'warning' },
+        { label: 'Delete', icon: 'lucide:trash-2', color: 'error' }
+    ]
+
+    // Checkbox items (closeOnSelect: false keeps menu open after toggling)
+    const checkboxItems: ContextMenuItem[] = $derived([
+        { type: 'label', label: 'Appearance' },
+        {
+            type: 'checkbox',
+            label: 'Status Bar',
+            checked: showStatusBar,
+            closeOnSelect: false,
+            onCheckedChange: (v: boolean) => (showStatusBar = v)
+        },
+        {
+            type: 'checkbox',
+            label: 'Activity Bar',
+            checked: showActivityBar,
+            closeOnSelect: false,
+            onCheckedChange: (v: boolean) => (showActivityBar = v)
+        },
+        {
+            type: 'checkbox',
+            label: 'Panel',
+            checked: showPanel,
+            closeOnSelect: false,
+            onCheckedChange: (v: boolean) => (showPanel = v)
+        }
+    ])
+
+    // Radio items with group
+    const radioItems: ContextMenuItem[] = [
+        { type: 'label', label: 'Theme' },
+        { type: 'radio', label: 'Light', value: 'light' },
+        { type: 'radio', label: 'Dark', value: 'dark' },
+        { type: 'radio', label: 'System', value: 'system' }
+    ]
+
+    const radioGroups: ContextMenuRadioGroup[] = $derived([
+        {
+            name: 'theme',
+            value: selectedTheme,
+            onValueChange: (v: string) => (selectedTheme = v)
+        }
+    ])
+
+    // Submenu items
+    const submenuItems: ContextMenuItem[] = [
+        { label: 'Cut', icon: 'lucide:scissors', kbds: ['meta', 'x'] },
+        { label: 'Copy', icon: 'lucide:copy', kbds: ['meta', 'c'] },
+        { label: 'Paste', icon: 'lucide:clipboard', kbds: ['meta', 'v'] },
+        { type: 'separator' },
+        {
+            type: 'sub',
+            label: 'More Tools',
+            icon: 'lucide:wrench',
+            items: [
+                { label: 'Save Page As...', kbds: ['meta', 's'] },
+                { label: 'Create Shortcut...' },
+                { label: 'Name Window...' },
+                { type: 'separator' },
+                { label: 'Developer Tools', kbds: ['meta', 'alt', 'i'] }
+            ]
+        },
+        {
+            type: 'sub',
+            label: 'Share',
+            icon: 'lucide:share-2',
+            items: [
+                { label: 'Email', icon: 'lucide:mail' },
+                { label: 'Message', icon: 'lucide:message-square' },
+                { type: 'separator' },
+                { label: 'Copy Link', icon: 'lucide:link' }
+            ]
+        }
+    ]
+
+    // Combined example
+    const fullItems: ContextMenuItem[] = $derived([
+        { label: 'Cut', icon: 'lucide:scissors', kbds: ['meta', 'x'] },
+        { label: 'Copy', icon: 'lucide:copy', kbds: ['meta', 'c'] },
+        { label: 'Paste', icon: 'lucide:clipboard', kbds: ['meta', 'v'] },
+        { type: 'separator' },
+        { type: 'label', label: 'View' },
+        {
+            type: 'checkbox',
+            label: 'Show Bookmarks',
+            checked: showStatusBar,
+            onCheckedChange: (v: boolean) => (showStatusBar = v)
+        },
+        {
+            type: 'checkbox',
+            label: 'Show Full URLs',
+            checked: showActivityBar,
+            onCheckedChange: (v: boolean) => (showActivityBar = v)
+        },
+        { type: 'separator' },
+        {
+            type: 'sub',
+            label: 'More Tools',
+            icon: 'lucide:wrench',
+            items: [
+                { label: 'Save Page As...', kbds: ['meta', 's'] },
+                { label: 'Create Shortcut...' },
+                { type: 'separator' },
+                { label: 'Developer Tools', kbds: ['meta', 'alt', 'i'] }
+            ]
+        },
+        { type: 'separator' },
+        { label: 'Delete', icon: 'lucide:trash-2', color: 'error', kbds: ['delete'] }
+    ])
+
+    const triggerClass =
+        'flex items-center justify-center rounded-lg border-2 border-dashed border-outline-variant bg-surface-container-low text-on-surface-variant transition-colors hover:border-primary/50 hover:bg-surface-container cursor-context-menu select-none'
+</script>
+
+<div class="space-y-12">
+    <header>
+        <h1 class="text-3xl font-bold text-on-surface">ContextMenu</h1>
+        <p class="mt-2 text-on-surface-variant">
+            Display a menu of actions or options triggered by right-click. Built on bits-ui
+            ContextMenu primitive.
+        </p>
+    </header>
+
+    <!-- Basic Usage -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Basic Usage</h2>
+        <p class="text-sm text-on-surface-variant">
+            Right-click on the area below to open a context menu with icons and keyboard shortcuts.
+        </p>
+        <ContextMenu items={basicItems}>
+            <div class="{triggerClass} h-36 w-full">
+                <span class="text-sm">Right-click here</span>
+            </div>
+        </ContextMenu>
+    </section>
+
+    <!-- Colored Items -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Colored Items</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="text-primary">color</code> prop on items for semantic coloring (e.g.,
+            destructive actions).
+        </p>
+        <ContextMenu items={coloredItems}>
+            <div class="{triggerClass} h-36 w-full">
+                <span class="text-sm">Right-click for colored items</span>
+            </div>
+        </ContextMenu>
+    </section>
+
+    <!-- Checkbox Items -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Checkbox Items</h2>
+        <p class="text-sm text-on-surface-variant">Toggle boolean states with checkbox items.</p>
+        <div class="flex items-start gap-6">
+            <ContextMenu items={checkboxItems} class="flex-1">
+                <div class="{triggerClass} h-36 w-full">
+                    <span class="text-sm">Right-click for checkboxes</span>
+                </div>
+            </ContextMenu>
+
+            <div class="text-sm text-on-surface-variant">
+                <p>Status Bar: <code class="text-primary">{showStatusBar}</code></p>
+                <p>Activity Bar: <code class="text-primary">{showActivityBar}</code></p>
+                <p>Panel: <code class="text-primary">{showPanel}</code></p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Radio Items -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Radio Items</h2>
+        <p class="text-sm text-on-surface-variant">Single selection with radio items and groups.</p>
+        <div class="flex items-start gap-6">
+            <ContextMenu items={radioItems} {radioGroups} class="flex-1">
+                <div class="{triggerClass} h-36 w-full">
+                    <span class="text-sm">Right-click for radio selection</span>
+                </div>
+            </ContextMenu>
+
+            <div class="text-sm text-on-surface-variant">
+                Selected: <code class="text-primary">{selectedTheme}</code>
+            </div>
+        </div>
+    </section>
+
+    <!-- Submenus -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Submenus</h2>
+        <p class="text-sm text-on-surface-variant">
+            Nested menus for complex navigation structures.
+        </p>
+        <ContextMenu items={submenuItems}>
+            <div class="{triggerClass} h-36 w-full">
+                <span class="text-sm">Right-click for submenus</span>
+            </div>
+        </ContextMenu>
+    </section>
+
+    <!-- Sizes -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Sizes</h2>
+        <p class="text-sm text-on-surface-variant">
+            Control the menu size with the <code class="text-primary">size</code> prop.
+        </p>
+        <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <ContextMenu items={basicItems.slice(0, 5)} size="xs">
+                <div class="{triggerClass} h-28">
+                    <span class="text-xs">XS size</span>
+                </div>
+            </ContextMenu>
+
+            <ContextMenu items={basicItems.slice(0, 5)} size="sm">
+                <div class="{triggerClass} h-28">
+                    <span class="text-xs">SM size</span>
+                </div>
+            </ContextMenu>
+
+            <ContextMenu items={basicItems.slice(0, 5)} size="md">
+                <div class="{triggerClass} h-28">
+                    <span class="text-xs">MD size (default)</span>
+                </div>
+            </ContextMenu>
+
+            <ContextMenu items={basicItems.slice(0, 5)} size="lg">
+                <div class="{triggerClass} h-28">
+                    <span class="text-xs">LG size</span>
+                </div>
+            </ContextMenu>
+
+            <ContextMenu items={basicItems.slice(0, 5)} size="xl">
+                <div class="{triggerClass} h-28">
+                    <span class="text-xs">XL size</span>
+                </div>
+            </ContextMenu>
+        </div>
+    </section>
+
+    <!-- Custom Header/Footer -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Custom Header/Footer</h2>
+        <p class="text-sm text-on-surface-variant">
+            Add custom content at the top or bottom of the menu.
+        </p>
+        <ContextMenu items={basicItems.slice(0, 4)}>
+            <div class="{triggerClass} h-36 w-full">
+                <span class="text-sm">Right-click for header/footer</span>
+            </div>
+            {#snippet header()}
+                <div class="px-3 py-2">
+                    <p class="text-sm font-medium">John Doe</p>
+                    <p class="text-xs text-on-surface-variant">john@example.com</p>
+                </div>
+                <Separator />
+            {/snippet}
+            {#snippet footer({ close })}
+                <Separator />
+                <div class="p-1">
+                    <button
+                        class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-error hover:bg-error-container hover:text-on-error-container"
+                        onclick={close}
+                    >
+                        Log out
+                    </button>
+                </div>
+            {/snippet}
+        </ContextMenu>
+    </section>
+
+    <!-- Custom Content -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Custom Content</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="text-primary">content</code> slot for fully custom context menu content.
+        </p>
+        <ContextMenu>
+            <div class="{triggerClass} h-36 w-full">
+                <span class="text-sm">Right-click for custom content</span>
+            </div>
+            {#snippet content({ close })}
+                <div class="p-4">
+                    <p class="mb-3 text-sm font-medium">Choose a color</p>
+                    <div class="grid grid-cols-5 gap-2">
+                        {#each ['bg-red-500', 'bg-orange-500', 'bg-yellow-500', 'bg-green-500', 'bg-teal-500', 'bg-blue-500', 'bg-indigo-500', 'bg-purple-500', 'bg-pink-500', 'bg-gray-500'] as color (color)}
+                            <button
+                                class="size-8 rounded-full {color} transition-all hover:ring-2 hover:ring-outline hover:ring-offset-2"
+                                aria-label="Select {color
+                                    .replace('bg-', '')
+                                    .replace('-500', '')} color"
+                                onclick={close}
+                            ></button>
+                        {/each}
+                    </div>
+                </div>
+            {/snippet}
+        </ContextMenu>
+    </section>
+
+    <!-- UI Slot Overrides -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">UI Slot Overrides</h2>
+        <p class="text-sm text-on-surface-variant">
+            Customize individual parts with the <code class="text-primary">ui</code> prop.
+        </p>
+        <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <ContextMenu
+                items={basicItems.slice(0, 5)}
+                ui={{
+                    content: 'bg-primary text-on-primary ring-primary/50',
+                    item: 'data-[highlighted]:bg-on-primary/20',
+                    separator: 'bg-on-primary/20'
+                }}
+            >
+                <div class="{triggerClass} h-28">
+                    <span class="text-sm">Primary Style</span>
+                </div>
+            </ContextMenu>
+
+            <ContextMenu
+                items={basicItems.slice(0, 5)}
+                ui={{
+                    content: 'rounded-xl shadow-2xl'
+                }}
+            >
+                <div class="{triggerClass} h-28">
+                    <span class="text-sm">Custom Rounding</span>
+                </div>
+            </ContextMenu>
+        </div>
+    </section>
+
+    <!-- Full Example -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Full Example</h2>
+        <p class="text-sm text-on-surface-variant">
+            A comprehensive context menu combining multiple features: actions, checkboxes, submenus,
+            and colored items.
+        </p>
+        <ContextMenu items={fullItems}>
+            <div class="{triggerClass} h-48 w-full">
+                <div class="text-center">
+                    <p class="text-sm font-medium text-on-surface">Interactive Area</p>
+                    <p class="mt-1 text-xs text-on-surface-variant">
+                        Right-click anywhere in this area
+                    </p>
+                </div>
+            </div>
+        </ContextMenu>
+    </section>
+</div>


### PR DESCRIPTION
## Summary
- Add new `ContextMenu` component built on `bits-ui` ContextMenu primitives, triggered by right-click
- Support 6 item types: **action**, **checkbox**, **radio**, **separator**, **label**, and **submenu** (nested)
- Include `tailwind-variants` based styling with `transition`, `size` (xs/sm/md/lg/xl), and `color` (9 semantic colors: default, primary, secondary, tertiary, success, warning, error, info, surface) variants
- Provide full slot customization via `children`, `header`, `footer`, `content`, `item`, `itemLeading`, `itemLabel`, `itemTrailing` snippets
- Support `closeOnSelect: false` to keep menu open after item interaction (useful for checkbox/radio toggling)
- Optimize render performance with `resolveSlot` helper, cached color variant computations (`getColorVariant`), and shared `collisionProps` derived
- Add comprehensive demo page at `/context-menu` with 9 interactive sections
- Export `ContextMenu`, `ContextMenuProps`, `ContextMenuItem`, `ContextMenuRadioGroup` from library entry point

## New Files
| File | Description |
|------|-------------|
| `src/lib/ContextMenu/ContextMenu.svelte` | Main component wrapping bits-ui primitives (Root, Trigger, Content, Item, CheckboxItem, RadioItem, Sub, SubTrigger, SubContent, Separator, Group, GroupHeading, Portal) |
| `src/lib/ContextMenu/context-menu.types.ts` | TypeScript interfaces: `ContextMenuItemBase`, `ContextMenuItemAction`, `ContextMenuItemCheckbox`, `ContextMenuItemRadio`, `ContextMenuItemSeparator`, `ContextMenuItemLabel`, `ContextMenuItemSub`, `ContextMenuItem` (union), `ContextMenuRadioGroup`, `ContextMenuItemSlotProps`, `ContextMenuProps` |
| `src/lib/ContextMenu/context-menu.variants.ts` | Tailwind Variants definition with 13 slots, `transition`/`size`/`color` variants, 8 compound color variants for highlighted states, and exported defaults |
| `src/lib/ContextMenu/index.ts` | Barrel exports for component and types |
| `src/routes/context-menu/+page.svelte` | Demo page with 9 sections: basic usage, colored items, checkbox items (with `closeOnSelect: false`), radio items, submenus, sizes, custom header/footer, custom content slot, UI slot overrides, and full combined example |

## Modified Files
| File | Change |
|------|--------|
| `src/lib/index.ts` | Added `export * from './ContextMenu/index.js'` |
| `src/routes/+layout.svelte` | Added Context Menu link to sidebar navigation |

## Component API

### Props
| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `items` | `ContextMenuItem[]` | `[]` | Array of menu items (action, checkbox, radio, separator, label, sub) |
| `radioGroups` | `ContextMenuRadioGroup[]` | `[]` | Radio group configurations for managing radio selections |
| `size` | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Size variant |
| `transition` | `boolean` | `true` | Animate open/close with fade + scale |
| `portal` | `boolean` | `true` | Render content in a portal |
| `open` | `boolean` | `false` | Bindable open state |
| `closeOnSelect` | `boolean` | `true` | Per-item control to keep menu open after interaction |
| `ui` | `Partial<Record<Slot, string>>` | — | Override classes for individual slots |
| `class` | `string` | — | CSS class for the trigger wrapper |

### Slots (Snippets)
| Slot | Props | Description |
|------|-------|-------------|
| `children` | `{ open }` | Right-click trigger area |
| `header` | `{ close }` | Custom content at top of menu |
| `footer` | `{ close }` | Custom content at bottom of menu |
| `content` | `{ open, close }` | Fully custom menu content (replaces default rendering) |
| `item` | `{ item, index }` | Custom item rendering |
| `itemLeading` | `{ item, index }` | Custom leading section (replaces icon) |
| `itemLabel` | `{ item, index }` | Custom label section |
| `itemTrailing` | `{ item, index }` | Custom trailing section (replaces kbd shortcuts) |

## Test plan
- [ ] Right-click triggers the context menu at cursor position
- [ ] All 6 item types render correctly (action, checkbox, radio, separator, label, sub)
- [ ] Keyboard navigation works (arrow keys, Enter, Escape)
- [ ] `closeOnSelect: false` keeps menu open after checkbox toggle
- [ ] Color variants apply correct text/background on hover (`data-[highlighted]`)
- [ ] Size variants (xs → xl) scale items, icons, and labels proportionally
- [ ] Submenus open/close with hover and keyboard
- [ ] Portal rendering works (menu renders outside DOM hierarchy)
- [ ] Custom `header`, `footer`, and `content` slots render correctly
- [ ] `ui` prop overrides individual slot classes
- [ ] Run `npm run check` — no TypeScript errors
