### PR TITLE
feat: add FieldGroup component

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,17 +104,28 @@ pnpm add sv5ui
 | Component                            | Description                                                                    |
 | :----------------------------------- | :----------------------------------------------------------------------------- |
 | [**Breadcrumb**](src/lib/Breadcrumb) | Hierarchical navigation trail with icons, custom separators, and snippet slots |
+| [**Tabs**](src/lib/Tabs)             | Tabbed interface with content panels and configurable orientation               |
+| [**Pagination**](src/lib/Pagination) | Page navigation with first/prev/next/last controls and ellipsis                |
 
 ### Overlay
 
-| Component                          | Description                                                               |
-| :--------------------------------- | :------------------------------------------------------------------------ |
-| [**Modal**](src/lib/Modal)         | Accessible dialog with overlay, focus trap, and scroll lock               |
-| [**Slideover**](src/lib/Slideover) | Side panel sliding from any edge with inset mode                          |
-| [**Drawer**](src/lib/Drawer)       | Draggable bottom/side sheet with snap points                              |
-| [**Tooltip**](src/lib/Tooltip)     | Hover tooltip with arrow, keyboard shortcut display, and portal rendering |
-| [**Popover**](src/lib/Popover)     | Floating interactive content panel with focus management                  |
-| [**Accordion**](src/lib/Accordion) | Expandable sections with single or multiple open modes                    |
+| Component                              | Description                                                               |
+| :------------------------------------- | :------------------------------------------------------------------------ |
+| [**Modal**](src/lib/Modal)             | Accessible dialog with overlay, focus trap, and scroll lock               |
+| [**Slideover**](src/lib/Slideover)     | Side panel sliding from any edge with inset mode                          |
+| [**Drawer**](src/lib/Drawer)           | Draggable bottom/side sheet with snap points                              |
+| [**Tooltip**](src/lib/Tooltip)         | Hover tooltip with arrow, keyboard shortcut display, and portal rendering |
+| [**Popover**](src/lib/Popover)         | Floating interactive content panel with focus management                  |
+| [**Accordion**](src/lib/Accordion)     | Expandable sections with single or multiple open modes                    |
+| [**DropdownMenu**](src/lib/DropdownMenu) | Triggered floating menu with items, groups, separators, and sub-menus   |
+| [**ContextMenu**](src/lib/ContextMenu) | Right-click context menu with items, colors, and keyboard navigation      |
+
+### Form
+
+| Component                            | Description                                                                       |
+| :----------------------------------- | :-------------------------------------------------------------------------------- |
+| [**Calendar**](src/lib/Calendar)     | Date picker calendar with single, multiple, and range selection modes              |
+| [**FieldGroup**](src/lib/FieldGroup) | Groups buttons and inputs with seamless borders and shared size/orientation context |
 
 ## Theming
 

--- a/README.md
+++ b/README.md
@@ -104,27 +104,27 @@ pnpm add sv5ui
 | Component                            | Description                                                                    |
 | :----------------------------------- | :----------------------------------------------------------------------------- |
 | [**Breadcrumb**](src/lib/Breadcrumb) | Hierarchical navigation trail with icons, custom separators, and snippet slots |
-| [**Tabs**](src/lib/Tabs)             | Tabbed interface with content panels and configurable orientation               |
+| [**Tabs**](src/lib/Tabs)             | Tabbed interface with content panels and configurable orientation              |
 | [**Pagination**](src/lib/Pagination) | Page navigation with first/prev/next/last controls and ellipsis                |
 
 ### Overlay
 
