### PR TITLE
fix: correct M3 container colors and sync ContextMenu icon color on highlight

### DIFF
--- a/src/lib/ContextMenu/context-menu.variants.ts
+++ b/src/lib/ContextMenu/context-menu.variants.ts
@@ -15,7 +15,7 @@ export const contextMenuVariants = tv({
         separator: '-mx-1 my-1 h-px bg-outline-variant',
         label: 'px-2 py-1.5 text-xs font-semibold text-on-surface-variant',
         item: [
-            'relative flex items-center gap-2 w-full rounded-sm px-2 cursor-pointer select-none',
+            'group relative flex items-center gap-2 w-full rounded-sm px-2 cursor-pointer select-none',
             'focus:outline-none',
             'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
             'data-[highlighted]:bg-surface-container-highest'
@@ -114,56 +114,56 @@ export const contextMenuVariants = tv({
             color: 'error',
             class: {
                 item: 'text-error data-[highlighted]:bg-error-container data-[highlighted]:text-on-error-container',
-                itemIcon: 'text-error'
+                itemIcon: 'text-error group-data-[highlighted]:text-on-error-container'
             }
         },
         {
             color: 'success',
             class: {
                 item: 'text-success data-[highlighted]:bg-success-container data-[highlighted]:text-on-success-container',
-                itemIcon: 'text-success'
+                itemIcon: 'text-success group-data-[highlighted]:text-on-success-container'
             }
         },
         {
             color: 'warning',
             class: {
                 item: 'text-warning data-[highlighted]:bg-warning-container data-[highlighted]:text-on-warning-container',
-                itemIcon: 'text-warning'
+                itemIcon: 'text-warning group-data-[highlighted]:text-on-warning-container'
             }
         },
         {
             color: 'info',
             class: {
                 item: 'text-info data-[highlighted]:bg-info-container data-[highlighted]:text-on-info-container',
-                itemIcon: 'text-info'
+                itemIcon: 'text-info group-data-[highlighted]:text-on-info-container'
             }
         },
         {
             color: 'primary',
             class: {
                 item: 'text-primary data-[highlighted]:bg-primary-container data-[highlighted]:text-on-primary-container',
-                itemIcon: 'text-primary'
+                itemIcon: 'text-primary group-data-[highlighted]:text-on-primary-container'
             }
         },
         {
             color: 'secondary',
             class: {
                 item: 'text-secondary data-[highlighted]:bg-secondary-container data-[highlighted]:text-on-secondary-container',
-                itemIcon: 'text-secondary'
+                itemIcon: 'text-secondary group-data-[highlighted]:text-on-secondary-container'
             }
         },
         {
             color: 'tertiary',
             class: {
                 item: 'text-tertiary data-[highlighted]:bg-tertiary-container data-[highlighted]:text-on-tertiary-container',
-                itemIcon: 'text-tertiary'
+                itemIcon: 'text-tertiary group-data-[highlighted]:text-on-tertiary-container'
             }
         },
         {
             color: 'surface',
             class: {
                 item: 'text-on-surface-variant data-[highlighted]:bg-surface-container-highest data-[highlighted]:text-on-surface',
-                itemIcon: 'text-on-surface-variant'
+                itemIcon: 'text-on-surface-variant group-data-[highlighted]:text-on-surface'
             }
         }
     ],

--- a/src/lib/theme.css
+++ b/src/lib/theme.css
@@ -23,44 +23,44 @@
     /* ========== PRIMARY ========== */
     --color-primary: oklch(0.546 0.245 262.88);
     --color-on-primary: oklch(1 0 0);
-    --color-primary-container: oklch(0.932 0.032 255.59);
-    --color-on-primary-container: oklch(0.283 0.091 267.94);
+    --color-primary-container: oklch(0.910 0.070 263);
+    --color-on-primary-container: oklch(0.283 0.090 263);
 
     /* ========== SECONDARY ========== */
     --color-secondary: oklch(0.446 0.043 257.28);
     --color-on-secondary: oklch(1 0 0);
-    --color-secondary-container: oklch(0.929 0.013 255.51);
-    --color-on-secondary-container: oklch(0.208 0.042 265.75);
+    --color-secondary-container: oklch(0.920 0.040 257);
+    --color-on-secondary-container: oklch(0.210 0.045 257);
 
     /* ========== TERTIARY ========== */
     --color-tertiary: oklch(0.541 0.281 293.54);
     --color-on-tertiary: oklch(1 0 0);
-    --color-tertiary-container: oklch(0.943 0.029 294.59);
-    --color-on-tertiary-container: oklch(0.283 0.141 291.09);
+    --color-tertiary-container: oklch(0.930 0.055 294);
+    --color-on-tertiary-container: oklch(0.283 0.105 294);
 
     /* ========== ERROR ========== */
     --color-error: oklch(0.577 0.245 27.33);
     --color-on-error: oklch(1 0 0);
-    --color-error-container: oklch(0.936 0.032 17.72);
-    --color-on-error-container: oklch(0.258 0.092 26.04);
+    --color-error-container: oklch(0.930 0.050 27);
+    --color-on-error-container: oklch(0.258 0.090 27);
 
     /* ========== SUCCESS ========== */
     --color-success: oklch(0.627 0.194 149.21);
     --color-on-success: oklch(1 0 0);
-    --color-success-container: oklch(0.962 0.044 156.74);
-    --color-on-success-container: oklch(0.266 0.065 152.93);
+    --color-success-container: oklch(0.935 0.060 149);
+    --color-on-success-container: oklch(0.266 0.065 149);
 
     /* ========== WARNING ========== */
     --color-warning: oklch(0.666 0.179 58.32);
     --color-on-warning: oklch(0.279 0.077 45.64);
-    --color-warning-container: oklch(0.962 0.059 95.26);
-    --color-on-warning-container: oklch(0.279 0.077 45.64);
+    --color-warning-container: oklch(0.940 0.070 58);
+    --color-on-warning-container: oklch(0.279 0.077 58);
 
     /* ========== INFO ========== */
     --color-info: oklch(0.598 0.158 241.97);
     --color-on-info: oklch(1 0 0);
-    --color-info-container: oklch(0.918 0.044 240.11);
-    --color-on-info-container: oklch(0.257 0.09 243.43);
+    --color-info-container: oklch(0.920 0.055 242);
+    --color-on-info-container: oklch(0.257 0.090 242);
 
     /* ========== SURFACE ========== */
     --color-surface: oklch(0.985 0.002 247.84);
@@ -95,44 +95,44 @@
     /* ========== PRIMARY ========== */
     --color-primary: oklch(0.707 0.165 254.62);
     --color-on-primary: oklch(0.379 0.146 265.52);
-    --color-primary-container: oklch(0.424 0.199 265.64);
-    --color-on-primary-container: oklch(0.882 0.059 254.13);
+    --color-primary-container: oklch(0.380 0.130 263);
+    --color-on-primary-container: oklch(0.890 0.065 255);
 
     /* ========== SECONDARY ========== */
     --color-secondary: oklch(0.704 0.04 256.79);
     --color-on-secondary: oklch(0.279 0.041 260.03);
-    --color-secondary-container: oklch(0.372 0.044 257.29);
-    --color-on-secondary-container: oklch(0.869 0.022 252.89);
+    --color-secondary-container: oklch(0.372 0.044 257);
+    --color-on-secondary-container: oklch(0.880 0.025 255);
 
     /* ========== TERTIARY ========== */
     --color-tertiary: oklch(0.702 0.183 293.54);
     --color-on-tertiary: oklch(0.368 0.174 292.52);
-    --color-tertiary-container: oklch(0.432 0.232 292.76);
-    --color-on-tertiary-container: oklch(0.894 0.057 293.28);
+    --color-tertiary-container: oklch(0.370 0.140 293);
+    --color-on-tertiary-container: oklch(0.890 0.060 293);
 
     /* ========== ERROR ========== */
     --color-error: oklch(0.704 0.191 22.22);
     --color-on-error: oklch(0.396 0.141 25.72);
-    --color-error-container: oklch(0.444 0.177 26.9);
-    --color-on-error-container: oklch(0.885 0.062 18.33);
+    --color-error-container: oklch(0.400 0.120 25);
+    --color-on-error-container: oklch(0.890 0.060 22);
 
     /* ========== SUCCESS ========== */
     --color-success: oklch(0.792 0.209 151.71);
     --color-on-success: oklch(0.393 0.095 152.54);
-    --color-success-container: oklch(0.448 0.119 151.33);
-    --color-on-success-container: oklch(0.871 0.15 154.45);
+    --color-success-container: oklch(0.390 0.100 151);
+    --color-on-success-container: oklch(0.880 0.075 152);
 
     /* ========== WARNING ========== */
     --color-warning: oklch(0.828 0.189 84.43);
     --color-on-warning: oklch(0.414 0.112 45.9);
-    --color-warning-container: oklch(0.473 0.137 46.2);
-    --color-on-warning-container: oklch(0.879 0.169 91.61);
+    --color-warning-container: oklch(0.400 0.110 70);
+    --color-on-warning-container: oklch(0.890 0.080 75);
 
     /* ========== INFO ========== */
     --color-info: oklch(0.697 0.127 241.97);
     --color-on-info: oklch(0.32 0.103 243.43);
-    --color-info-container: oklch(0.398 0.125 242.76);
-    --color-on-info-container: oklch(0.869 0.066 240.11);
+    --color-info-container: oklch(0.370 0.105 242);
+    --color-on-info-container: oklch(0.880 0.065 242);
 
     /* ========== SURFACE ========== */
     --color-surface: oklch(0.145 0.014 247.09);

--- a/src/lib/theme.css
+++ b/src/lib/theme.css
@@ -23,44 +23,44 @@
     /* ========== PRIMARY ========== */
     --color-primary: oklch(0.546 0.245 262.88);
     --color-on-primary: oklch(1 0 0);
-    --color-primary-container: oklch(0.910 0.070 263);
-    --color-on-primary-container: oklch(0.283 0.090 263);
+    --color-primary-container: oklch(0.91 0.07 263);
+    --color-on-primary-container: oklch(0.283 0.09 263);
 
     /* ========== SECONDARY ========== */
     --color-secondary: oklch(0.446 0.043 257.28);
     --color-on-secondary: oklch(1 0 0);
-    --color-secondary-container: oklch(0.920 0.040 257);
-    --color-on-secondary-container: oklch(0.210 0.045 257);
+    --color-secondary-container: oklch(0.92 0.04 257);
+    --color-on-secondary-container: oklch(0.21 0.045 257);
 
     /* ========== TERTIARY ========== */
     --color-tertiary: oklch(0.541 0.281 293.54);
     --color-on-tertiary: oklch(1 0 0);
-    --color-tertiary-container: oklch(0.930 0.055 294);
+    --color-tertiary-container: oklch(0.93 0.055 294);
     --color-on-tertiary-container: oklch(0.283 0.105 294);
 
     /* ========== ERROR ========== */
     --color-error: oklch(0.577 0.245 27.33);
     --color-on-error: oklch(1 0 0);
-    --color-error-container: oklch(0.930 0.050 27);
-    --color-on-error-container: oklch(0.258 0.090 27);
+    --color-error-container: oklch(0.93 0.05 27);
+    --color-on-error-container: oklch(0.258 0.09 27);
 
     /* ========== SUCCESS ========== */
     --color-success: oklch(0.627 0.194 149.21);
     --color-on-success: oklch(1 0 0);
-    --color-success-container: oklch(0.935 0.060 149);
+    --color-success-container: oklch(0.935 0.06 149);
     --color-on-success-container: oklch(0.266 0.065 149);
 
     /* ========== WARNING ========== */
     --color-warning: oklch(0.666 0.179 58.32);
     --color-on-warning: oklch(0.279 0.077 45.64);
-    --color-warning-container: oklch(0.940 0.070 58);
+    --color-warning-container: oklch(0.94 0.07 58);
     --color-on-warning-container: oklch(0.279 0.077 58);
 
     /* ========== INFO ========== */
     --color-info: oklch(0.598 0.158 241.97);
     --color-on-info: oklch(1 0 0);
-    --color-info-container: oklch(0.920 0.055 242);
-    --color-on-info-container: oklch(0.257 0.090 242);
+    --color-info-container: oklch(0.92 0.055 242);
+    --color-on-info-container: oklch(0.257 0.09 242);
 
     /* ========== SURFACE ========== */
     --color-surface: oklch(0.985 0.002 247.84);
@@ -95,44 +95,44 @@
     /* ========== PRIMARY ========== */
     --color-primary: oklch(0.707 0.165 254.62);
     --color-on-primary: oklch(0.379 0.146 265.52);
-    --color-primary-container: oklch(0.380 0.130 263);
-    --color-on-primary-container: oklch(0.890 0.065 255);
+    --color-primary-container: oklch(0.38 0.13 263);
+    --color-on-primary-container: oklch(0.89 0.065 255);
 
     /* ========== SECONDARY ========== */
     --color-secondary: oklch(0.704 0.04 256.79);
     --color-on-secondary: oklch(0.279 0.041 260.03);
     --color-secondary-container: oklch(0.372 0.044 257);
-    --color-on-secondary-container: oklch(0.880 0.025 255);
+    --color-on-secondary-container: oklch(0.88 0.025 255);
 
     /* ========== TERTIARY ========== */
     --color-tertiary: oklch(0.702 0.183 293.54);
     --color-on-tertiary: oklch(0.368 0.174 292.52);
-    --color-tertiary-container: oklch(0.370 0.140 293);
-    --color-on-tertiary-container: oklch(0.890 0.060 293);
+    --color-tertiary-container: oklch(0.37 0.14 293);
+    --color-on-tertiary-container: oklch(0.89 0.06 293);
 
     /* ========== ERROR ========== */
     --color-error: oklch(0.704 0.191 22.22);
     --color-on-error: oklch(0.396 0.141 25.72);
-    --color-error-container: oklch(0.400 0.120 25);
-    --color-on-error-container: oklch(0.890 0.060 22);
+    --color-error-container: oklch(0.4 0.12 25);
+    --color-on-error-container: oklch(0.89 0.06 22);
 
     /* ========== SUCCESS ========== */
     --color-success: oklch(0.792 0.209 151.71);
     --color-on-success: oklch(0.393 0.095 152.54);
-    --color-success-container: oklch(0.390 0.100 151);
-    --color-on-success-container: oklch(0.880 0.075 152);
+    --color-success-container: oklch(0.39 0.1 151);
+    --color-on-success-container: oklch(0.88 0.075 152);
 
     /* ========== WARNING ========== */
     --color-warning: oklch(0.828 0.189 84.43);
     --color-on-warning: oklch(0.414 0.112 45.9);
-    --color-warning-container: oklch(0.400 0.110 70);
-    --color-on-warning-container: oklch(0.890 0.080 75);
+    --color-warning-container: oklch(0.4 0.11 70);
+    --color-on-warning-container: oklch(0.89 0.08 75);
 
     /* ========== INFO ========== */
     --color-info: oklch(0.697 0.127 241.97);
     --color-on-info: oklch(0.32 0.103 243.43);
-    --color-info-container: oklch(0.370 0.105 242);
-    --color-on-info-container: oklch(0.880 0.065 242);
+    --color-info-container: oklch(0.37 0.105 242);
+    --color-on-info-container: oklch(0.88 0.065 242);
 
     /* ========== SURFACE ========== */
     --color-surface: oklch(0.145 0.014 247.09);


### PR DESCRIPTION
## Summary

### 1. Fix theme container colors (`theme.css`)

Recalculated all `-container` and `-on-container` color values to follow **Material Design 3 tonal palette** principles.

#### Light theme

| Color | Issue | Before | After |
|---|---|---|---|
| `primary-container` | Chroma too low, appeared gray | `0.032` chroma, hue `255` | `0.070` chroma, hue `263` |
| `secondary-container` | Chroma too low, nearly white | `0.013` chroma, hue `255` | `0.040` chroma, hue `257` |
| `tertiary-container` | Chroma too low | `0.029` chroma | `0.055` chroma |
| `on-tertiary-container` | Chroma too high, poor readability | `0.141` chroma | `0.105` chroma |
| `error-container` | Hue misaligned by 10° from main | hue `17` | hue `27` |
| `success-container` | Hue misaligned by 7° from main | hue `156` | hue `149` |
| `warning-container` | **Wrong hue entirely** — displayed green instead of amber | hue `95` (green) | hue `58` (amber) |
| `info-container` | Chroma too low | `0.044` chroma | `0.055` chroma |

#### Dark theme

| Color | Issue | Before | After |
|---|---|---|---|
| `primary-container` | Oversaturated | `0.199` chroma | `0.130` chroma |
| `tertiary-container` | Extremely oversaturated | `0.232` chroma | `0.140` chroma |
| `error-container` | Chroma too high | `0.177` chroma | `0.120` chroma |
| `success-on-container` | Text oversaturated, poor readability | `0.150` chroma | `0.075` chroma |
| `warning-container` | Hue misaligned from main (84) | hue `46` | hue `70` |
| `warning-on-container` | High chroma + hue off by 45° | `0.169` chroma, hue `91` | `0.080` chroma, hue `75` |

**M3 guidelines applied:**

| | Light container | Dark container | Light on-container | Dark on-container |
|---|---|---|---|---|
| Lightness | ~0.91–0.94 | ~0.37–0.40 | ~0.25–0.28 | ~0.88–0.89 |
| Chroma | ~0.04–0.07 | ~0.10–0.14 | ~0.06–0.10 | ~0.06–0.08 |
| Hue | = main color | = main color | = main color | = main color |

---

### 2. Sync ContextMenu icon color on highlight (`context-menu.variants.ts`)

When hovering a menu item with a color variant (error, success, etc.), the text color changed to `on-{color}-container` but the **icon stayed at `text-{color}`** — causing a visible color mismatch between icon and text.

**Changes:**
- Added `group` class to the base `item` slot
- Added `group-data-[highlighted]:text-on-{color}-container` to `itemIcon` across all 8 color compound variants

## Test plan

- [ ] Verify light theme: container colors show clear semantic tint, not washed out
- [ ] Verify dark theme: containers are not oversaturated, on-container text is readable
- [ ] Verify ContextMenu: hovering colored items shows matching icon and text color
- [ ] Verify dark mode for ContextMenu colored items
