### PR TITLE
feat: add FormField component

### DIFF
--- a/src/lib/FormField/FormField.svelte
+++ b/src/lib/FormField/FormField.svelte
@@ -1,0 +1,128 @@
+<script lang="ts" module>
+    import type { FormFieldProps } from './form-field.types.js'
+
+    export type Props = FormFieldProps
+</script>
+
+<script lang="ts">
+    import { Label, useId } from 'bits-ui'
+    import { formFieldVariants, formFieldDefaults } from './form-field.variants.js'
+    import { getComponentConfig } from '../config.js'
+    import { setContext } from 'svelte'
+
+    const config = getComponentConfig('formField', formFieldDefaults)
+
+    let {
+        ui,
+        name,
+        label,
+        description,
+        hint,
+        help,
+        error,
+        size = config.defaultVariants.size ?? 'md',
+        required = false,
+        orientation = config.defaultVariants.orientation ?? 'vertical',
+        class: className,
+        children,
+        labelSlot,
+        hintSlot,
+        descriptionSlot,
+        helpSlot,
+        errorSlot,
+        ...restProps
+    }: Props = $props()
+
+    const id = useId()
+    const ariaId = $derived(name ? `form-field-${name}` : id)
+
+    const classes = $derived.by(() => {
+        const slots = formFieldVariants({ size, required, orientation })
+        return {
+            root: slots.root({ class: [config.slots.root, className, ui?.root] }),
+            wrapper: slots.wrapper({ class: [config.slots.wrapper, ui?.wrapper] }),
+            labelWrapper: slots.labelWrapper({
+                class: [config.slots.labelWrapper, ui?.labelWrapper]
+            }),
+            label: slots.label({ class: [config.slots.label, ui?.label] }),
+            container: slots.container({ class: [config.slots.container, ui?.container] }),
+            description: slots.description({
+                class: [config.slots.description, ui?.description]
+            }),
+            error: slots.error({ class: [config.slots.error, ui?.error] }),
+            hint: slots.hint({ class: [config.slots.hint, ui?.hint] }),
+            help: slots.help({ class: [config.slots.help, ui?.help] })
+        }
+    })
+
+    const hasError = $derived(error !== undefined && error !== false)
+    const errorMessage = $derived(typeof error === 'string' ? error : undefined)
+
+    setContext<{
+        name?: string
+        size: NonNullable<FormFieldProps['size']>
+        error?: string | boolean
+        ariaId: string
+    }>('formField', {
+        get name() {
+            return name
+        },
+        get size() {
+            return size
+        },
+        get error() {
+            return error
+        },
+        get ariaId() {
+            return ariaId
+        }
+    })
+</script>
+
+<div class={classes.root} {...restProps}>
+    <div class={classes.wrapper}>
+        {#if label || labelSlot || hint || hintSlot}
+            <div class={classes.labelWrapper}>
+                {#if labelSlot}
+                    {@render labelSlot({ label })}
+                {:else if label}
+                    <Label.Root for={ariaId} class={classes.label}>
+                        {label}
+                    </Label.Root>
+                {/if}
+
+                {#if hintSlot}
+                    {@render hintSlot({ hint })}
+                {:else if hint}
+                    <span class={classes.hint}>{hint}</span>
+                {/if}
+            </div>
+        {/if}
+
+        {#if descriptionSlot}
+            {@render descriptionSlot({ description })}
+        {:else if description}
+            <p id="{ariaId}-description" class={classes.description}>{description}</p>
+        {/if}
+    </div>
+
+    <div class={classes.container}>
+        {#if children}
+            {@render children({ error })}
+        {/if}
+
+        {#if hasError && (errorMessage || errorSlot)}
+            {#if errorSlot}
+                {@render errorSlot({ error })}
+            {:else if errorMessage}
+                <p id="{ariaId}-error" class={classes.error}>{errorMessage}</p>
+            {/if}
+        {:else if help || helpSlot}
+            {#if helpSlot}
+                {@render helpSlot({ help })}
+            {:else if help}
+                <p id="{ariaId}-help" class={classes.help}>{help}</p>
+            {/if}
+        {/if}
+    </div>
+</div>

--- a/src/lib/FormField/form-field.types.ts
+++ b/src/lib/FormField/form-field.types.ts
@@ -1,0 +1,95 @@
+import type { Snippet } from 'svelte'
+import type { HTMLAttributes } from 'svelte/elements'
+import type { ClassNameValue } from 'tailwind-merge'
+import type { FormFieldSlots, FormFieldVariantProps } from './form-field.variants.js'
+
+export type FormFieldProps = Omit<HTMLAttributes<HTMLDivElement>, 'class'> & {
+    /**
+     * The name of the form field, used for matching form errors.
+     */
+    name?: string
+
+    /**
+     * The label text displayed above the form control.
+     */
+    label?: string
+
+    /**
+     * Additional description text displayed below the label.
+     */
+    description?: string
+
+    /**
+     * Hint text displayed next to the label (right side).
+     */
+    hint?: string
+
+    /**
+     * Help text displayed below the form control.
+     */
+    help?: string
+
+    /**
+     * Error message to display. When set, replaces the help text.
+     * Can be a string (error message) or boolean (error state without message).
+     */
+    error?: string | boolean
+
+    /**
+     * Controls the size of the form field labels and text.
+     * @default 'md'
+     */
+    size?: NonNullable<FormFieldVariantProps['size']>
+
+    /**
+     * Whether the field is required. Adds an asterisk indicator to the label.
+     * @default false
+     */
+    required?: boolean
+
+    /**
+     * Controls the layout direction.
+     * @default 'vertical'
+     */
+    orientation?: NonNullable<FormFieldVariantProps['orientation']>
+
+    /**
+     * Additional CSS classes for the root element.
+     */
+    class?: ClassNameValue
+
+    /**
+     * Override styles for specific form field slots.
+     */
+    ui?: Partial<Record<FormFieldSlots, ClassNameValue>>
+
+    /**
+     * The default slot content (form control).
+     */
+    children?: Snippet<[{ error?: string | boolean }]>
+
+    /**
+     * Custom label slot.
+     */
+    labelSlot?: Snippet<[{ label?: string }]>
+
+    /**
+     * Custom hint slot.
+     */
+    hintSlot?: Snippet<[{ hint?: string }]>
+
+    /**
+     * Custom description slot.
+     */
+    descriptionSlot?: Snippet<[{ description?: string }]>
+
+    /**
+     * Custom help slot.
+     */
+    helpSlot?: Snippet<[{ help?: string }]>
+
+    /**
+     * Custom error slot.
+     */
+    errorSlot?: Snippet<[{ error?: string | boolean }]>
+}

--- a/src/lib/FormField/form-field.variants.ts
+++ b/src/lib/FormField/form-field.variants.ts
@@ -1,0 +1,79 @@
+import { tv, type VariantProps } from 'tailwind-variants'
+
+export const formFieldVariants = tv({
+    slots: {
+        root: '',
+        wrapper: '',
+        labelWrapper: 'flex content-center items-center justify-between gap-1',
+        label: 'block font-medium text-on-surface',
+        container: 'relative',
+        description: 'text-on-surface-variant',
+        error: 'mt-2 text-error',
+        hint: 'text-on-surface-variant',
+        help: 'mt-2 text-on-surface-variant'
+    },
+    variants: {
+        size: {
+            xs: {
+                label: 'text-xs',
+                description: 'text-xs',
+                hint: 'text-xs',
+                error: 'text-xs',
+                help: 'text-xs'
+            },
+            sm: {
+                label: 'text-xs',
+                description: 'text-xs',
+                hint: 'text-xs',
+                error: 'text-xs',
+                help: 'text-xs'
+            },
+            md: {
+                label: 'text-sm',
+                description: 'text-sm',
+                hint: 'text-sm',
+                error: 'text-sm',
+                help: 'text-sm'
+            },
+            lg: {
+                label: 'text-sm',
+                description: 'text-sm',
+                hint: 'text-sm',
+                error: 'text-sm',
+                help: 'text-sm'
+            },
+            xl: {
+                label: 'text-base',
+                description: 'text-base',
+                hint: 'text-base',
+                error: 'text-base',
+                help: 'text-base'
+            }
+        },
+        required: {
+            true: {
+                label: "after:ms-0.5 after:text-error after:content-['*']"
+            }
+        },
+        orientation: {
+            vertical: {
+                container: 'mt-1'
+            },
+            horizontal: {
+                root: 'grid grid-cols-2 gap-2 items-baseline'
+            }
+        }
+    },
+    defaultVariants: {
+        size: 'md',
+        orientation: 'vertical'
+    }
+})
+
+export type FormFieldVariantProps = VariantProps<typeof formFieldVariants>
+export type FormFieldSlots = keyof ReturnType<typeof formFieldVariants>
+
+export const formFieldDefaults = {
+    defaultVariants: formFieldVariants.defaultVariants,
+    slots: {} as Partial<Record<FormFieldSlots, string>>
+}

--- a/src/lib/FormField/index.ts
+++ b/src/lib/FormField/index.ts
@@ -1,0 +1,2 @@
+export { default as FormField } from './FormField.svelte'
+export type { FormFieldProps } from './form-field.types.js'

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -29,6 +29,7 @@ export * from './ContextMenu/index.js'
 export * from './Tabs/index.js'
 export * from './Pagination/index.js'
 export * from './FieldGroup/index.js'
+export * from './FormField/index.js'
 
 // Configuration
 export { defineConfig } from './config.js'

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -39,7 +39,8 @@
         { href: '/tabs', label: 'Tabs', icon: 'lucide:panel-top' },
         { href: '/context-menu', label: 'Context Menu', icon: 'lucide:mouse-pointer' },
         { href: '/pagination', label: 'Pagination', icon: 'lucide:chevrons-left-right-ellipsis' },
-        { href: '/field-group', label: 'Field Group', icon: 'lucide:group' }
+        { href: '/field-group', label: 'Field Group', icon: 'lucide:group' },
+        { href: '/form-field', label: 'Form Field', icon: 'lucide:text-cursor-input' }
     ]
 
     const docItems = [

--- a/src/routes/form-field/+page.svelte
+++ b/src/routes/form-field/+page.svelte
@@ -37,8 +37,8 @@
     <section class="space-y-3">
         <h2 class="text-lg font-semibold">Required</h2>
         <p class="text-sm text-on-surface-variant">
-            Use the <code class="rounded bg-surface-container-highest px-1">required</code> prop to
-            add an asterisk indicator to the label.
+            Use the <code class="rounded bg-surface-container-highest px-1">required</code> prop to add
+            an asterisk indicator to the label.
         </p>
         <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
             <div class="w-full max-w-sm">
@@ -53,15 +53,12 @@
     <section class="space-y-3">
         <h2 class="text-lg font-semibold">Description</h2>
         <p class="text-sm text-on-surface-variant">
-            Use the <code class="rounded bg-surface-container-highest px-1">description</code> prop
-            to add a description below the label.
+            Use the <code class="rounded bg-surface-container-highest px-1">description</code> prop to
+            add a description below the label.
         </p>
         <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
             <div class="w-full max-w-sm">
-                <FormField
-                    label="Email"
-                    description="We'll use this to send you notifications."
-                >
+                <FormField label="Email" description="We'll use this to send you notifications.">
                     <input type="email" placeholder="Enter your email" class={inputClass} />
                 </FormField>
             </div>
@@ -72,8 +69,8 @@
     <section class="space-y-3">
         <h2 class="text-lg font-semibold">Hint</h2>
         <p class="text-sm text-on-surface-variant">
-            Use the <code class="rounded bg-surface-container-highest px-1">hint</code> prop to add
-            a hint text next to the label.
+            Use the <code class="rounded bg-surface-container-highest px-1">hint</code> prop to add a
+            hint text next to the label.
         </p>
         <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
             <div class="w-full max-w-sm">
@@ -88,17 +85,13 @@
     <section class="space-y-3">
         <h2 class="text-lg font-semibold">Help</h2>
         <p class="text-sm text-on-surface-variant">
-            Use the <code class="rounded bg-surface-container-highest px-1">help</code> prop to add
-            help text below the form control.
+            Use the <code class="rounded bg-surface-container-highest px-1">help</code> prop to add help
+            text below the form control.
         </p>
         <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
             <div class="w-full max-w-sm">
                 <FormField label="Password" help="Must be at least 8 characters.">
-                    <input
-                        type="password"
-                        placeholder="Enter your password"
-                        class={inputClass}
-                    />
+                    <input type="password" placeholder="Enter your password" class={inputClass} />
                 </FormField>
             </div>
         </div>
@@ -108,8 +101,8 @@
     <section class="space-y-3">
         <h2 class="text-lg font-semibold">Error</h2>
         <p class="text-sm text-on-surface-variant">
-            Use the <code class="rounded bg-surface-container-highest px-1">error</code> prop to
-            display an error message. It replaces the help text when present.
+            Use the <code class="rounded bg-surface-container-highest px-1">error</code> prop to display
+            an error message. It replaces the help text when present.
         </p>
         <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
             <div class="w-full max-w-sm space-y-4">
@@ -140,8 +133,8 @@
     <section class="space-y-3">
         <h2 class="text-lg font-semibold">Size</h2>
         <p class="text-sm text-on-surface-variant">
-            Use the <code class="rounded bg-surface-container-highest px-1">size</code> prop to
-            control the size of the label and text.
+            Use the <code class="rounded bg-surface-container-highest px-1">size</code> prop to control
+            the size of the label and text.
         </p>
         <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
             <div class="w-full space-y-4">
@@ -154,11 +147,7 @@
                             {size}
                             required
                         >
-                            <input
-                                type="email"
-                                placeholder="Enter your email"
-                                class={inputClass}
-                            />
+                            <input type="email" placeholder="Enter your email" class={inputClass} />
                         </FormField>
                     </div>
                 {/each}
@@ -170,30 +159,30 @@
     <section class="space-y-3">
         <h2 class="text-lg font-semibold">Orientation</h2>
         <p class="text-sm text-on-surface-variant">
-            Use the <code class="rounded bg-surface-container-highest px-1">orientation</code> prop
-            to change the layout direction.
+            Use the <code class="rounded bg-surface-container-highest px-1">orientation</code> prop to
+            change the layout direction.
         </p>
         <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
             <div class="w-full space-y-6">
                 <div class="max-w-sm">
                     <p class="mb-2 text-xs text-on-surface-variant">vertical (default)</p>
-                    <FormField label="Email" description="Your primary email." orientation="vertical">
-                        <input
-                            type="email"
-                            placeholder="Enter your email"
-                            class={inputClass}
-                        />
+                    <FormField
+                        label="Email"
+                        description="Your primary email."
+                        orientation="vertical"
+                    >
+                        <input type="email" placeholder="Enter your email" class={inputClass} />
                     </FormField>
                 </div>
 
                 <div class="max-w-lg">
                     <p class="mb-2 text-xs text-on-surface-variant">horizontal</p>
-                    <FormField label="Email" description="Your primary email." orientation="horizontal">
-                        <input
-                            type="email"
-                            placeholder="Enter your email"
-                            class={inputClass}
-                        />
+                    <FormField
+                        label="Email"
+                        description="Your primary email."
+                        orientation="horizontal"
+                    >
+                        <input type="email" placeholder="Enter your email" class={inputClass} />
                     </FormField>
                 </div>
             </div>
@@ -203,9 +192,7 @@
     <!-- Full Example -->
     <section class="space-y-3">
         <h2 class="text-lg font-semibold">Full Example</h2>
-        <p class="text-sm text-on-surface-variant">
-            A complete example with all props combined.
-        </p>
+        <p class="text-sm text-on-surface-variant">A complete example with all props combined.</p>
         <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
             <div class="w-full max-w-sm space-y-4">
                 <FormField
@@ -224,10 +211,7 @@
                     hint="Optional"
                     help="Max 280 characters."
                 >
-                    <textarea
-                        placeholder="Write something..."
-                        rows="3"
-                        class={inputClass}
+                    <textarea placeholder="Write something..." rows="3" class={inputClass}
                     ></textarea>
                 </FormField>
             </div>

--- a/src/routes/form-field/+page.svelte
+++ b/src/routes/form-field/+page.svelte
@@ -1,0 +1,236 @@
+<script lang="ts">
+    import { FormField } from '$lib/index.js'
+
+    const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const
+
+    const inputClass =
+        'w-full rounded-md border border-outline bg-surface px-3 py-2 text-sm text-on-surface placeholder:text-on-surface-variant/50 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary'
+</script>
+
+<div class="space-y-8">
+    <div class="space-y-2">
+        <h1 class="text-2xl font-bold">FormField</h1>
+        <p class="text-on-surface-variant">
+            A wrapper component for form controls that provides label, description, hint, help text,
+            and error handling.
+        </p>
+    </div>
+
+    <!-- Basic Usage -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Basic Usage</h2>
+        <p class="text-sm text-on-surface-variant">
+            Wrap a form control with <code class="rounded bg-surface-container-highest px-1"
+                >FormField</code
+            > to add a label.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm">
+                <FormField label="Email">
+                    <input type="email" placeholder="Enter your email" class={inputClass} />
+                </FormField>
+            </div>
+        </div>
+    </section>
+
+    <!-- Required -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Required</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">required</code> prop to
+            add an asterisk indicator to the label.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm">
+                <FormField label="Email" required>
+                    <input type="email" placeholder="Enter your email" class={inputClass} />
+                </FormField>
+            </div>
+        </div>
+    </section>
+
+    <!-- Description -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Description</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">description</code> prop
+            to add a description below the label.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm">
+                <FormField
+                    label="Email"
+                    description="We'll use this to send you notifications."
+                >
+                    <input type="email" placeholder="Enter your email" class={inputClass} />
+                </FormField>
+            </div>
+        </div>
+    </section>
+
+    <!-- Hint -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Hint</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">hint</code> prop to add
+            a hint text next to the label.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm">
+                <FormField label="Email" hint="Optional">
+                    <input type="email" placeholder="Enter your email" class={inputClass} />
+                </FormField>
+            </div>
+        </div>
+    </section>
+
+    <!-- Help -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Help</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">help</code> prop to add
+            help text below the form control.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm">
+                <FormField label="Password" help="Must be at least 8 characters.">
+                    <input
+                        type="password"
+                        placeholder="Enter your password"
+                        class={inputClass}
+                    />
+                </FormField>
+            </div>
+        </div>
+    </section>
+
+    <!-- Error -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Error</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">error</code> prop to
+            display an error message. It replaces the help text when present.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm space-y-4">
+                <FormField label="Email" error="Please enter a valid email address.">
+                    <input
+                        type="email"
+                        value="invalid-email"
+                        class="{inputClass} border-error! focus:ring-error!"
+                    />
+                </FormField>
+
+                <FormField
+                    label="Email"
+                    help="We'll never share your email."
+                    error="This email is already taken."
+                >
+                    <input
+                        type="email"
+                        value="taken@example.com"
+                        class="{inputClass} border-error! focus:ring-error!"
+                    />
+                </FormField>
+            </div>
+        </div>
+    </section>
+
+    <!-- Size -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Size</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">size</code> prop to
+            control the size of the label and text.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full space-y-4">
+                {#each sizes as size (size)}
+                    <div class="max-w-sm">
+                        <FormField
+                            label="Email ({size})"
+                            description="Enter your email address."
+                            hint="Required"
+                            {size}
+                            required
+                        >
+                            <input
+                                type="email"
+                                placeholder="Enter your email"
+                                class={inputClass}
+                            />
+                        </FormField>
+                    </div>
+                {/each}
+            </div>
+        </div>
+    </section>
+
+    <!-- Orientation -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Orientation</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">orientation</code> prop
+            to change the layout direction.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full space-y-6">
+                <div class="max-w-sm">
+                    <p class="mb-2 text-xs text-on-surface-variant">vertical (default)</p>
+                    <FormField label="Email" description="Your primary email." orientation="vertical">
+                        <input
+                            type="email"
+                            placeholder="Enter your email"
+                            class={inputClass}
+                        />
+                    </FormField>
+                </div>
+
+                <div class="max-w-lg">
+                    <p class="mb-2 text-xs text-on-surface-variant">horizontal</p>
+                    <FormField label="Email" description="Your primary email." orientation="horizontal">
+                        <input
+                            type="email"
+                            placeholder="Enter your email"
+                            class={inputClass}
+                        />
+                    </FormField>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Full Example -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Full Example</h2>
+        <p class="text-sm text-on-surface-variant">
+            A complete example with all props combined.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm space-y-4">
+                <FormField
+                    label="Username"
+                    description="Choose a unique username."
+                    hint="Required"
+                    help="3-20 characters, letters and numbers only."
+                    required
+                >
+                    <input type="text" placeholder="Enter username" class={inputClass} />
+                </FormField>
+
+                <FormField
+                    label="Bio"
+                    description="Tell us about yourself."
+                    hint="Optional"
+                    help="Max 280 characters."
+                >
+                    <textarea
+                        placeholder="Write something..."
+                        rows="3"
+                        class={inputClass}
+                    ></textarea>
+                </FormField>
+            </div>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
## Summary
- Add `FormField` wrapper component for form controls, inspired by [Nuxt UI FormField](https://ui.nuxt.com/docs/components/form-field)
- Provide label, description, hint, help text, and error message display with accessible markup
- Use `Label.Root` and `useId()` from `bits-ui` for proper label-input association via `for`/`id`
- Provide `formField` context (`name`, `size`, `error`, `ariaId`) via `setContext` for future Input/Select component integration

## New Files
| File | Description |
|------|-------------|
| `src/lib/FormField/FormField.svelte` | Main component with `Label.Root`, `useId`, `setContext`, and slot rendering |
| `src/lib/FormField/form-field.types.ts` | Props definition: `label`, `description`, `hint`, `help`, `error`, `size`, `required`, `orientation`, custom snippet slots (`labelSlot`, `hintSlot`, `descriptionSlot`, `helpSlot`, `errorSlot`) |
| `src/lib/FormField/form-field.variants.ts` | TV variants with 9 slots (`root`, `wrapper`, `labelWrapper`, `label`, `container`, `description`, `error`, `hint`, `help`), size (xs-xl), required asterisk, orientation (vertical/horizontal) |
| `src/lib/FormField/index.ts` | Re-exports component and types |
| `src/routes/form-field/+page.svelte` | Demo page: Basic, Required, Description, Hint, Help, Error, Size, Orientation, Full Example |

## Modified Files
| File | Change |
|------|--------|
| `src/lib/index.ts` | Add `FormField` export |
| `src/routes/+layout.svelte` | Add Form Field nav entry in sidebar |

## Features
- **Label**: Rendered via `Label.Root` from bits-ui, linked to form control via `for={ariaId}`
- **Required**: Adds `*` asterisk via CSS `after` pseudo-element with `text-error` color
- **Description**: Displayed below label with `aria-describedby` support via `id="{ariaId}-description"`
- **Hint**: Displayed inline next to label (right-aligned)
- **Help**: Displayed below form control, auto-hidden when error is present
- **Error**: Replaces help text when set, displayed with `text-error` color
- **Size**: 5 sizes (xs, sm, md, lg, xl) controlling label/text font sizes
- **Orientation**: `vertical` (default) stacks label above control, `horizontal` uses CSS grid side-by-side layout
- **Context**: `setContext('formField', { name, size, error, ariaId })` allows child input components to inherit field state
- **Customization**: `class` and `ui` slot overrides, `getComponentConfig` support for global config

## Test plan
- [ ] Label renders and associates with form control via `for` attribute
- [ ] Required asterisk (`*`) appears in error color when `required` is set
- [ ] Description, hint, and help text display in correct positions
- [ ] Error message replaces help text when `error` prop is set
- [ ] All size variants (xs, sm, md, lg, xl) render with correct text sizes
- [ ] Horizontal and vertical orientation layouts render correctly
- [ ] Custom snippet slots (`labelSlot`, `hintSlot`, etc.) override default rendering
