### PR TITLE
feat: add Pagination component with variants, types, and demo page

### DIFF
--- a/src/lib/Pagination/Pagination.svelte
+++ b/src/lib/Pagination/Pagination.svelte
@@ -1,0 +1,198 @@
+<script lang="ts" module>
+    import type { PaginationProps } from './pagination.types.js'
+
+    export type Props = PaginationProps
+</script>
+
+<script lang="ts">
+    import { Pagination } from 'bits-ui'
+    import { untrack } from 'svelte'
+    import { paginationVariants, paginationDefaults } from './pagination.variants.js'
+    import { getComponentConfig } from '../config.js'
+    import Icon from '../Icon/Icon.svelte'
+    import ButtonComponent from '../Button/Button.svelte'
+
+    const config = getComponentConfig('pagination', paginationDefaults)
+
+    let {
+        page = $bindable(),
+        defaultPage = 1,
+        total = 0,
+        itemsPerPage = 10,
+        siblingCount = 1,
+        showEdges = false,
+        showControls = true,
+        disabled = false,
+        onPageChange,
+        size = config.defaultVariants.size ?? 'md',
+        activeColor = config.defaultVariants.activeColor ?? 'primary',
+        firstIcon = 'lucide:chevrons-left',
+        prevIcon = 'lucide:chevron-left',
+        nextIcon = 'lucide:chevron-right',
+        lastIcon = 'lucide:chevrons-right',
+        ellipsisIcon = 'lucide:ellipsis',
+        ui,
+        class: className,
+        firstSlot,
+        prevSlot,
+        nextSlot,
+        lastSlot,
+        ellipsisSlot,
+        itemSlot
+    }: Props = $props()
+
+    if (page === undefined) {
+        page = untrack(() => defaultPage)
+    }
+
+    const totalPages = $derived(Math.max(1, Math.ceil(total / itemsPerPage)))
+    const isFirstPage = $derived(page === 1)
+    const isLastPage = $derived(page === totalPages)
+    const prevDisabled = $derived(disabled || isFirstPage)
+    const nextDisabled = $derived(disabled || isLastPage)
+
+    const variantSlots = $derived(paginationVariants({ size, activeColor, disabled }))
+
+    function resolveSlot(slot: keyof typeof variantSlots, extra?: unknown) {
+        const configSlot = config.slots[slot as keyof typeof config.slots]
+        const uiSlot = ui?.[slot as keyof typeof ui]
+        return (variantSlots[slot] as (opts: { class: unknown[] }) => string)({
+            class: [configSlot, extra, uiSlot]
+        })
+    }
+
+    const baseClasses = $derived.by(() => ({
+        root: resolveSlot('root', className),
+        list: resolveSlot('list'),
+        item: resolveSlot('item'),
+        ellipsis: resolveSlot('ellipsis'),
+        ellipsisIcon: resolveSlot('ellipsisIcon')
+    }))
+
+    const controlClasses = $derived.by(() =>
+        showControls
+            ? {
+                  prev: resolveSlot('prev'),
+                  next: resolveSlot('next'),
+                  prevIcon: resolveSlot('prevIcon'),
+                  nextIcon: resolveSlot('nextIcon')
+              }
+            : null
+    )
+
+    const edgeClasses = $derived.by(() =>
+        showEdges
+            ? {
+                  first: resolveSlot('first'),
+                  last: resolveSlot('last'),
+                  firstIcon: resolveSlot('firstIcon'),
+                  lastIcon: resolveSlot('lastIcon')
+              }
+            : null
+    )
+
+    function handlePageChange(newPage: number) {
+        page = newPage
+        onPageChange?.(newPage)
+    }
+
+    function goToFirst() {
+        if (!isFirstPage) handlePageChange(1)
+    }
+
+    function goToLast() {
+        if (!isLastPage) handlePageChange(totalPages)
+    }
+</script>
+
+<Pagination.Root
+    count={total}
+    perPage={itemsPerPage}
+    {siblingCount}
+    {page}
+    onPageChange={handlePageChange}
+    class={baseClasses.root}
+>
+    {#snippet children({ pages })}
+        <div class={baseClasses.list}>
+            {#if edgeClasses}
+                <ButtonComponent
+                    variant="ghost"
+                    color="surface"
+                    square
+                    class={edgeClasses.first}
+                    disabled={prevDisabled}
+                    aria-label="First page"
+                    onclick={goToFirst}
+                >
+                    {#if firstSlot}
+                        {@render firstSlot({ page: page!, disabled: prevDisabled })}
+                    {:else}
+                        <Icon name={firstIcon} class={edgeClasses.firstIcon} />
+                    {/if}
+                </ButtonComponent>
+            {/if}
+
+            {#if controlClasses}
+                <Pagination.PrevButton class={controlClasses.prev} disabled={prevDisabled}>
+                    {#if prevSlot}
+                        {@render prevSlot({ page: page!, disabled: prevDisabled })}
+                    {:else}
+                        <Icon name={prevIcon} class={controlClasses.prevIcon} />
+                    {/if}
+                </Pagination.PrevButton>
+            {/if}
+
+            {#each pages as pageItem (pageItem.key)}
+                {#if pageItem.type === 'ellipsis'}
+                    <span class={baseClasses.ellipsis}>
+                        {#if ellipsisSlot}
+                            {@render ellipsisSlot()}
+                        {:else}
+                            <Icon name={ellipsisIcon} class={baseClasses.ellipsisIcon} />
+                        {/if}
+                    </span>
+                {:else}
+                    <Pagination.Page page={pageItem} class={baseClasses.item} {disabled}>
+                        {#if itemSlot}
+                            {@render itemSlot({
+                                page: pageItem.value,
+                                selected: page === pageItem.value
+                            })}
+                        {:else}
+                            {pageItem.value}
+                        {/if}
+                    </Pagination.Page>
+                {/if}
+            {/each}
+
+            {#if controlClasses}
+                <Pagination.NextButton class={controlClasses.next} disabled={nextDisabled}>
+                    {#if nextSlot}
+                        {@render nextSlot({ page: page!, disabled: nextDisabled })}
+                    {:else}
+                        <Icon name={nextIcon} class={controlClasses.nextIcon} />
+                    {/if}
+                </Pagination.NextButton>
+            {/if}
+
+            {#if edgeClasses}
+                <ButtonComponent
+                    variant="ghost"
+                    color="surface"
+                    square
+                    class={edgeClasses.last}
+                    disabled={nextDisabled}
+                    aria-label="Last page"
+                    onclick={goToLast}
+                >
+                    {#if lastSlot}
+                        {@render lastSlot({ page: page!, disabled: nextDisabled })}
+                    {:else}
+                        <Icon name={lastIcon} class={edgeClasses.lastIcon} />
+                    {/if}
+                </ButtonComponent>
+            {/if}
+        </div>
+    {/snippet}
+</Pagination.Root>

--- a/src/lib/Pagination/Pagination.svelte.spec.ts
+++ b/src/lib/Pagination/Pagination.svelte.spec.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-svelte'
+import { page } from 'vitest/browser'
+import Pagination from './Pagination.svelte'
+
+describe('Pagination', () => {
+    const defaultProps = { total: 100, itemsPerPage: 10 }
+
+    const getRoot = () => document.querySelector('[data-pagination-root]') as HTMLElement | null
+    const getPageButtons = () => document.querySelectorAll('[data-pagination-page]')
+    const getPrevButton = () =>
+        document.querySelector('[data-pagination-prev]') as HTMLButtonElement | null
+    const getNextButton = () =>
+        document.querySelector('[data-pagination-next]') as HTMLButtonElement | null
+    const getFirstButton = () =>
+        document.querySelector('button[aria-label="First page"]') as HTMLButtonElement | null
+    const getLastButton = () =>
+        document.querySelector('button[aria-label="Last page"]') as HTMLButtonElement | null
+
+    // ==================== RENDERING ====================
+
+    describe('rendering', () => {
+        it('should render without crashing', () => {
+            const { container } = render(Pagination, defaultProps)
+            expect(container).not.toBeNull()
+        })
+
+        it('should render pagination root', async () => {
+            render(Pagination, defaultProps)
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+            })
+        })
+
+        it('should render page buttons', async () => {
+            render(Pagination, defaultProps)
+            await vi.waitFor(() => {
+                const buttons = getPageButtons()
+                expect(buttons.length).toBeGreaterThan(0)
+            })
+        })
+
+        it('should render prev and next buttons by default', async () => {
+            render(Pagination, defaultProps)
+            await vi.waitFor(() => {
+                expect(getPrevButton()).not.toBeNull()
+                expect(getNextButton()).not.toBeNull()
+            })
+        })
+
+        it('should not render first and last buttons by default', async () => {
+            render(Pagination, defaultProps)
+            await vi.waitFor(() => {
+                expect(getFirstButton()).toBeNull()
+                expect(getLastButton()).toBeNull()
+            })
+        })
+    })
+
+    // ==================== DEFAULT PAGE ====================
+
+    describe('default page', () => {
+        it('should select first page by default', async () => {
+            render(Pagination, defaultProps)
+            await vi.waitFor(() => {
+                const buttons = getPageButtons()
+                const selected = Array.from(buttons).find(
+                    (b) => b.getAttribute('data-selected') !== null
+                )
+                expect(selected).not.toBeUndefined()
+                expect(selected?.textContent?.trim()).toBe('1')
+            })
+        })
+
+        it('should select specified page', async () => {
+            render(Pagination, { ...defaultProps, page: 5 })
+            await vi.waitFor(() => {
+                const buttons = getPageButtons()
+                const selected = Array.from(buttons).find(
+                    (b) => b.getAttribute('data-selected') !== null
+                )
+                expect(selected?.textContent?.trim()).toBe('5')
+            })
+        })
+
+        it('should select defaultPage when page is not provided', async () => {
+            render(Pagination, { ...defaultProps, defaultPage: 3 })
+            await vi.waitFor(() => {
+                const buttons = getPageButtons()
+                const selected = Array.from(buttons).find(
+                    (b) => b.getAttribute('data-selected') !== null
+                )
+                expect(selected?.textContent?.trim()).toBe('3')
+            })
+        })
+    })
+
+    // ==================== PAGE NAVIGATION ====================
+
+    describe('page navigation', () => {
+        it('should navigate to next page on next button click', async () => {
+            render(Pagination, defaultProps)
+
+            await vi.waitFor(() => {
+                const nextBtn = getNextButton()
+                expect(nextBtn).not.toBeNull()
+            })
+
+            getNextButton()!.click()
+
+            await vi.waitFor(() => {
+                const buttons = getPageButtons()
+                const selected = Array.from(buttons).find(
+                    (b) => b.getAttribute('data-selected') !== null
+                )
+                expect(selected?.textContent?.trim()).toBe('2')
+            })
+        })
+
+        it('should navigate to page on page button click', async () => {
+            render(Pagination, defaultProps)
+
+            await page.getByText('3').click()
+
+            await vi.waitFor(() => {
+                const buttons = getPageButtons()
+                const selected = Array.from(buttons).find(
+                    (b) => b.getAttribute('data-selected') !== null
+                )
+                expect(selected?.textContent?.trim()).toBe('3')
+            })
+        })
+
+        it('should disable prev button on first page', async () => {
+            render(Pagination, { ...defaultProps, page: 1 })
+            await vi.waitFor(() => {
+                const prevBtn = getPrevButton()
+                expect(prevBtn).not.toBeNull()
+                expect(prevBtn!.disabled).toBe(true)
+            })
+        })
+
+        it('should disable next button on last page', async () => {
+            render(Pagination, { ...defaultProps, page: 10 })
+            await vi.waitFor(() => {
+                const nextBtn = getNextButton()
+                expect(nextBtn).not.toBeNull()
+                expect(nextBtn!.disabled).toBe(true)
+            })
+        })
+    })
+
+    // ==================== SHOW EDGES ====================
+
+    describe('showEdges', () => {
+        it('should render first and last buttons when showEdges is true', async () => {
+            render(Pagination, { ...defaultProps, showEdges: true })
+            await vi.waitFor(() => {
+                expect(getFirstButton()).not.toBeNull()
+                expect(getLastButton()).not.toBeNull()
+            })
+        })
+
+        it('should disable first button on first page', async () => {
+            render(Pagination, { ...defaultProps, showEdges: true, page: 1 })
+            await vi.waitFor(() => {
+                const firstBtn = getFirstButton()
+                expect(firstBtn).not.toBeNull()
+                expect(firstBtn!.disabled).toBe(true)
+            })
+        })
+
+        it('should disable last button on last page', async () => {
+            render(Pagination, { ...defaultProps, showEdges: true, page: 10 })
+            await vi.waitFor(() => {
+                const lastBtn = getLastButton()
+                expect(lastBtn).not.toBeNull()
+                expect(lastBtn!.disabled).toBe(true)
+            })
+        })
+    })
+
+    // ==================== SHOW CONTROLS ====================
+
+    describe('showControls', () => {
+        it('should hide prev and next buttons when showControls is false', async () => {
+            render(Pagination, { ...defaultProps, showControls: false })
+            await vi.waitFor(() => {
+                expect(getPrevButton()).toBeNull()
+                expect(getNextButton()).toBeNull()
+            })
+        })
+    })
+
+    // ==================== DISABLED STATE ====================
+
+    describe('disabled state', () => {
+        it('should apply disabled styles when disabled', async () => {
+            render(Pagination, { ...defaultProps, disabled: true })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+                expect(root!.className).toContain('opacity-50')
+                expect(root!.className).toContain('pointer-events-none')
+            })
+        })
+
+        it('should disable prev and next buttons when disabled', async () => {
+            render(Pagination, { ...defaultProps, disabled: true })
+            await vi.waitFor(() => {
+                const prevBtn = getPrevButton()
+                const nextBtn = getNextButton()
+                expect(prevBtn).not.toBeNull()
+                expect(nextBtn).not.toBeNull()
+                expect(prevBtn!.disabled).toBe(true)
+                expect(nextBtn!.disabled).toBe(true)
+            })
+        })
+    })
+
+    // ==================== CALLBACKS ====================
+
+    describe('callbacks', () => {
+        it('should call onPageChange when page changes', async () => {
+            const onPageChange = vi.fn()
+            render(Pagination, { ...defaultProps, onPageChange })
+
+            await page.getByText('3').click()
+
+            await vi.waitFor(() => {
+                expect(onPageChange).toHaveBeenCalledWith(3)
+            })
+        })
+    })
+
+    // ==================== SIZE VARIANTS ====================
+
+    describe('size variants', () => {
+        it('should apply xs size classes', async () => {
+            render(Pagination, { ...defaultProps, size: 'xs' })
+            await vi.waitFor(() => {
+                const buttons = getPageButtons()
+                expect(buttons.length).toBeGreaterThan(0)
+                const btn = buttons[0] as HTMLElement
+                expect(btn.className).toContain('text-xs')
+            })
+        })
+
+        it('should apply md size classes', async () => {
+            render(Pagination, { ...defaultProps, size: 'md' })
+            await vi.waitFor(() => {
+                const buttons = getPageButtons()
+                expect(buttons.length).toBeGreaterThan(0)
+                const btn = buttons[0] as HTMLElement
+                expect(btn.className).toContain('text-sm')
+            })
+        })
+
+        it('should apply xl size classes', async () => {
+            render(Pagination, { ...defaultProps, size: 'xl' })
+            await vi.waitFor(() => {
+                const buttons = getPageButtons()
+                expect(buttons.length).toBeGreaterThan(0)
+                const btn = buttons[0] as HTMLElement
+                expect(btn.className).toContain('text-base')
+            })
+        })
+    })
+
+    // ==================== UI SLOT OVERRIDES ====================
+
+    describe('ui slot overrides', () => {
+        it('should apply ui.list class', async () => {
+            render(Pagination, {
+                ...defaultProps,
+                ui: { list: 'custom-list' }
+            })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+                const list = root!.querySelector('.custom-list')
+                expect(list).not.toBeNull()
+            })
+        })
+
+        it('should apply ui.item class', async () => {
+            render(Pagination, {
+                ...defaultProps,
+                ui: { item: 'custom-item' }
+            })
+            await vi.waitFor(() => {
+                const buttons = getPageButtons()
+                expect(buttons.length).toBeGreaterThan(0)
+                expect((buttons[0] as HTMLElement).className).toContain('custom-item')
+            })
+        })
+    })
+
+    // ==================== ITEMS PER PAGE ====================
+
+    describe('itemsPerPage', () => {
+        it('should calculate correct number of pages', async () => {
+            render(Pagination, { total: 50, itemsPerPage: 5, page: 1 })
+            await vi.waitFor(() => {
+                const buttons = getPageButtons()
+                const lastPageButton = buttons[buttons.length - 1]
+                expect(lastPageButton?.textContent?.trim()).toBe('10')
+            })
+        })
+
+        it('should handle single page', async () => {
+            render(Pagination, { total: 5, itemsPerPage: 10, page: 1 })
+            await vi.waitFor(() => {
+                const buttons = getPageButtons()
+                expect(buttons.length).toBe(1)
+                expect(buttons[0]?.textContent?.trim()).toBe('1')
+            })
+        })
+    })
+})

--- a/src/lib/Pagination/index.ts
+++ b/src/lib/Pagination/index.ts
@@ -1,0 +1,2 @@
+export { default as Pagination } from './Pagination.svelte'
+export type { PaginationProps } from './pagination.types.js'

--- a/src/lib/Pagination/pagination.types.ts
+++ b/src/lib/Pagination/pagination.types.ts
@@ -1,0 +1,231 @@
+import type { Snippet } from 'svelte'
+import type { ClassNameValue } from 'tailwind-merge'
+import type { PaginationSlots, PaginationVariantProps } from './pagination.variants.js'
+
+// ============================================================================
+// Slot Props Types
+// ============================================================================
+
+/**
+ * Props passed to navigation button snippet slots (first, prev, next, last).
+ */
+export interface PaginationNavSlotProps {
+    /** The current active page number */
+    page: number
+    /** Whether this navigation button is disabled */
+    disabled: boolean
+}
+
+/**
+ * Props passed to the page item snippet slot.
+ */
+export interface PaginationItemSlotProps {
+    /** The page number this item represents */
+    page: number
+    /** Whether this page is currently selected */
+    selected: boolean
+}
+
+// ============================================================================
+// Component Props
+// ============================================================================
+
+/**
+ * Props for the Pagination component.
+ *
+ * Wraps bits-ui's Pagination primitives with enhanced styling,
+ * data-driven rendering, and configurable navigation controls.
+ *
+ * @example
+ * ```svelte
+ * <Pagination
+ *   total={100}
+ *   itemsPerPage={10}
+ *   bind:page={currentPage}
+ *   activeColor="primary"
+ * />
+ * ```
+ *
+ * @see https://bits-ui.com/docs/components/pagination
+ */
+export interface PaginationProps {
+    // -------------------------------------------------------------------------
+    // State
+    // -------------------------------------------------------------------------
+
+    /**
+     * The currently active page number.
+     * Use `bind:page` for two-way binding.
+     * @default 1
+     */
+    page?: number
+
+    /**
+     * The default active page when uncontrolled.
+     * Used as the initial value when `page` is not provided.
+     * @default 1
+     */
+    defaultPage?: number
+
+    /**
+     * Total number of items to paginate.
+     * @default 0
+     */
+    total?: number
+
+    /**
+     * Number of items displayed per page.
+     * @default 10
+     */
+    itemsPerPage?: number
+
+    /**
+     * Number of page buttons shown adjacent to the current page on each side.
+     * @default 1
+     */
+    siblingCount?: number
+
+    // -------------------------------------------------------------------------
+    // Behavior
+    // -------------------------------------------------------------------------
+
+    /**
+     * Whether to show first/last page navigation buttons.
+     * @default false
+     */
+    showEdges?: boolean
+
+    /**
+     * Whether to show previous/next page navigation buttons.
+     * @default true
+     */
+    showControls?: boolean
+
+    /**
+     * Whether all pagination controls are disabled.
+     * @default false
+     */
+    disabled?: boolean
+
+    // -------------------------------------------------------------------------
+    // Callbacks
+    // -------------------------------------------------------------------------
+
+    /**
+     * Callback fired when the active page changes.
+     * Receives the new page number.
+     */
+    onPageChange?: (page: number) => void
+
+    // -------------------------------------------------------------------------
+    // Styling
+    // -------------------------------------------------------------------------
+
+    /**
+     * Size variant controlling button dimensions, text size, and icon sizes.
+     * @default 'md'
+     */
+    size?: NonNullable<PaginationVariantProps['size']>
+
+    /**
+     * Color applied to the currently selected page button.
+     * @default 'primary'
+     */
+    activeColor?: NonNullable<PaginationVariantProps['activeColor']>
+
+    // -------------------------------------------------------------------------
+    // Icons
+    // -------------------------------------------------------------------------
+
+    /**
+     * Icon for the "first page" button.
+     * @default 'lucide:chevrons-left'
+     */
+    firstIcon?: string
+
+    /**
+     * Icon for the "previous page" button.
+     * @default 'lucide:chevron-left'
+     */
+    prevIcon?: string
+
+    /**
+     * Icon for the "next page" button.
+     * @default 'lucide:chevron-right'
+     */
+    nextIcon?: string
+
+    /**
+     * Icon for the "last page" button.
+     * @default 'lucide:chevrons-right'
+     */
+    lastIcon?: string
+
+    /**
+     * Icon displayed in the ellipsis placeholder.
+     * @default 'lucide:ellipsis'
+     */
+    ellipsisIcon?: string
+
+    // -------------------------------------------------------------------------
+    // Styling Overrides
+    // -------------------------------------------------------------------------
+
+    /**
+     * Additional CSS classes for the root element.
+     */
+    class?: ClassNameValue
+
+    /**
+     * Override classes for pagination component slots.
+     *
+     * @example
+     * ```ts
+     * ui={{
+     *   list: 'gap-2',
+     *   item: 'rounded-full',
+     *   prev: 'rounded-full'
+     * }}
+     * ```
+     */
+    ui?: Partial<Record<PaginationSlots, ClassNameValue>>
+
+    // -------------------------------------------------------------------------
+    // Slots (Snippets)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Custom snippet for the first page button.
+     * @param props - Contains `{ page, disabled }`
+     */
+    firstSlot?: Snippet<[PaginationNavSlotProps]>
+
+    /**
+     * Custom snippet for the previous page button.
+     * @param props - Contains `{ page, disabled }`
+     */
+    prevSlot?: Snippet<[PaginationNavSlotProps]>
+
+    /**
+     * Custom snippet for the next page button.
+     * @param props - Contains `{ page, disabled }`
+     */
+    nextSlot?: Snippet<[PaginationNavSlotProps]>
+
+    /**
+     * Custom snippet for the last page button.
+     * @param props - Contains `{ page, disabled }`
+     */
+    lastSlot?: Snippet<[PaginationNavSlotProps]>
+
+    /**
+     * Custom snippet for the ellipsis indicator.
+     */
+    ellipsisSlot?: Snippet
+
+    /**
+     * Custom snippet for individual page buttons.
+     * @param props - Contains `{ page, selected }`
+     */
+    itemSlot?: Snippet<[PaginationItemSlotProps]>
+}

--- a/src/lib/Pagination/pagination.variants.ts
+++ b/src/lib/Pagination/pagination.variants.ts
@@ -1,0 +1,153 @@
+import { tv, type VariantProps } from 'tailwind-variants'
+
+const navButton = [
+    'inline-flex items-center justify-center rounded-md',
+    'cursor-pointer select-none transition-colors',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+    'disabled:cursor-not-allowed disabled:opacity-50',
+    'hover:bg-surface-container-high text-on-surface-variant'
+]
+
+const navIcon = 'shrink-0'
+
+export const paginationVariants = tv({
+    slots: {
+        root: '',
+        list: 'flex items-center gap-1',
+        item: [
+            'inline-flex items-center justify-center rounded-md font-medium',
+            'cursor-pointer select-none transition-colors',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+            'disabled:cursor-not-allowed disabled:opacity-50',
+            'hover:bg-surface-container-high text-on-surface'
+        ],
+        ellipsis:
+            'inline-flex items-center justify-center pointer-events-none text-on-surface-variant',
+        first: navButton,
+        prev: navButton,
+        next: navButton,
+        last: navButton,
+        ellipsisIcon: navIcon,
+        firstIcon: navIcon,
+        prevIcon: navIcon,
+        nextIcon: navIcon,
+        lastIcon: navIcon
+    },
+    variants: {
+        activeColor: {
+            primary: {
+                item: 'data-[selected]:bg-primary data-[selected]:text-on-primary data-[selected]:hover:bg-primary/90'
+            },
+            secondary: {
+                item: 'data-[selected]:bg-secondary data-[selected]:text-on-secondary data-[selected]:hover:bg-secondary/90'
+            },
+            tertiary: {
+                item: 'data-[selected]:bg-tertiary data-[selected]:text-on-tertiary data-[selected]:hover:bg-tertiary/90'
+            },
+            success: {
+                item: 'data-[selected]:bg-success data-[selected]:text-on-success data-[selected]:hover:bg-success/90'
+            },
+            warning: {
+                item: 'data-[selected]:bg-warning data-[selected]:text-on-warning data-[selected]:hover:bg-warning/90'
+            },
+            error: {
+                item: 'data-[selected]:bg-error data-[selected]:text-on-error data-[selected]:hover:bg-error/90'
+            },
+            info: {
+                item: 'data-[selected]:bg-info data-[selected]:text-on-info data-[selected]:hover:bg-info/90'
+            },
+            surface: {
+                item: 'data-[selected]:bg-surface-container-highest data-[selected]:text-on-surface data-[selected]:hover:bg-surface-container-highest/90'
+            }
+        },
+        size: {
+            xs: {
+                list: 'gap-0.5',
+                item: 'size-7 text-xs',
+                ellipsis: 'size-7 text-xs',
+                first: 'size-7',
+                prev: 'size-7',
+                next: 'size-7',
+                last: 'size-7',
+                ellipsisIcon: 'size-3',
+                firstIcon: 'size-3',
+                prevIcon: 'size-3',
+                nextIcon: 'size-3',
+                lastIcon: 'size-3'
+            },
+            sm: {
+                list: 'gap-0.5',
+                item: 'size-8 text-xs',
+                ellipsis: 'size-8 text-xs',
+                first: 'size-8',
+                prev: 'size-8',
+                next: 'size-8',
+                last: 'size-8',
+                ellipsisIcon: 'size-3.5',
+                firstIcon: 'size-3.5',
+                prevIcon: 'size-3.5',
+                nextIcon: 'size-3.5',
+                lastIcon: 'size-3.5'
+            },
+            md: {
+                list: 'gap-1',
+                item: 'size-9 text-sm',
+                ellipsis: 'size-9 text-sm',
+                first: 'size-9',
+                prev: 'size-9',
+                next: 'size-9',
+                last: 'size-9',
+                ellipsisIcon: 'size-4',
+                firstIcon: 'size-4',
+                prevIcon: 'size-4',
+                nextIcon: 'size-4',
+                lastIcon: 'size-4'
+            },
+            lg: {
+                list: 'gap-1',
+                item: 'size-10 text-sm',
+                ellipsis: 'size-10 text-sm',
+                first: 'size-10',
+                prev: 'size-10',
+                next: 'size-10',
+                last: 'size-10',
+                ellipsisIcon: 'size-5',
+                firstIcon: 'size-5',
+                prevIcon: 'size-5',
+                nextIcon: 'size-5',
+                lastIcon: 'size-5'
+            },
+            xl: {
+                list: 'gap-1.5',
+                item: 'size-11 text-base',
+                ellipsis: 'size-11 text-base',
+                first: 'size-11',
+                prev: 'size-11',
+                next: 'size-11',
+                last: 'size-11',
+                ellipsisIcon: 'size-5',
+                firstIcon: 'size-5',
+                prevIcon: 'size-5',
+                nextIcon: 'size-5',
+                lastIcon: 'size-5'
+            }
+        },
+        disabled: {
+            true: {
+                root: 'opacity-50 pointer-events-none'
+            }
+        }
+    },
+    defaultVariants: {
+        activeColor: 'primary',
+        size: 'md'
+    }
+})
+
+export type PaginationVariantProps = VariantProps<typeof paginationVariants>
+export type PaginationSlots = keyof ReturnType<typeof paginationVariants>
+
+export const paginationDefaults = {
+    defaultVariants: paginationVariants.defaultVariants,
+    slots: {} as Partial<Record<PaginationSlots, string>>
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -27,6 +27,7 @@ export * from './Calendar/index.js'
 export * from './DropdownMenu/index.js'
 export * from './ContextMenu/index.js'
 export * from './Tabs/index.js'
+export * from './Pagination/index.js'
 
 // Configuration
 export { defineConfig } from './config.js'

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -37,7 +37,8 @@
         { href: '/calendar', label: 'Calendar', icon: 'lucide:calendar' },
         { href: '/dropdown-menu', label: 'Dropdown Menu', icon: 'lucide:chevron-down-square' },
         { href: '/tabs', label: 'Tabs', icon: 'lucide:panel-top' },
-        { href: '/context-menu', label: 'Context Menu', icon: 'lucide:mouse-pointer' }
+        { href: '/context-menu', label: 'Context Menu', icon: 'lucide:mouse-pointer' },
+        { href: '/pagination', label: 'Pagination', icon: 'lucide:chevrons-left-right-ellipsis' }
     ]
 
     const docItems = [

--- a/src/routes/pagination/+page.svelte
+++ b/src/routes/pagination/+page.svelte
@@ -1,0 +1,418 @@
+<script lang="ts">
+    import { Pagination, Button } from '$lib/index.js'
+
+    const colors = [
+        'primary',
+        'secondary',
+        'tertiary',
+        'success',
+        'warning',
+        'error',
+        'info',
+        'surface'
+    ] as const
+    const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const
+
+    let currentPage = $state(1)
+    let controlledPage = $state(5)
+    let callbackPage = $state(1)
+    let callbackLog = $state('')
+</script>
+
+<div class="space-y-12">
+    <header>
+        <h1 class="text-3xl font-bold text-on-surface">Pagination</h1>
+        <p class="mt-2 text-on-surface-variant">
+            Navigate through paginated content with page controls. Built on bits-ui Pagination
+            primitive.
+        </p>
+    </header>
+
+    <!-- Basic Usage -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Basic Usage</h2>
+        <p class="text-sm text-on-surface-variant">
+            Simple pagination with previous/next controls and page numbers.
+        </p>
+        <Pagination total={100} itemsPerPage={10} />
+    </section>
+
+    <!-- Default Page -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Default Page</h2>
+        <p class="text-sm text-on-surface-variant">
+            Set the initial page with the <code class="text-primary">defaultPage</code> prop.
+        </p>
+        <Pagination total={100} itemsPerPage={10} defaultPage={5} />
+    </section>
+
+    <!-- With Show Edges -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Show Edges</h2>
+        <p class="text-sm text-on-surface-variant">
+            Display first/last page buttons with the <code class="text-primary">showEdges</code> prop.
+        </p>
+        <Pagination total={100} itemsPerPage={10} showEdges />
+    </section>
+
+    <!-- Without Controls -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Without Controls</h2>
+        <p class="text-sm text-on-surface-variant">
+            Hide prev/next buttons with <code class="text-primary">showControls=false</code>.
+        </p>
+        <Pagination total={100} itemsPerPage={10} showControls={false} />
+    </section>
+
+    <!-- Show Edges Without Controls -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Show Edges Without Controls</h2>
+        <p class="text-sm text-on-surface-variant">
+            Combine <code class="text-primary">showEdges</code> with
+            <code class="text-primary">showControls=false</code> to show only first/last buttons.
+        </p>
+        <Pagination total={100} itemsPerPage={10} showEdges showControls={false} />
+    </section>
+
+    <!-- Sibling Count -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Sibling Count</h2>
+        <p class="text-sm text-on-surface-variant">
+            Control visible siblings around current page with the <code class="text-primary"
+                >siblingCount</code
+            > prop.
+        </p>
+        <div class="space-y-3">
+            <div>
+                <p class="mb-1 text-xs text-on-surface-variant">siblingCount=0</p>
+                <Pagination total={100} itemsPerPage={10} page={5} siblingCount={0} />
+            </div>
+            <div>
+                <p class="mb-1 text-xs text-on-surface-variant">siblingCount=1 (default)</p>
+                <Pagination total={100} itemsPerPage={10} page={5} siblingCount={1} />
+            </div>
+            <div>
+                <p class="mb-1 text-xs text-on-surface-variant">siblingCount=2</p>
+                <Pagination total={100} itemsPerPage={10} page={5} siblingCount={2} />
+            </div>
+        </div>
+    </section>
+
+    <!-- Items Per Page -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Items Per Page</h2>
+        <p class="text-sm text-on-surface-variant">
+            Control page count with the <code class="text-primary">itemsPerPage</code> prop. Same total
+            (100) with different items per page.
+        </p>
+        <div class="space-y-3">
+            <div>
+                <p class="mb-1 text-xs text-on-surface-variant">5 items/page (20 pages)</p>
+                <Pagination total={100} itemsPerPage={5} />
+            </div>
+            <div>
+                <p class="mb-1 text-xs text-on-surface-variant">10 items/page (10 pages)</p>
+                <Pagination total={100} itemsPerPage={10} />
+            </div>
+            <div>
+                <p class="mb-1 text-xs text-on-surface-variant">25 items/page (4 pages)</p>
+                <Pagination total={100} itemsPerPage={25} />
+            </div>
+            <div>
+                <p class="mb-1 text-xs text-on-surface-variant">50 items/page (2 pages)</p>
+                <Pagination total={100} itemsPerPage={50} />
+            </div>
+        </div>
+    </section>
+
+    <!-- Controlled State -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Controlled State</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="text-primary">bind:page</code> for two-way binding. Current page:
+            <code class="text-primary">{controlledPage}</code>
+        </p>
+        <Pagination total={200} itemsPerPage={10} bind:page={controlledPage} showEdges />
+        <div class="flex gap-2">
+            <Button
+                variant="solid"
+                color="primary"
+                size="sm"
+                label="Go to page 1"
+                onclick={() => (controlledPage = 1)}
+            />
+            <Button
+                variant="solid"
+                color="primary"
+                size="sm"
+                label="Go to page 10"
+                onclick={() => (controlledPage = 10)}
+            />
+            <Button
+                variant="solid"
+                color="primary"
+                size="sm"
+                label="Go to page 20"
+                onclick={() => (controlledPage = 20)}
+            />
+        </div>
+    </section>
+
+    <!-- Active Colors -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Active Colors</h2>
+        <p class="text-sm text-on-surface-variant">
+            Customize the active page color with the <code class="text-primary">activeColor</code> prop.
+        </p>
+        <div class="space-y-3">
+            {#each colors as color (color)}
+                <div class="flex items-center gap-4">
+                    <span class="w-20 text-sm text-on-surface-variant">{color}</span>
+                    <Pagination total={100} itemsPerPage={10} page={3} activeColor={color} />
+                </div>
+            {/each}
+        </div>
+    </section>
+
+    <!-- Sizes -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Sizes</h2>
+        <p class="text-sm text-on-surface-variant">
+            Control the pagination size with the <code class="text-primary">size</code> prop.
+        </p>
+        <div class="space-y-4">
+            {#each sizes as size (size)}
+                <div class="flex items-center gap-4">
+                    <span class="w-8 text-sm text-on-surface-variant">{size}</span>
+                    <Pagination total={100} itemsPerPage={10} {size} showEdges />
+                </div>
+            {/each}
+        </div>
+    </section>
+
+    <!-- Disabled -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Disabled</h2>
+        <p class="text-sm text-on-surface-variant">
+            Disable all pagination controls with the <code class="text-primary">disabled</code> prop.
+        </p>
+        <Pagination total={100} itemsPerPage={10} page={3} disabled showEdges />
+    </section>
+
+    <!-- Page Change Callback -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Page Change Callback</h2>
+        <p class="text-sm text-on-surface-variant">
+            Listen for page changes with <code class="text-primary">onPageChange</code>. Current
+            page: <code class="text-primary">{callbackPage}</code>
+        </p>
+        <Pagination
+            total={100}
+            itemsPerPage={10}
+            bind:page={callbackPage}
+            onPageChange={(p) => (callbackLog = `Page changed to ${p}`)}
+            showEdges
+        />
+        {#if callbackLog}
+            <p class="text-xs text-on-surface-variant">{callbackLog}</p>
+        {/if}
+    </section>
+
+    <!-- Custom Icons -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Custom Icons</h2>
+        <p class="text-sm text-on-surface-variant">
+            Customize navigation icons with
+            <code class="text-primary">firstIcon</code>,
+            <code class="text-primary">prevIcon</code>,
+            <code class="text-primary">nextIcon</code>,
+            <code class="text-primary">lastIcon</code>, and
+            <code class="text-primary">ellipsisIcon</code> props.
+        </p>
+        <Pagination
+            total={100}
+            itemsPerPage={10}
+            page={5}
+            showEdges
+            firstIcon="lucide:chevrons-left"
+            prevIcon="lucide:arrow-left"
+            nextIcon="lucide:arrow-right"
+            lastIcon="lucide:chevrons-right"
+            ellipsisIcon="lucide:more-horizontal"
+        />
+    </section>
+
+    <!-- Custom Snippet Slots -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Custom Snippet Slots</h2>
+        <p class="text-sm text-on-surface-variant">Override individual parts with snippet slots.</p>
+
+        <div class="space-y-4">
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">Custom item slot</p>
+                <Pagination total={50} itemsPerPage={10} page={2}>
+                    {#snippet itemSlot({ page, selected })}
+                        <span
+                            class="inline-flex size-9 items-center justify-center rounded-full text-sm font-bold {selected
+                                ? 'bg-primary text-on-primary'
+                                : 'text-on-surface-variant'}"
+                        >
+                            {page}
+                        </span>
+                    {/snippet}
+                </Pagination>
+            </div>
+
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">Custom prev/next slots</p>
+                <Pagination total={100} itemsPerPage={10} page={3}>
+                    {#snippet prevSlot({ disabled })}
+                        <span
+                            class="text-sm font-medium {disabled
+                                ? 'text-on-surface-variant/50'
+                                : 'text-primary'}"
+                        >
+                            Prev
+                        </span>
+                    {/snippet}
+                    {#snippet nextSlot({ disabled })}
+                        <span
+                            class="text-sm font-medium {disabled
+                                ? 'text-on-surface-variant/50'
+                                : 'text-primary'}"
+                        >
+                            Next
+                        </span>
+                    {/snippet}
+                </Pagination>
+            </div>
+
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">Custom first/last slots</p>
+                <Pagination total={100} itemsPerPage={10} page={5} showEdges>
+                    {#snippet firstSlot({ disabled })}
+                        <span
+                            class="text-xs {disabled
+                                ? 'text-on-surface-variant/50'
+                                : 'text-primary'}"
+                        >
+                            First
+                        </span>
+                    {/snippet}
+                    {#snippet lastSlot({ disabled })}
+                        <span
+                            class="text-xs {disabled
+                                ? 'text-on-surface-variant/50'
+                                : 'text-primary'}"
+                        >
+                            Last
+                        </span>
+                    {/snippet}
+                </Pagination>
+            </div>
+
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">Custom ellipsis slot</p>
+                <Pagination total={100} itemsPerPage={10} page={5}>
+                    {#snippet ellipsisSlot()}
+                        <span class="text-on-surface-variant">---</span>
+                    {/snippet}
+                </Pagination>
+            </div>
+        </div>
+    </section>
+
+    <!-- Edge Cases -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Edge Cases</h2>
+        <p class="text-sm text-on-surface-variant">
+            Handling special scenarios like single page, few pages, or many pages.
+        </p>
+        <div class="space-y-3">
+            <div>
+                <p class="mb-1 text-xs text-on-surface-variant">Single page (total=5, 10/page)</p>
+                <Pagination total={5} itemsPerPage={10} showEdges />
+            </div>
+            <div>
+                <p class="mb-1 text-xs text-on-surface-variant">Few pages (total=30, 10/page)</p>
+                <Pagination total={30} itemsPerPage={10} showEdges />
+            </div>
+            <div>
+                <p class="mb-1 text-xs text-on-surface-variant">Many pages (total=1000, 10/page)</p>
+                <Pagination total={1000} itemsPerPage={10} page={50} showEdges />
+            </div>
+            <div>
+                <p class="mb-1 text-xs text-on-surface-variant">Zero total</p>
+                <Pagination total={0} itemsPerPage={10} />
+            </div>
+        </div>
+    </section>
+
+    <!-- UI Slot Overrides -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">UI Slot Overrides</h2>
+        <p class="text-sm text-on-surface-variant">
+            Customize individual parts with the <code class="text-primary">ui</code> prop.
+        </p>
+        <div class="space-y-4">
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">Rounded buttons</p>
+                <Pagination
+                    total={100}
+                    itemsPerPage={10}
+                    page={3}
+                    showEdges
+                    ui={{
+                        item: 'rounded-full',
+                        first: 'rounded-full',
+                        prev: 'rounded-full',
+                        next: 'rounded-full',
+                        last: 'rounded-full'
+                    }}
+                />
+            </div>
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">Custom gap</p>
+                <Pagination total={100} itemsPerPage={10} page={3} ui={{ list: 'gap-2' }} />
+            </div>
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">Custom root class</p>
+                <Pagination
+                    total={100}
+                    itemsPerPage={10}
+                    page={3}
+                    class="rounded-lg border border-outline-variant bg-surface-container p-3"
+                />
+            </div>
+        </div>
+    </section>
+
+    <!-- Combined Features -->
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-on-surface">Combined Features</h2>
+        <p class="text-sm text-on-surface-variant">
+            Full example combining multiple features together.
+        </p>
+        <Pagination
+            total={200}
+            itemsPerPage={10}
+            bind:page={currentPage}
+            activeColor="success"
+            size="lg"
+            showEdges
+            siblingCount={2}
+            ui={{
+                item: 'rounded-full',
+                first: 'rounded-full',
+                prev: 'rounded-full',
+                next: 'rounded-full',
+                last: 'rounded-full',
+                list: 'gap-1.5'
+            }}
+        />
+        <p class="text-xs text-on-surface-variant">
+            Current page: <code class="text-primary">{currentPage}</code> | Size: lg | Color: success
+            | Edges: on | Siblings: 2 | Rounded
+        </p>
+    </section>
+</div>


### PR DESCRIPTION
## Summary

- Add `Pagination` component wrapping bits-ui `Pagination` primitives with tailwind-variants styling system
- Support full set of props: `page`, `defaultPage`, `total`, `itemsPerPage`, `siblingCount`, `showEdges`, `showControls`, `disabled`, `activeColor`, `size`
- Custom icon props (`firstIcon`, `prevIcon`, `nextIcon`, `lastIcon`, `ellipsisIcon`) and snippet slots (`itemSlot`, `prevSlot`, `nextSlot`, `firstSlot`, `lastSlot`, `ellipsisSlot`)
- UI slot overrides via `ui` prop for granular styling control
- Add 26 unit tests covering rendering, navigation, disabled state, size/color variants, callbacks, and slot overrides
- Add comprehensive demo page at `/pagination` with all feature cases

## New Files

| File | Description |
|---|---|
| `src/lib/Pagination/Pagination.svelte` | Main component using bits-ui primitives + Button component |
| `src/lib/Pagination/pagination.types.ts` | TypeScript interfaces (`PaginationProps`, slot props) |
| `src/lib/Pagination/pagination.variants.ts` | tailwind-variants definitions (size, activeColor, disabled) |
| `src/lib/Pagination/index.ts` | Public exports |
| `src/lib/Pagination/Pagination.svelte.spec.ts` | 26 unit tests |
| `src/routes/pagination/+page.svelte` | Demo page |

## Modified Files

| File | Change |
|---|---|
| `src/lib/index.ts` | Add Pagination export |
| `src/routes/+layout.svelte` | Add Pagination to sidebar navigation |

## Features

- **8 active colors**: primary, secondary, tertiary, success, warning, error, info, surface
- **5 sizes**: xs, sm, md, lg, xl
- **Navigation controls**: prev/next buttons (hideable via `showControls`)
- **Edge buttons**: first/last page buttons (via `showEdges`)
- **Two-way binding**: `bind:page` for controlled state
- **Callback**: `onPageChange` event
- **Disabled state**: disables all controls with reduced opacity
- **Snippet slots**: full customization of all interactive parts
- **UI overrides**: per-slot class overrides via `ui` prop
- **Performance**: split `$derived` computations (`baseClasses`, `controlClasses`, `edgeClasses`) to avoid unnecessary work

## Demo Cases

Basic | Default Page | Show Edges | Without Controls | Show Edges Without Controls | Sibling Count | Items Per Page | Controlled State | Active Colors | Sizes | Disabled | Page Change Callback | Custom Icons | Custom Snippet Slots | Edge Cases | UI Slot Overrides | Combined Features

## Test Plan

- [x] 26 unit tests pass (`npx vitest run src/lib/Pagination`)
- [x] `svelte-check` reports 0 errors
- [x] ESLint reports 0 errors
- [ ] Manual verification at `/pagination` route