-| Component                              | Description                                                               |
-| :------------------------------------- | :------------------------------------------------------------------------ |
-| [**Modal**](src/lib/Modal)             | Accessible dialog with overlay, focus trap, and scroll lock               |
-| [**Slideover**](src/lib/Slideover)     | Side panel sliding from any edge with inset mode                          |
-| [**Drawer**](src/lib/Drawer)           | Draggable bottom/side sheet with snap points                              |
-| [**Tooltip**](src/lib/Tooltip)         | Hover tooltip with arrow, keyboard shortcut display, and portal rendering |
-| [**Popover**](src/lib/Popover)         | Floating interactive content panel with focus management                  |
-| [**Accordion**](src/lib/Accordion)     | Expandable sections with single or multiple open modes                    |
-| [**DropdownMenu**](src/lib/DropdownMenu) | Triggered floating menu with items, groups, separators, and sub-menus   |
-| [**ContextMenu**](src/lib/ContextMenu) | Right-click context menu with items, colors, and keyboard navigation      |
+| Component                                | Description                                                               |
+| :--------------------------------------- | :------------------------------------------------------------------------ |
+| [**Modal**](src/lib/Modal)               | Accessible dialog with overlay, focus trap, and scroll lock               |
+| [**Slideover**](src/lib/Slideover)       | Side panel sliding from any edge with inset mode                          |
+| [**Drawer**](src/lib/Drawer)             | Draggable bottom/side sheet with snap points                              |
+| [**Tooltip**](src/lib/Tooltip)           | Hover tooltip with arrow, keyboard shortcut display, and portal rendering |
+| [**Popover**](src/lib/Popover)           | Floating interactive content panel with focus management                  |
+| [**Accordion**](src/lib/Accordion)       | Expandable sections with single or multiple open modes                    |
+| [**DropdownMenu**](src/lib/DropdownMenu) | Triggered floating menu with items, groups, separators, and sub-menus     |
+| [**ContextMenu**](src/lib/ContextMenu)   | Right-click context menu with items, colors, and keyboard navigation      |
 
 ### Form
 
-| Component                            | Description                                                                       |
-| :----------------------------------- | :-------------------------------------------------------------------------------- |
-| [**Calendar**](src/lib/Calendar)     | Date picker calendar with single, multiple, and range selection modes              |
+| Component                            | Description                                                                         |
+| :----------------------------------- | :---------------------------------------------------------------------------------- |
+| [**Calendar**](src/lib/Calendar)     | Date picker calendar with single, multiple, and range selection modes               |
 | [**FieldGroup**](src/lib/FieldGroup) | Groups buttons and inputs with seamless borders and shared size/orientation context |
 
 ## Theming

--- a/src/lib/Button/Button.svelte
+++ b/src/lib/Button/Button.svelte
@@ -8,9 +8,12 @@
     import { Button } from 'bits-ui'
     import { buttonVariants, buttonDefaults } from './button.variants.js'
     import { getComponentConfig, iconsDefaults } from '../config.js'
+    import { getContext } from 'svelte'
+    import { fieldGroupVariant } from '../FieldGroup/field-group.variants.js'
     import Icon from '../Icon/Icon.svelte'
     import Avatar from '../Avatar/Avatar.svelte'
     import type { AvatarSize } from '../Avatar/avatar.types.js'
+    import type { FieldGroupVariantProps } from '../FieldGroup/field-group.variants.js'
 
     const config = getComponentConfig('button', buttonDefaults)
     const icons = getComponentConfig('icons', iconsDefaults)
@@ -20,7 +23,7 @@
         ui,
         color = config.defaultVariants.color,
         variant = config.defaultVariants.variant,
-        size = config.defaultVariants.size,
+        size,
         label,
         loading = false,
         loadingIcon = icons.loading,
@@ -39,6 +42,21 @@
         ...restProps
     }: Props = $props()
 
+    const fieldGroupContext = getContext<
+        | {
+              orientation: NonNullable<FieldGroupVariantProps['orientation']>
+              size: NonNullable<FieldGroupVariantProps['size']>
+          }
+        | undefined
+    >('fieldGroup')
+
+    const resolvedSize = $derived(size ?? fieldGroupContext?.size ?? config.defaultVariants.size)
+    const fieldGroupClass = $derived(
+        fieldGroupContext
+            ? fieldGroupVariant.fieldGroup[fieldGroupContext.orientation ?? 'horizontal']
+            : undefined
+    )
+
     const isIconOnly = $derived(square || (!label && !children))
     const isLeading = $derived((!!icon && !trailing) || (loading && !trailing) || !!leadingIcon)
     const isTrailing = $derived((!!icon && trailing) || (loading && trailing) || !!trailingIcon)
@@ -56,7 +74,7 @@
         const slots = buttonVariants({
             variant,
             color,
-            size,
+            size: resolvedSize,
             block,
             square: isIconOnly,
             loading,
@@ -64,7 +82,7 @@
             trailing: isTrailing
         })
         return {
-            base: slots.base({ class: [config.slots.base, className, ui?.base] }),
+            base: slots.base({ class: [config.slots.base, fieldGroupClass, className, ui?.base] }),
             label: slots.label({ class: [config.slots.label, ui?.label] }),
             leadingIcon: slots.leadingIcon({ class: [config.slots.leadingIcon, ui?.leadingIcon] }),
             trailingIcon: slots.trailingIcon({

--- a/src/lib/DropdownMenu/dropdown-menu.variants.ts
+++ b/src/lib/DropdownMenu/dropdown-menu.variants.ts
@@ -15,7 +15,7 @@ export const dropdownMenuVariants = tv({
         separator: '-mx-1 my-1 h-px bg-outline-variant',
         label: 'px-2 py-1.5 text-xs font-semibold text-on-surface-variant',
         item: [
-            'relative flex items-center gap-2 w-full rounded-sm px-2 cursor-pointer select-none',
+            'group relative flex items-center gap-2 w-full rounded-sm px-2 cursor-pointer select-none',
             'focus:outline-none',
             'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
             'data-[highlighted]:bg-surface-container-highest'
@@ -133,56 +133,56 @@ export const dropdownMenuVariants = tv({
             color: 'error',
             class: {
                 item: 'text-error data-[highlighted]:bg-error-container data-[highlighted]:text-on-error-container',
-                itemIcon: 'text-error'
+                itemIcon: 'text-error group-data-[highlighted]:text-on-error-container'
             }
         },
         {
             color: 'success',
             class: {
                 item: 'text-success data-[highlighted]:bg-success-container data-[highlighted]:text-on-success-container',
-                itemIcon: 'text-success'
+                itemIcon: 'text-success group-data-[highlighted]:text-on-success-container'
             }
         },
         {
             color: 'warning',
             class: {
                 item: 'text-warning data-[highlighted]:bg-warning-container data-[highlighted]:text-on-warning-container',
-                itemIcon: 'text-warning'
+                itemIcon: 'text-warning group-data-[highlighted]:text-on-warning-container'
             }
         },
         {
             color: 'info',
             class: {
                 item: 'text-info data-[highlighted]:bg-info-container data-[highlighted]:text-on-info-container',
-                itemIcon: 'text-info'
+                itemIcon: 'text-info group-data-[highlighted]:text-on-info-container'
             }
         },
         {
             color: 'primary',
             class: {
                 item: 'text-primary data-[highlighted]:bg-primary-container data-[highlighted]:text-on-primary-container',
-                itemIcon: 'text-primary'
+                itemIcon: 'text-primary group-data-[highlighted]:text-on-primary-container'
             }
         },
         {
             color: 'secondary',
             class: {
                 item: 'text-secondary data-[highlighted]:bg-secondary-container data-[highlighted]:text-on-secondary-container',
-                itemIcon: 'text-secondary'
+                itemIcon: 'text-secondary group-data-[highlighted]:text-on-secondary-container'
             }
         },
         {
             color: 'tertiary',
             class: {
                 item: 'text-tertiary data-[highlighted]:bg-tertiary-container data-[highlighted]:text-on-tertiary-container',
-                itemIcon: 'text-tertiary'
+                itemIcon: 'text-tertiary group-data-[highlighted]:text-on-tertiary-container'
             }
         },
         {
             color: 'surface',
             class: {
                 item: 'text-on-surface-variant data-[highlighted]:bg-surface-container-highest data-[highlighted]:text-on-surface',
-                itemIcon: 'text-on-surface-variant'
+                itemIcon: 'text-on-surface-variant group-data-[highlighted]:text-on-surface'
             }
         }
     ],

--- a/src/lib/FieldGroup/FieldGroup.svelte
+++ b/src/lib/FieldGroup/FieldGroup.svelte
@@ -1,0 +1,48 @@
+<script lang="ts" module>
+    import type { FieldGroupProps } from './field-group.types.js'
+
+    export type Props = FieldGroupProps
+</script>
+
+<script lang="ts">
+    import { fieldGroupVariants, fieldGroupDefaults } from './field-group.variants.js'
+    import { getComponentConfig } from '../config.js'
+    import { setContext } from 'svelte'
+
+    const config = getComponentConfig('fieldGroup', fieldGroupDefaults)
+
+    let {
+        as = 'div',
+        ui,
+        size = config.defaultVariants.size ?? 'md',
+        orientation = config.defaultVariants.orientation ?? 'horizontal',
+        class: className,
+        children,
+        ...restProps
+    }: Props = $props()
+
+    const classes = $derived.by(() => {
+        const slots = fieldGroupVariants({ size, orientation })
+        return {
+            root: slots.root({ class: [config.slots.root, className, ui?.root] })
+        }
+    })
+
+    setContext<{
+        orientation: NonNullable<Props['orientation']>
+        size: NonNullable<Props['size']>
+    }>('fieldGroup', {
+        get orientation() {
+            return orientation
+        },
+        get size() {
+            return size
+        }
+    })
+</script>
+
+<svelte:element this={as} class={classes.root} data-orientation={orientation} {...restProps}>
+    {#if children}
+        {@render children()}
+    {/if}
+</svelte:element>

--- a/src/lib/FieldGroup/FieldGroup.svelte.spec.ts
+++ b/src/lib/FieldGroup/FieldGroup.svelte.spec.ts
@@ -47,7 +47,9 @@ describe('FieldGroup', () => {
 
         it('should render multiple children', () => {
             const { container } = render(FieldGroup, {
-                children: snippet('<div><button>A</button><button>B</button><button>C</button></div>')
+                children: snippet(
+                    '<div><button>A</button><button>B</button><button>C</button></div>'
+                )
             })
             const buttons = container.querySelectorAll('button')
             expect(buttons.length).toBe(3)
@@ -227,7 +229,9 @@ describe('FieldGroup', () => {
         it('should render horizontal group with children and correct structure', () => {
             const { container } = render(FieldGroup, {
                 orientation: 'horizontal',
-                children: snippet('<div><button>A</button><button>B</button><button>C</button></div>')
+                children: snippet(
+                    '<div><button>A</button><button>B</button><button>C</button></div>'
+                )
             })
             const root = getRoot(container)
             const buttons = container.querySelectorAll('button')

--- a/src/lib/FieldGroup/FieldGroup.svelte.spec.ts
+++ b/src/lib/FieldGroup/FieldGroup.svelte.spec.ts
@@ -1,0 +1,274 @@
+import { page } from 'vitest/browser'
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-svelte'
+import { createRawSnippet } from 'svelte'
+import FieldGroup from './FieldGroup.svelte'
+
+function snippet(html: string) {
+    return createRawSnippet(() => ({
+        render: () => html,
+        setup: () => {}
+    }))
+}
+
+describe('FieldGroup', () => {
+    const getRoot = (container: Element) => container.firstElementChild as HTMLElement
+
+    // ==================== RENDERING ====================
+
+    describe('rendering', () => {
+        it('should render the root element', async () => {
+            const { container } = render(FieldGroup)
+            const root = page.elementLocator(getRoot(container))
+            await expect.element(root).toBeInTheDocument()
+        })
+
+        it('should render as div by default', () => {
+            const { container } = render(FieldGroup)
+            expect(getRoot(container).tagName).toBe('DIV')
+        })
+
+        it('should apply base root class', () => {
+            const { container } = render(FieldGroup)
+            expect(getRoot(container).className).toContain('relative')
+        })
+
+        it('should render children content', () => {
+            const { container } = render(FieldGroup, {
+                children: snippet('<button>Click</button>')
+            })
+            expect(container.textContent).toContain('Click')
+        })
+
+        it('should render nothing when no children provided', () => {
+            const { container } = render(FieldGroup)
+            expect(getRoot(container).children.length).toBe(0)
+        })
+
+        it('should render multiple children', () => {
+            const { container } = render(FieldGroup, {
+                children: snippet('<div><button>A</button><button>B</button><button>C</button></div>')
+            })
+            const buttons = container.querySelectorAll('button')
+            expect(buttons.length).toBe(3)
+        })
+    })
+
+    // ==================== AS PROP ====================
+
+    describe('as prop', () => {
+        it('should render as section element', () => {
+            const { container } = render(FieldGroup, { as: 'section' })
+            expect(getRoot(container).tagName).toBe('SECTION')
+        })
+
+        it('should render as span element', () => {
+            const { container } = render(FieldGroup, { as: 'span' })
+            expect(getRoot(container).tagName).toBe('SPAN')
+        })
+
+        it('should render as nav element', () => {
+            const { container } = render(FieldGroup, { as: 'nav' })
+            expect(getRoot(container).tagName).toBe('NAV')
+        })
+    })
+
+    // ==================== ORIENTATION ====================
+
+    describe('orientation', () => {
+        it('should default to horizontal orientation', () => {
+            const { container } = render(FieldGroup)
+            const root = getRoot(container)
+            expect(root.className).toContain('inline-flex')
+            expect(root.className).toContain('-space-x-px')
+        })
+
+        it('should set data-orientation to horizontal by default', () => {
+            const { container } = render(FieldGroup)
+            expect(getRoot(container).getAttribute('data-orientation')).toBe('horizontal')
+        })
+
+        it('should apply horizontal orientation classes', () => {
+            const { container } = render(FieldGroup, { orientation: 'horizontal' })
+            const root = getRoot(container)
+            expect(root.className).toContain('inline-flex')
+            expect(root.className).toContain('-space-x-px')
+        })
+
+        it('should apply vertical orientation classes', () => {
+            const { container } = render(FieldGroup, { orientation: 'vertical' })
+            const root = getRoot(container)
+            expect(root.className).toContain('flex')
+            expect(root.className).toContain('flex-col')
+            expect(root.className).toContain('-space-y-px')
+        })
+
+        it('should set data-orientation to vertical', () => {
+            const { container } = render(FieldGroup, { orientation: 'vertical' })
+            expect(getRoot(container).getAttribute('data-orientation')).toBe('vertical')
+        })
+
+        it('should not apply vertical classes when horizontal', () => {
+            const { container } = render(FieldGroup, { orientation: 'horizontal' })
+            const root = getRoot(container)
+            expect(root.className).not.toContain('flex-col')
+            expect(root.className).not.toContain('-space-y-px')
+        })
+
+        it('should not apply horizontal spacing when vertical', () => {
+            const { container } = render(FieldGroup, { orientation: 'vertical' })
+            expect(getRoot(container).className).not.toContain('-space-x-px')
+        })
+    })
+
+    // ==================== SIZE ====================
+
+    describe('size', () => {
+        const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const
+
+        for (const size of sizes) {
+            it(`should accept size="${size}" without error`, () => {
+                const { container } = render(FieldGroup, { size })
+                expect(getRoot(container)).not.toBeNull()
+            })
+        }
+
+        it('should default to md size', () => {
+            const { container } = render(FieldGroup)
+            expect(getRoot(container)).not.toBeNull()
+        })
+    })
+
+    // ==================== CUSTOM CLASS ====================
+
+    describe('custom class', () => {
+        it('should apply custom class to root', () => {
+            const { container } = render(FieldGroup, { class: 'my-group' })
+            expect(getRoot(container).className).toContain('my-group')
+        })
+
+        it('should merge custom class with variant classes', () => {
+            const { container } = render(FieldGroup, { class: 'my-group' })
+            const root = getRoot(container)
+            expect(root.className).toContain('my-group')
+            expect(root.className).toContain('relative')
+            expect(root.className).toContain('inline-flex')
+        })
+    })
+
+    // ==================== UI SLOT OVERRIDES ====================
+
+    describe('ui slot overrides', () => {
+        it('should apply ui.root class', () => {
+            const { container } = render(FieldGroup, { ui: { root: 'custom-root' } })
+            expect(getRoot(container).className).toContain('custom-root')
+        })
+
+        it('should merge ui.root with base classes', () => {
+            const { container } = render(FieldGroup, { ui: { root: 'custom-root' } })
+            const root = getRoot(container)
+            expect(root.className).toContain('custom-root')
+            expect(root.className).toContain('relative')
+        })
+    })
+
+    // ==================== HTML ATTRIBUTES ====================
+
+    describe('html attributes', () => {
+        it('should pass through HTML attributes', () => {
+            const { container } = render(FieldGroup, {
+                id: 'my-field-group',
+                title: 'Field group'
+            })
+            const root = getRoot(container)
+            expect(root.getAttribute('id')).toBe('my-field-group')
+            expect(root.getAttribute('title')).toBe('Field group')
+        })
+
+        it('should apply role attribute', () => {
+            const { container } = render(FieldGroup, { role: 'group' })
+            expect(getRoot(container).getAttribute('role')).toBe('group')
+        })
+
+        it('should apply aria attributes', () => {
+            const { container } = render(FieldGroup, { 'aria-label': 'Button group' })
+            expect(getRoot(container).getAttribute('aria-label')).toBe('Button group')
+        })
+    })
+
+    // ==================== COMBINED FEATURES ====================
+
+    describe('combined features', () => {
+        it('should apply vertical orientation with custom class', () => {
+            const { container } = render(FieldGroup, {
+                orientation: 'vertical',
+                class: 'my-vertical-group'
+            })
+            const root = getRoot(container)
+            expect(root.className).toContain('flex-col')
+            expect(root.className).toContain('-space-y-px')
+            expect(root.className).toContain('my-vertical-group')
+            expect(root.getAttribute('data-orientation')).toBe('vertical')
+        })
+
+        it('should apply custom element with orientation and ui override', () => {
+            const { container } = render(FieldGroup, {
+                as: 'section',
+                orientation: 'vertical',
+                ui: { root: 'gap-2' }
+            })
+            const root = getRoot(container)
+            expect(root.tagName).toBe('SECTION')
+            expect(root.className).toContain('flex-col')
+            expect(root.className).toContain('gap-2')
+            expect(root.getAttribute('data-orientation')).toBe('vertical')
+        })
+
+        it('should render horizontal group with children and correct structure', () => {
+            const { container } = render(FieldGroup, {
+                orientation: 'horizontal',
+                children: snippet('<div><button>A</button><button>B</button><button>C</button></div>')
+            })
+            const root = getRoot(container)
+            const buttons = container.querySelectorAll('button')
+            expect(root.className).toContain('inline-flex')
+            expect(root.className).toContain('-space-x-px')
+            expect(root.getAttribute('data-orientation')).toBe('horizontal')
+            expect(buttons.length).toBe(3)
+        })
+
+        it('should render vertical group with children', () => {
+            const { container } = render(FieldGroup, {
+                orientation: 'vertical',
+                children: snippet('<div><button>A</button><button>B</button></div>')
+            })
+            const root = getRoot(container)
+            const buttons = container.querySelectorAll('button')
+            expect(root.className).toContain('flex-col')
+            expect(root.className).toContain('-space-y-px')
+            expect(buttons.length).toBe(2)
+        })
+
+        it('should apply all props together', () => {
+            const { container } = render(FieldGroup, {
+                as: 'nav',
+                orientation: 'vertical',
+                size: 'lg',
+                class: 'my-nav',
+                ui: { root: 'shadow-md' },
+                role: 'group',
+                'aria-label': 'Navigation group',
+                children: snippet('<button>Item</button>')
+            })
+            const root = getRoot(container)
+            expect(root.tagName).toBe('NAV')
+            expect(root.className).toContain('flex-col')
+            expect(root.className).toContain('my-nav')
+            expect(root.className).toContain('shadow-md')
+            expect(root.getAttribute('data-orientation')).toBe('vertical')
+            expect(root.getAttribute('role')).toBe('group')
+            expect(root.getAttribute('aria-label')).toBe('Navigation group')
+            expect(container.querySelectorAll('button').length).toBe(1)
+        })
+    })
+})

--- a/src/lib/FieldGroup/field-group.types.ts
+++ b/src/lib/FieldGroup/field-group.types.ts
@@ -1,0 +1,39 @@
+import type { Snippet } from 'svelte'
+import type { HTMLAttributes } from 'svelte/elements'
+import type { ClassNameValue } from 'tailwind-merge'
+import type { FieldGroupSlots, FieldGroupVariantProps } from './field-group.variants.js'
+
+export type FieldGroupProps = Omit<HTMLAttributes<HTMLDivElement>, 'class'> & {
+    /**
+     * The HTML element to render as.
+     * @default 'div'
+     */
+    as?: keyof HTMLElementTagNameMap
+
+    /**
+     * Controls the size of all child components in the group.
+     * @default 'md'
+     */
+    size?: NonNullable<FieldGroupVariantProps['size']>
+
+    /**
+     * Controls the layout direction of the group.
+     * @default 'horizontal'
+     */
+    orientation?: NonNullable<FieldGroupVariantProps['orientation']>
+
+    /**
+     * Additional CSS classes for the root element.
+     */
+    class?: ClassNameValue
+
+    /**
+     * Override styles for specific field group slots.
+     */
+    ui?: Partial<Record<FieldGroupSlots, ClassNameValue>>
+
+    /**
+     * The child content of the field group.
+     */
+    children?: Snippet
+}

--- a/src/lib/FieldGroup/field-group.variants.ts
+++ b/src/lib/FieldGroup/field-group.variants.ts
@@ -1,0 +1,58 @@
+import { tv, type VariantProps } from 'tailwind-variants'
+
+export const fieldGroupVariants = tv({
+    slots: {
+        root: 'relative'
+    },
+    variants: {
+        size: {
+            xs: '',
+            sm: '',
+            md: '',
+            lg: '',
+            xl: ''
+        },
+        orientation: {
+            horizontal: {
+                root: 'inline-flex -space-x-px'
+            },
+            vertical: {
+                root: 'flex flex-col -space-y-px'
+            }
+        }
+    },
+    defaultVariants: {
+        size: 'md',
+        orientation: 'horizontal'
+    }
+})
+
+export const fieldGroupVariant = {
+    fieldGroup: {
+        horizontal:
+            'not-only:first:rounded-e-none not-only:last:rounded-s-none not-last:not-first:rounded-none focus-visible:z-[1]',
+        vertical:
+            'not-only:first:rounded-b-none not-only:last:rounded-t-none not-last:not-first:rounded-none focus-visible:z-[1]'
+    }
+}
+
+export const fieldGroupVariantWithRoot = {
+    fieldGroup: {
+        horizontal: {
+            root: 'group has-focus-visible:z-[1]',
+            base: 'group-not-only:group-first:rounded-e-none group-not-only:group-last:rounded-s-none group-not-last:group-not-first:rounded-none'
+        },
+        vertical: {
+            root: 'group has-focus-visible:z-[1]',
+            base: 'group-not-only:group-first:rounded-b-none group-not-only:group-last:rounded-t-none group-not-last:group-not-first:rounded-none'
+        }
+    }
+}
+
+export type FieldGroupVariantProps = VariantProps<typeof fieldGroupVariants>
+export type FieldGroupSlots = keyof ReturnType<typeof fieldGroupVariants>
+
+export const fieldGroupDefaults = {
+    defaultVariants: fieldGroupVariants.defaultVariants,
+    slots: {} as Partial<Record<FieldGroupSlots, string>>
+}

--- a/src/lib/FieldGroup/index.ts
+++ b/src/lib/FieldGroup/index.ts
@@ -1,0 +1,2 @@
+export { default as FieldGroup } from './FieldGroup.svelte'
+export type { FieldGroupProps } from './field-group.types.js'

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -28,6 +28,7 @@ export * from './DropdownMenu/index.js'
 export * from './ContextMenu/index.js'
 export * from './Tabs/index.js'
 export * from './Pagination/index.js'
+export * from './FieldGroup/index.js'
 
 // Configuration
 export { defineConfig } from './config.js'

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -38,7 +38,8 @@
         { href: '/dropdown-menu', label: 'Dropdown Menu', icon: 'lucide:chevron-down-square' },
         { href: '/tabs', label: 'Tabs', icon: 'lucide:panel-top' },
         { href: '/context-menu', label: 'Context Menu', icon: 'lucide:mouse-pointer' },
-        { href: '/pagination', label: 'Pagination', icon: 'lucide:chevrons-left-right-ellipsis' }
+        { href: '/pagination', label: 'Pagination', icon: 'lucide:chevrons-left-right-ellipsis' },
+        { href: '/field-group', label: 'Field Group', icon: 'lucide:group' }
     ]
 
     const docItems = [

--- a/src/routes/field-group/+page.svelte
+++ b/src/routes/field-group/+page.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+    import { Button, FieldGroup } from '$lib/index.js'
+
+    const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const
+</script>
+
+<div class="space-y-8">
+    <div class="space-y-2">
+        <h1 class="text-2xl font-bold">FieldGroup</h1>
+        <p class="text-on-surface-variant">
+            Group multiple button-like elements together with seamless borders.
+        </p>
+    </div>
+
+    <!-- Basic Usage -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Basic Usage</h2>
+        <p class="text-sm text-on-surface-variant">
+            Wrap multiple <code class="rounded bg-surface-container-highest px-1">Button</code>
+            within a <code class="rounded bg-surface-container-highest px-1">FieldGroup</code> to group
+            them together.
+        </p>
+        <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
+            <FieldGroup>
+                <Button label="Action" />
+                <Button label="Action" />
+                <Button label="Action" />
+            </FieldGroup>
+        </div>
+    </section>
+
+    <!-- Orientation -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Orientation</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">orientation</code> prop to
+            change the layout direction.
+        </p>
+        <div class="flex flex-wrap items-start gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="space-y-2">
+                <span class="text-xs text-on-surface-variant">horizontal</span>
+                <FieldGroup orientation="horizontal">
+                    <Button label="Left" />
+                    <Button label="Center" />
+                    <Button label="Right" />
+                </FieldGroup>
+            </div>
+            <div class="space-y-2">
+                <span class="text-xs text-on-surface-variant">vertical</span>
+                <FieldGroup orientation="vertical">
+                    <Button label="Top" />
+                    <Button label="Middle" />
+                    <Button label="Bottom" />
+                </FieldGroup>
+            </div>
+        </div>
+    </section>
+
+    <!-- Size -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Size</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">size</code> prop to set the
+            size of all child components.
+        </p>
+        <div class="flex flex-wrap items-end gap-6 rounded-lg bg-surface-container-high p-4">
+            {#each sizes as size (size)}
+                <div class="flex flex-col items-center gap-2">
+                    <FieldGroup {size}>
+                        <Button label="Action" />
+                        <Button label="Action" />
+                        <Button label="Action" />
+                    </FieldGroup>
+                    <span class="text-xs text-on-surface-variant">{size}</span>
+                </div>
+            {/each}
+        </div>
+    </section>
+
+    <!-- Variants -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">With Variants</h2>
+        <p class="text-sm text-on-surface-variant">
+            FieldGroup works with different button variants.
+        </p>
+        <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
+            <FieldGroup>
+                <Button variant="outline" color="surface" label="Left" />
+                <Button variant="outline" color="surface" label="Center" />
+                <Button variant="outline" color="surface" label="Right" />
+            </FieldGroup>
+
+            <FieldGroup>
+                <Button variant="soft" label="Left" />
+                <Button variant="soft" label="Center" />
+                <Button variant="soft" label="Right" />
+            </FieldGroup>
+
+            <FieldGroup>
+                <Button variant="subtle" label="Left" />
+                <Button variant="subtle" label="Center" />
+                <Button variant="subtle" label="Right" />
+            </FieldGroup>
+        </div>
+    </section>
+
+    <!-- With Icons -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">With Icons</h2>
+        <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
+            <FieldGroup>
+                <Button icon="lucide:align-left" variant="outline" color="surface" />
+                <Button icon="lucide:align-center" variant="outline" color="surface" />
+                <Button icon="lucide:align-right" variant="outline" color="surface" />
+                <Button icon="lucide:align-justify" variant="outline" color="surface" />
+            </FieldGroup>
+
+            <FieldGroup>
+                <Button icon="lucide:bold" variant="outline" color="surface" />
+                <Button icon="lucide:italic" variant="outline" color="surface" />
+                <Button icon="lucide:underline" variant="outline" color="surface" />
+                <Button icon="lucide:strikethrough" variant="outline" color="surface" />
+            </FieldGroup>
+        </div>
+    </section>
+
+    <!-- Vertical with Icons -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Vertical with Icons</h2>
+        <div class="flex flex-wrap items-start gap-6 rounded-lg bg-surface-container-high p-4">
+            <FieldGroup orientation="vertical">
+                <Button icon="lucide:zoom-in" variant="outline" color="surface" />
+                <Button icon="lucide:zoom-out" variant="outline" color="surface" />
+                <Button icon="lucide:rotate-cw" variant="outline" color="surface" />
+            </FieldGroup>
+
+            <FieldGroup orientation="vertical">
+                <Button leadingIcon="lucide:home" label="Home" variant="soft" />
+                <Button leadingIcon="lucide:settings" label="Settings" variant="soft" />
+                <Button leadingIcon="lucide:user" label="Profile" variant="soft" />
+            </FieldGroup>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
## Summary
- Add FieldGroup component that groups multiple button-like elements with seamless borders, supporting `orientation` (horizontal/vertical) and `size` (xs–xl) props
- Integrate `fieldGroup` context into Button so child buttons inherit size and apply border-radius adjustments automatically
- Fix DropdownMenu item icon color not syncing on highlight state

## Test plan
- [x] 34 unit tests covering rendering, `as`, `orientation`, `size`, custom class, `ui` overrides, HTML attributes, and combined features
- [ ] Verify horizontal and vertical grouping visually on `/field-group` demo page
- [ ] Confirm Button size inheritance works when no explicit size is passed
- [ ] Confirm standalone Button behavior is unaffected (no FieldGroup context)