### PR TITLE
feat: add Input component with variants, icons, avatar, and FormField/FieldGroup integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,10 @@ pnpm add sv5ui
 
 | Component                            | Description                                                                         |
 | :----------------------------------- | :---------------------------------------------------------------------------------- |
-| [**Calendar**](src/lib/Calendar)     | Date picker calendar with single, multiple, and range selection modes               |
+| [**Input**](src/lib/Input)           | Text input with 5 variants, icons, avatar, loading state, and FormField integration |
+| [**FormField**](src/lib/FormField)   | Form control wrapper providing label, description, hint, help, and error handling   |
 | [**FieldGroup**](src/lib/FieldGroup) | Groups buttons and inputs with seamless borders and shared size/orientation context |
+| [**Calendar**](src/lib/Calendar)     | Date picker calendar with single, multiple, and range selection modes               |
 
 ## Theming
 

--- a/src/lib/Input/Input.svelte
+++ b/src/lib/Input/Input.svelte
@@ -1,0 +1,174 @@
+<script lang="ts" module>
+    import type { InputProps } from './input.types.js'
+
+    export type Props = InputProps
+</script>
+
+<script lang="ts">
+    import { inputVariants, inputDefaults } from './input.variants.js'
+    import { getComponentConfig, iconsDefaults } from '../config.js'
+    import { getContext } from 'svelte'
+    import {
+        fieldGroupVariantWithRoot,
+        type FieldGroupVariantProps
+    } from '../FieldGroup/field-group.variants.js'
+    import Icon from '../Icon/Icon.svelte'
+    import Avatar from '../Avatar/Avatar.svelte'
+    import type { AvatarSize } from '../Avatar/avatar.types.js'
+    import type { FormFieldProps } from '../FormField/form-field.types.js'
+
+    const config = getComponentConfig('input', inputDefaults)
+    const icons = getComponentConfig('icons', iconsDefaults)
+
+    let {
+        ref = $bindable(null),
+        value = $bindable(),
+        ui,
+        id,
+        name,
+        color = config.defaultVariants.color,
+        variant = config.defaultVariants.variant,
+        size,
+        type = 'text',
+        highlight,
+        loading = false,
+        loadingIcon = icons.loading,
+        disabled = false,
+        icon,
+        leadingIcon,
+        trailingIcon,
+        trailing = false,
+        avatar,
+        leadingSlot,
+        trailingSlot,
+        class: className,
+        ...restProps
+    }: Props = $props()
+
+    const formFieldContext = getContext<
+        | {
+              name?: string
+              size: NonNullable<FormFieldProps['size']>
+              error?: string | boolean
+              ariaId: string
+          }
+        | undefined
+    >('formField')
+
+    const fieldGroupContext = getContext<
+        | {
+              orientation: NonNullable<FieldGroupVariantProps['orientation']>
+              size: NonNullable<FieldGroupVariantProps['size']>
+          }
+        | undefined
+    >('fieldGroup')
+
+    const hasError = $derived(
+        formFieldContext?.error !== undefined && formFieldContext?.error !== false
+    )
+    const resolvedSize = $derived(
+        size ?? formFieldContext?.size ?? fieldGroupContext?.size ?? config.defaultVariants.size
+    )
+    const resolvedColor = $derived(hasError ? 'error' : color)
+    const resolvedHighlight = $derived(highlight ?? hasError)
+    const fieldGroupClass = $derived(
+        fieldGroupContext
+            ? fieldGroupVariantWithRoot.fieldGroup[fieldGroupContext.orientation ?? 'horizontal']
+            : undefined
+    )
+
+    const resolvedId = $derived(id ?? formFieldContext?.ariaId)
+    const resolvedName = $derived(name ?? formFieldContext?.name)
+
+    const isLeading = $derived(
+        (!!icon && !trailing) || (loading && !trailing) || !!leadingIcon || !!avatar
+    )
+    const isTrailing = $derived((!!icon && trailing) || (loading && trailing) || !!trailingIcon)
+
+    const leadingIconName = $derived(
+        loading && isLeading
+            ? loadingIcon
+            : leadingIcon || (isLeading && !trailing && !avatar ? icon : undefined)
+    )
+    const trailingIconName = $derived(
+        loading && isTrailing ? loadingIcon : trailingIcon || (trailing ? icon : undefined)
+    )
+
+    const ariaDescribedBy = $derived.by(() => {
+        if (!formFieldContext) return undefined
+        const id = formFieldContext.ariaId
+        if (hasError) return `${id}-error`
+        return `${id}-description ${id}-help`
+    })
+
+    const classes = $derived.by(() => {
+        const slots = inputVariants({
+            variant,
+            color: resolvedColor,
+            size: resolvedSize,
+            leading: isLeading,
+            trailing: isTrailing,
+            loading,
+            highlight: resolvedHighlight
+        })
+        return {
+            root: slots.root({
+                class: [config.slots.root, fieldGroupClass?.root, className, ui?.root]
+            }),
+            base: slots.base({
+                class: [config.slots.base, fieldGroupClass?.base, ui?.base]
+            }),
+            leading: slots.leading({ class: [config.slots.leading, ui?.leading] }),
+            leadingIcon: slots.leadingIcon({
+                class: [config.slots.leadingIcon, ui?.leadingIcon]
+            }),
+            leadingAvatar: slots.leadingAvatar({
+                class: [config.slots.leadingAvatar, ui?.leadingAvatar]
+            }),
+            leadingAvatarSize: slots.leadingAvatarSize() as AvatarSize,
+            trailing: slots.trailing({ class: [config.slots.trailing, ui?.trailing] }),
+            trailingIcon: slots.trailingIcon({
+                class: [config.slots.trailingIcon, ui?.trailingIcon]
+            })
+        }
+    })
+</script>
+
+<div class={classes.root}>
+    {#if leadingSlot}
+        <span class={classes.leading}>
+            {@render leadingSlot()}
+        </span>
+    {:else if isLeading && leadingIconName}
+        <span class={classes.leading}>
+            <Icon name={leadingIconName} class={classes.leadingIcon} />
+        </span>
+    {:else if avatar}
+        <span class={classes.leading}>
+            <Avatar {...avatar} size={classes.leadingAvatarSize} class={classes.leadingAvatar} />
+        </span>
+    {/if}
+
+    <input
+        bind:this={ref}
+        bind:value
+        {type}
+        id={resolvedId}
+        name={resolvedName}
+        disabled={disabled || loading}
+        aria-describedby={ariaDescribedBy}
+        aria-invalid={resolvedHighlight ? true : undefined}
+        class={classes.base}
+        {...restProps}
+    />
+
+    {#if trailingSlot}
+        <span class={classes.trailing}>
+            {@render trailingSlot()}
+        </span>
+    {:else if isTrailing && trailingIconName}
+        <span class={classes.trailing}>
+            <Icon name={trailingIconName} class={classes.trailingIcon} />
+        </span>
+    {/if}
+</div>

--- a/src/lib/Input/Input.svelte.spec.ts
+++ b/src/lib/Input/Input.svelte.spec.ts
@@ -1,0 +1,444 @@
+import { page } from 'vitest/browser'
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-svelte'
+import Input from './Input.svelte'
+
+const getInput = () => document.querySelector('input') as HTMLInputElement | null
+
+describe('Input', () => {
+    // ==================== RENDERING ====================
+
+    describe('rendering', () => {
+        it('should render an input element', async () => {
+            render(Input)
+            const input = page.getByRole('textbox')
+            await expect.element(input).toBeInTheDocument()
+        })
+
+        it('should render with placeholder', async () => {
+            render(Input, { placeholder: 'Enter text...' })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toBeInTheDocument()
+            expect(getInput()!.placeholder).toBe('Enter text...')
+        })
+
+        it('should render with type text by default', () => {
+            render(Input)
+            expect(getInput()!.type).toBe('text')
+        })
+
+        it('should render with custom type', () => {
+            render(Input, { type: 'email' })
+            expect(getInput()!.type).toBe('email')
+        })
+
+        it('should render with id', () => {
+            render(Input, { id: 'my-input' })
+            expect(getInput()!.id).toBe('my-input')
+        })
+
+        it('should render with name', () => {
+            render(Input, { name: 'email' })
+            expect(getInput()!.name).toBe('email')
+        })
+
+        it('should render with value', async () => {
+            render(Input, { value: 'hello' })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveValue('hello')
+        })
+    })
+
+    // ==================== DISABLED STATE ====================
+
+    describe('disabled', () => {
+        it('should be disabled when disabled prop is true', async () => {
+            render(Input, { disabled: true })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toBeDisabled()
+        })
+
+        it('should not be disabled by default', async () => {
+            render(Input)
+            const input = page.getByRole('textbox')
+            await expect.element(input).toBeEnabled()
+        })
+
+        it('should apply disabled styling', async () => {
+            render(Input, { disabled: true })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/disabled:cursor-not-allowed/)
+        })
+    })
+
+    // ==================== LOADING STATE ====================
+
+    describe('loading', () => {
+        it('should be disabled when loading', async () => {
+            render(Input, { loading: true })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toBeDisabled()
+        })
+
+        it('should render loading icon on leading side by default', () => {
+            const { container } = render(Input, { loading: true })
+            const spans = container.querySelectorAll('span')
+            expect(spans.length).toBeGreaterThanOrEqual(1)
+        })
+
+        it('should render loading icon on trailing side when trailing is true', () => {
+            const { container } = render(Input, { loading: true, trailing: true })
+            const spans = container.querySelectorAll('span')
+            expect(spans.length).toBeGreaterThanOrEqual(1)
+        })
+    })
+
+    // ==================== VARIANTS ====================
+
+    describe('variants', () => {
+        const variants = ['outline', 'soft', 'subtle', 'ghost', 'none'] as const
+
+        for (const variant of variants) {
+            it(`should render with variant="${variant}"`, async () => {
+                render(Input, { variant })
+                const input = page.getByRole('textbox')
+                await expect.element(input).toBeInTheDocument()
+            })
+        }
+
+        it('should apply outline variant classes by default', async () => {
+            render(Input)
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/ring/)
+            await expect.element(input).toHaveClass(/ring-inset/)
+        })
+
+        it('should apply soft variant classes', async () => {
+            render(Input, { variant: 'soft', color: 'primary' })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/bg-primary-container/)
+        })
+
+        it('should apply ghost variant classes', async () => {
+            render(Input, { variant: 'ghost', color: 'primary' })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/bg-transparent/)
+        })
+
+        it('should apply none variant classes', async () => {
+            render(Input, { variant: 'none' })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/bg-transparent/)
+        })
+    })
+
+    // ==================== COLORS ====================
+
+    describe('colors', () => {
+        const colors = [
+            'primary',
+            'secondary',
+            'tertiary',
+            'success',
+            'warning',
+            'error',
+            'info'
+        ] as const
+
+        for (const color of colors) {
+            it(`should render with color="${color}"`, async () => {
+                render(Input, { color })
+                const input = page.getByRole('textbox')
+                await expect.element(input).toHaveClass(new RegExp(`ring-${color}`))
+            })
+        }
+
+        it('should apply surface color with outline variant', async () => {
+            render(Input, { color: 'surface', variant: 'outline' })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/ring-outline-variant/)
+        })
+    })
+
+    // ==================== SIZES ====================
+
+    describe('sizes', () => {
+        it('should apply xs size classes', async () => {
+            render(Input, { size: 'xs' })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/text-xs/)
+            await expect.element(input).toHaveClass(/py-1/)
+        })
+
+        it('should apply sm size classes', async () => {
+            render(Input, { size: 'sm' })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/text-xs/)
+        })
+
+        it('should apply md size classes by default', async () => {
+            render(Input, { size: 'md' })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/text-sm/)
+        })
+
+        it('should apply lg size classes', async () => {
+            render(Input, { size: 'lg' })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/text-sm/)
+        })
+
+        it('should apply xl size classes', async () => {
+            render(Input, { size: 'xl' })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/text-base/)
+        })
+    })
+
+    // ==================== HIGHLIGHT ====================
+
+    describe('highlight', () => {
+        it('should apply highlight ring when highlight is true', async () => {
+            render(Input, { highlight: true, color: 'primary' })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/ring-2/)
+            await expect.element(input).toHaveClass(/ring-primary/)
+        })
+
+        it('should apply error highlight ring', async () => {
+            render(Input, { highlight: true, color: 'error' })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/ring-2/)
+            await expect.element(input).toHaveClass(/ring-error/)
+        })
+
+        it('should set aria-invalid when highlight is true', () => {
+            render(Input, { highlight: true })
+            expect(getInput()!.getAttribute('aria-invalid')).toBe('true')
+        })
+
+        it('should not set aria-invalid when highlight is false', () => {
+            render(Input)
+            expect(getInput()!.getAttribute('aria-invalid')).toBeNull()
+        })
+    })
+
+    // ==================== ICONS ====================
+
+    describe('icons', () => {
+        it('should render with leadingIcon and adjust padding', async () => {
+            render(Input, { leadingIcon: 'lucide:search' })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toBeInTheDocument()
+            await expect.element(input).toHaveClass(/ps-9/)
+        })
+
+        it('should render with trailingIcon and adjust padding', async () => {
+            render(Input, { trailingIcon: 'lucide:eye' })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toBeInTheDocument()
+            await expect.element(input).toHaveClass(/pe-9/)
+        })
+
+        it('should render icon on leading side by default', async () => {
+            render(Input, { icon: 'lucide:user' })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/ps-9/)
+        })
+
+        it('should render icon on trailing side when trailing is true', async () => {
+            render(Input, { icon: 'lucide:user', trailing: true })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/pe-9/)
+        })
+
+        it('should render both leading and trailing icons', async () => {
+            render(Input, {
+                leadingIcon: 'lucide:mail',
+                trailingIcon: 'lucide:check'
+            })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/ps-9/)
+            await expect.element(input).toHaveClass(/pe-9/)
+        })
+
+        it('should adjust leading padding per size', async () => {
+            render(Input, { leadingIcon: 'lucide:search', size: 'xs' })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/ps-7/)
+        })
+
+        it('should adjust trailing padding per size', async () => {
+            render(Input, { trailingIcon: 'lucide:eye', size: 'xl' })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/pe-12/)
+        })
+    })
+
+    // ==================== AVATAR ====================
+
+    describe('avatar', () => {
+        it('should render avatar with alt initials as fallback', () => {
+            const { container } = render(Input, {
+                avatar: { alt: 'John Doe' }
+            })
+            expect(container.textContent).toContain('JD')
+        })
+
+        it('should render avatar with src as img element', async () => {
+            render(Input, {
+                avatar: { src: 'https://i.pravatar.cc/64', alt: 'User avatar' }
+            })
+            const img = page.getByRole('img', { name: 'User avatar' })
+            await expect.element(img).toBeInTheDocument()
+        })
+
+        it('should apply leading padding when avatar is present', async () => {
+            render(Input, { avatar: { alt: 'User' } })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/ps-9/)
+        })
+
+        it('should not render avatar when leadingIcon is provided', () => {
+            const { container } = render(Input, {
+                leadingIcon: 'lucide:user',
+                avatar: { alt: 'John Doe' }
+            })
+            expect(container.textContent).not.toContain('JD')
+        })
+
+        it('should not render avatar when loading', () => {
+            const { container } = render(Input, {
+                avatar: { alt: 'John Doe' },
+                loading: true
+            })
+            expect(container.textContent).not.toContain('JD')
+        })
+    })
+
+    // ==================== EVENTS ====================
+
+    describe('events', () => {
+        it('should handle input events', async () => {
+            const oninput = vi.fn()
+            render(Input, { oninput })
+            const input = page.getByRole('textbox')
+            await input.fill('hello')
+            expect(oninput).toHaveBeenCalled()
+        })
+
+        it('should handle focus events', async () => {
+            const onfocus = vi.fn()
+            render(Input, { onfocus })
+            const input = page.getByRole('textbox')
+            await input.click()
+            expect(onfocus).toHaveBeenCalledOnce()
+        })
+
+        it('should handle blur events', async () => {
+            const onblur = vi.fn()
+            render(Input, { onblur })
+            await page.getByRole('textbox').click()
+            getInput()!.blur()
+            expect(onblur).toHaveBeenCalledOnce()
+        })
+    })
+
+    // ==================== CUSTOM CLASS ====================
+
+    describe('custom class', () => {
+        it('should apply custom class to root element', () => {
+            const { container } = render(Input, { class: 'my-custom-class' })
+            const root = container.firstElementChild as HTMLElement
+            expect(root.className).toContain('my-custom-class')
+        })
+
+        it('should apply ui slot overrides to input element', async () => {
+            render(Input, { ui: { base: 'my-input-class' } })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/my-input-class/)
+        })
+
+        it('should apply ui slot overrides to root element', () => {
+            const { container } = render(Input, { ui: { root: 'my-root-class' } })
+            const root = container.firstElementChild as HTMLElement
+            expect(root.className).toContain('my-root-class')
+        })
+    })
+
+    // ==================== ACCESSIBILITY ====================
+
+    describe('accessibility', () => {
+        it('should support aria-label', () => {
+            render(Input, { 'aria-label': 'Search input' })
+            expect(getInput()!.getAttribute('aria-label')).toBe('Search input')
+        })
+
+        it('should support readonly', () => {
+            render(Input, { readonly: true })
+            expect(getInput()!.readOnly).toBe(true)
+        })
+
+        it('should support required', () => {
+            render(Input, { required: true })
+            expect(getInput()!.required).toBe(true)
+        })
+
+        it('should support autocomplete', () => {
+            render(Input, { autocomplete: 'email' })
+            expect(getInput()!.autocomplete).toBe('email')
+        })
+    })
+
+    // ==================== COMBINED PROPS ====================
+
+    describe('combined props', () => {
+        it('should render with multiple props combined', async () => {
+            render(Input, {
+                variant: 'outline',
+                color: 'error',
+                size: 'lg',
+                highlight: true
+            })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toBeInTheDocument()
+            await expect.element(input).toHaveClass(/ring-2/)
+            await expect.element(input).toHaveClass(/ring-error/)
+            await expect.element(input).toHaveClass(/text-sm/)
+        })
+
+        it('should render loading with leadingIcon', async () => {
+            render(Input, {
+                leadingIcon: 'lucide:search',
+                loading: true
+            })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toBeDisabled()
+            await expect.element(input).toHaveClass(/ps-9/)
+        })
+
+        it('should render disabled with highlight', async () => {
+            render(Input, {
+                disabled: true,
+                highlight: true,
+                color: 'error'
+            })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toBeDisabled()
+            await expect.element(input).toHaveClass(/ring-error/)
+        })
+
+        it('should render with both icons and highlight', async () => {
+            render(Input, {
+                leadingIcon: 'lucide:mail',
+                trailingIcon: 'lucide:check',
+                highlight: true,
+                color: 'success'
+            })
+            const input = page.getByRole('textbox')
+            await expect.element(input).toHaveClass(/ps-9/)
+            await expect.element(input).toHaveClass(/pe-9/)
+            await expect.element(input).toHaveClass(/ring-success/)
+        })
+    })
+})

--- a/src/lib/Input/index.ts
+++ b/src/lib/Input/index.ts
@@ -1,0 +1,2 @@
+export { default as Input } from './Input.svelte'
+export type { InputProps } from './input.types.js'

--- a/src/lib/Input/input.types.ts
+++ b/src/lib/Input/input.types.ts
@@ -1,0 +1,109 @@
+import type { Snippet } from 'svelte'
+import type { HTMLInputAttributes } from 'svelte/elements'
+import type { ClassNameValue } from 'tailwind-merge'
+import type { InputVariantProps, InputSlots } from './input.variants.js'
+import type { AvatarProps } from '../Avatar/avatar.types.js'
+
+export type InputProps = Omit<HTMLInputAttributes, 'class' | 'size'> & {
+    /**
+     * Bind a reference to the underlying HTMLInputElement.
+     */
+    ref?: HTMLInputElement | null
+
+    /**
+     * The current value of the input. Supports two-way binding with `bind:value`.
+     */
+    value?: string
+
+    /**
+     * Controls the visual style of the input.
+     * @default 'outline'
+     */
+    variant?: NonNullable<InputVariantProps['variant']>
+
+    /**
+     * Sets the color scheme for focus ring and highlight.
+     * @default 'primary'
+     */
+    color?: NonNullable<InputVariantProps['color']>
+
+    /**
+     * Controls the dimensions and text size of the input.
+     * @default 'md'
+     */
+    size?: NonNullable<InputVariantProps['size']>
+
+    /**
+     * Emphasizes ring color like focus state, even when not focused.
+     * Automatically enabled when used inside a FormField with an error.
+     * @default false
+     */
+    highlight?: boolean
+
+    /**
+     * Renders a loading spinner and optionally disables interaction.
+     * @default false
+     */
+    loading?: boolean
+
+    /**
+     * Icon displayed as the loading indicator.
+     * Supports any valid Iconify icon name.
+     * @default Uses `icons.loading` from app config
+     */
+    loadingIcon?: string
+
+    /**
+     * Icon displayed on the leading or trailing side.
+     * Position controlled by the `trailing` prop.
+     * Supports any valid Iconify icon name.
+     */
+    icon?: string
+
+    /**
+     * Icon placed before the input value.
+     * Supports any valid Iconify icon name.
+     */
+    leadingIcon?: string
+
+    /**
+     * Icon placed after the input value.
+     * Supports any valid Iconify icon name.
+     */
+    trailingIcon?: string
+
+    /**
+     * Moves the icon to the trailing (right) side.
+     * Only takes effect when using the `icon` prop.
+     * @default false
+     */
+    trailing?: boolean
+
+    /**
+     * Avatar displayed before the input value.
+     * Takes precedence over `leadingIcon`.
+     */
+    avatar?: AvatarProps
+
+    /**
+     * Custom content rendered before the input.
+     * Takes precedence over `avatar` and `leadingIcon`.
+     */
+    leadingSlot?: Snippet
+
+    /**
+     * Custom content rendered after the input.
+     * Takes precedence over `trailingIcon`.
+     */
+    trailingSlot?: Snippet
+
+    /**
+     * Additional CSS classes for the root element.
+     */
+    class?: ClassNameValue
+
+    /**
+     * Override styles for specific input slots.
+     */
+    ui?: Partial<Record<InputSlots, ClassNameValue>>
+}

--- a/src/lib/Input/input.variants.ts
+++ b/src/lib/Input/input.variants.ts
@@ -1,0 +1,419 @@
+import { tv, type VariantProps } from 'tailwind-variants'
+
+export const inputVariants = tv({
+    slots: {
+        root: 'relative w-full inline-flex items-center',
+        base: [
+            'w-full rounded-md border-0 bg-surface text-on-surface placeholder:text-on-surface-variant/50',
+            'disabled:cursor-not-allowed disabled:opacity-75',
+            'transition-colors',
+            'focus:outline-none'
+        ],
+        leading: 'absolute inset-y-0 start-0 flex items-center pointer-events-none',
+        leadingIcon: 'shrink-0 text-on-surface-variant/75',
+        leadingAvatar: 'shrink-0',
+        leadingAvatarSize: '',
+        trailing: 'absolute inset-y-0 end-0 flex items-center pointer-events-none',
+        trailingIcon: 'shrink-0 text-on-surface-variant/75'
+    },
+    variants: {
+        variant: {
+            outline: '',
+            soft: '',
+            subtle: '',
+            ghost: '',
+            none: ''
+        },
+        color: {
+            primary: '',
+            secondary: '',
+            tertiary: '',
+            success: '',
+            warning: '',
+            error: '',
+            info: '',
+            surface: ''
+        },
+        size: {
+            xs: {
+                base: 'px-2 py-1 text-xs rounded',
+                leading: 'ps-2',
+                leadingIcon: 'size-3.5',
+                leadingAvatarSize: '3xs',
+                trailing: 'pe-2',
+                trailingIcon: 'size-3.5'
+            },
+            sm: {
+                base: 'px-2.5 py-1.5 text-xs rounded-md',
+                leading: 'ps-2.5',
+                leadingIcon: 'size-4',
+                leadingAvatarSize: '3xs',
+                trailing: 'pe-2.5',
+                trailingIcon: 'size-4'
+            },
+            md: {
+                base: 'px-3 py-2 text-sm rounded-md',
+                leading: 'ps-3',
+                leadingIcon: 'size-5',
+                leadingAvatarSize: '2xs',
+                trailing: 'pe-3',
+                trailingIcon: 'size-5'
+            },
+            lg: {
+                base: 'px-4 py-2.5 text-sm rounded-md',
+                leading: 'ps-4',
+                leadingIcon: 'size-5',
+                leadingAvatarSize: '2xs',
+                trailing: 'pe-4',
+                trailingIcon: 'size-5'
+            },
+            xl: {
+                base: 'px-5 py-3 text-base rounded-lg',
+                leading: 'ps-5',
+                leadingIcon: 'size-6',
+                leadingAvatarSize: 'xs',
+                trailing: 'pe-5',
+                trailingIcon: 'size-6'
+            }
+        },
+        leading: {
+            true: ''
+        },
+        trailing: {
+            true: ''
+        },
+        loading: {
+            true: ''
+        },
+        highlight: {
+            true: ''
+        }
+    },
+    compoundVariants: [
+        // ========== OUTLINE VARIANTS ==========
+        {
+            variant: 'outline',
+            color: 'primary',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-primary'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'secondary',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-secondary'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'tertiary',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-tertiary'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'success',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-success'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'warning',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-warning'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'error',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-error'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'info',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-info'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'surface',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-outline'
+            }
+        },
+
+        // ========== SOFT VARIANTS ==========
+        {
+            variant: 'soft',
+            color: 'primary',
+            class: {
+                base: 'bg-primary-container/50 focus:bg-primary-container/75 focus:ring-2 focus:ring-inset focus:ring-primary'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'secondary',
+            class: {
+                base: 'bg-secondary-container/50 focus:bg-secondary-container/75 focus:ring-2 focus:ring-inset focus:ring-secondary'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'tertiary',
+            class: {
+                base: 'bg-tertiary-container/50 focus:bg-tertiary-container/75 focus:ring-2 focus:ring-inset focus:ring-tertiary'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'success',
+            class: {
+                base: 'bg-success-container/50 focus:bg-success-container/75 focus:ring-2 focus:ring-inset focus:ring-success'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'warning',
+            class: {
+                base: 'bg-warning-container/50 focus:bg-warning-container/75 focus:ring-2 focus:ring-inset focus:ring-warning'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'error',
+            class: {
+                base: 'bg-error-container/50 focus:bg-error-container/75 focus:ring-2 focus:ring-inset focus:ring-error'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'info',
+            class: {
+                base: 'bg-info-container/50 focus:bg-info-container/75 focus:ring-2 focus:ring-inset focus:ring-info'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'surface',
+            class: {
+                base: 'bg-surface-container-highest/50 focus:bg-surface-container-highest/75 focus:ring-2 focus:ring-inset focus:ring-outline'
+            }
+        },
+
+        // ========== SUBTLE VARIANTS ==========
+        {
+            variant: 'subtle',
+            color: 'primary',
+            class: {
+                base: 'ring ring-inset ring-primary/25 bg-primary-container/50 focus:ring-2 focus:ring-primary'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'secondary',
+            class: {
+                base: 'ring ring-inset ring-secondary/25 bg-secondary-container/50 focus:ring-2 focus:ring-secondary'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'tertiary',
+            class: {
+                base: 'ring ring-inset ring-tertiary/25 bg-tertiary-container/50 focus:ring-2 focus:ring-tertiary'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'success',
+            class: {
+                base: 'ring ring-inset ring-success/25 bg-success-container/50 focus:ring-2 focus:ring-success'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'warning',
+            class: {
+                base: 'ring ring-inset ring-warning/25 bg-warning-container/50 focus:ring-2 focus:ring-warning'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'error',
+            class: {
+                base: 'ring ring-inset ring-error/25 bg-error-container/50 focus:ring-2 focus:ring-error'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'info',
+            class: {
+                base: 'ring ring-inset ring-info/25 bg-info-container/50 focus:ring-2 focus:ring-info'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'surface',
+            class: {
+                base: 'ring ring-inset ring-outline-variant bg-surface-container-highest/50 focus:ring-2 focus:ring-outline'
+            }
+        },
+
+        // ========== GHOST VARIANTS ==========
+        {
+            variant: 'ghost',
+            color: 'primary',
+            class: {
+                base: 'bg-transparent hover:bg-primary-container/50 focus:ring-2 focus:ring-inset focus:ring-primary'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'secondary',
+            class: {
+                base: 'bg-transparent hover:bg-secondary-container/50 focus:ring-2 focus:ring-inset focus:ring-secondary'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'tertiary',
+            class: {
+                base: 'bg-transparent hover:bg-tertiary-container/50 focus:ring-2 focus:ring-inset focus:ring-tertiary'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'success',
+            class: {
+                base: 'bg-transparent hover:bg-success-container/50 focus:ring-2 focus:ring-inset focus:ring-success'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'warning',
+            class: {
+                base: 'bg-transparent hover:bg-warning-container/50 focus:ring-2 focus:ring-inset focus:ring-warning'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'error',
+            class: {
+                base: 'bg-transparent hover:bg-error-container/50 focus:ring-2 focus:ring-inset focus:ring-error'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'info',
+            class: {
+                base: 'bg-transparent hover:bg-info-container/50 focus:ring-2 focus:ring-inset focus:ring-info'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'surface',
+            class: {
+                base: 'bg-transparent hover:bg-surface-container-highest/50 focus:ring-2 focus:ring-inset focus:ring-outline'
+            }
+        },
+
+        // ========== NONE VARIANT ==========
+        {
+            variant: 'none',
+            class: {
+                base: 'bg-transparent focus:ring-0'
+            }
+        },
+
+        // ========== HIGHLIGHT VARIANTS ==========
+        {
+            highlight: true,
+            color: 'primary',
+            class: { base: 'ring-2 ring-inset ring-primary' }
+        },
+        {
+            highlight: true,
+            color: 'secondary',
+            class: { base: 'ring-2 ring-inset ring-secondary' }
+        },
+        {
+            highlight: true,
+            color: 'tertiary',
+            class: { base: 'ring-2 ring-inset ring-tertiary' }
+        },
+        {
+            highlight: true,
+            color: 'success',
+            class: { base: 'ring-2 ring-inset ring-success' }
+        },
+        {
+            highlight: true,
+            color: 'warning',
+            class: { base: 'ring-2 ring-inset ring-warning' }
+        },
+        {
+            highlight: true,
+            color: 'error',
+            class: { base: 'ring-2 ring-inset ring-error' }
+        },
+        {
+            highlight: true,
+            color: 'info',
+            class: { base: 'ring-2 ring-inset ring-info' }
+        },
+        {
+            highlight: true,
+            color: 'surface',
+            class: { base: 'ring-2 ring-inset ring-outline' }
+        },
+
+        // ========== LEADING PADDING ADJUSTMENTS ==========
+        { leading: true, size: 'xs', class: { base: 'ps-7' } },
+        { leading: true, size: 'sm', class: { base: 'ps-8' } },
+        { leading: true, size: 'md', class: { base: 'ps-9' } },
+        { leading: true, size: 'lg', class: { base: 'ps-10' } },
+        { leading: true, size: 'xl', class: { base: 'ps-12' } },
+
+        // ========== TRAILING PADDING ADJUSTMENTS ==========
+        { trailing: true, size: 'xs', class: { base: 'pe-7' } },
+        { trailing: true, size: 'sm', class: { base: 'pe-8' } },
+        { trailing: true, size: 'md', class: { base: 'pe-9' } },
+        { trailing: true, size: 'lg', class: { base: 'pe-10' } },
+        { trailing: true, size: 'xl', class: { base: 'pe-12' } },
+
+        // ========== LOADING ICON ANIMATION ==========
+        {
+            loading: true,
+            leading: true,
+            class: {
+                leadingIcon: 'animate-spin'
+            }
+        },
+        {
+            loading: true,
+            leading: false,
+            trailing: true,
+            class: {
+                trailingIcon: 'animate-spin'
+            }
+        }
+    ],
+    defaultVariants: {
+        variant: 'outline',
+        color: 'primary',
+        size: 'md'
+    }
+})
+
+export type InputVariantProps = VariantProps<typeof inputVariants>
+export type InputSlots = keyof ReturnType<typeof inputVariants>
+
+export const inputDefaults = {
+    defaultVariants: inputVariants.defaultVariants,
+    slots: {} as Partial<Record<InputSlots, string>>
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -30,6 +30,7 @@ export * from './Tabs/index.js'
 export * from './Pagination/index.js'
 export * from './FieldGroup/index.js'
 export * from './FormField/index.js'
+export * from './Input/index.js'
 
 // Configuration
 export { defineConfig } from './config.js'

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -40,7 +40,8 @@
         { href: '/context-menu', label: 'Context Menu', icon: 'lucide:mouse-pointer' },
         { href: '/pagination', label: 'Pagination', icon: 'lucide:chevrons-left-right-ellipsis' },
         { href: '/field-group', label: 'Field Group', icon: 'lucide:group' },
-        { href: '/form-field', label: 'Form Field', icon: 'lucide:text-cursor-input' }
+        { href: '/form-field', label: 'Form Field', icon: 'lucide:text-cursor-input' },
+        { href: '/input', label: 'Input', icon: 'lucide:text-cursor' }
     ]
 
     const docItems = [

--- a/src/routes/accordion/+page.svelte
+++ b/src/routes/accordion/+page.svelte
@@ -977,31 +977,31 @@
                         <!-- Form UI -->
                         <div class="space-y-3">
                             <div class="grid gap-3 sm:grid-cols-2">
-                                <div>
-                                    <label class="mb-1 block text-xs font-medium">Name</label>
+                                <label class="block">
+                                    <span class="mb-1 block text-xs font-medium">Name</span>
                                     <input
                                         type="text"
                                         placeholder="Your name"
                                         class="w-full rounded-lg border border-outline-variant bg-surface px-3 py-2 text-sm focus:border-primary focus:outline-none"
                                     />
-                                </div>
-                                <div>
-                                    <label class="mb-1 block text-xs font-medium">Email</label>
+                                </label>
+                                <label class="block">
+                                    <span class="mb-1 block text-xs font-medium">Email</span>
                                     <input
                                         type="email"
                                         placeholder="your@email.com"
                                         class="w-full rounded-lg border border-outline-variant bg-surface px-3 py-2 text-sm focus:border-primary focus:outline-none"
                                     />
-                                </div>
+                                </label>
                             </div>
-                            <div>
-                                <label class="mb-1 block text-xs font-medium">Message</label>
+                            <label class="block">
+                                <span class="mb-1 block text-xs font-medium">Message</span>
                                 <textarea
                                     placeholder="Your message..."
                                     rows="3"
                                     class="w-full rounded-lg border border-outline-variant bg-surface px-3 py-2 text-sm focus:border-primary focus:outline-none"
                                 ></textarea>
-                            </div>
+                            </label>
                             <Button
                                 variant="solid"
                                 label="Send Message"

--- a/src/routes/field-group/+page.svelte
+++ b/src/routes/field-group/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { Button, FieldGroup } from '$lib/index.js'
+    import { Button, Input, FieldGroup } from '$lib/index.js'
 
     const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const
 </script>
@@ -139,6 +139,70 @@
                 <Button leadingIcon="lucide:settings" label="Settings" variant="soft" />
                 <Button leadingIcon="lucide:user" label="Profile" variant="soft" />
             </FieldGroup>
+        </div>
+    </section>
+
+    <!-- With Input -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">With Input</h2>
+        <p class="text-sm text-on-surface-variant">
+            Combine <code class="rounded bg-surface-container-highest px-1">Input</code> and
+            <code class="rounded bg-surface-container-highest px-1">Button</code> in a FieldGroup.
+        </p>
+        <div class="flex flex-wrap items-start gap-6 rounded-lg bg-surface-container-high p-4">
+            <FieldGroup>
+                <Input leadingIcon="lucide:search" placeholder="Search..." />
+                <Button label="Search" />
+            </FieldGroup>
+
+            <FieldGroup>
+                <Input placeholder="Enter email" type="email" />
+                <Button label="Subscribe" variant="solid" color="primary" />
+            </FieldGroup>
+        </div>
+    </section>
+
+    <!-- With Input (Vertical) -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">With Input (Vertical)</h2>
+        <div class="flex flex-wrap items-start gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-72">
+                <FieldGroup orientation="vertical">
+                    <Input placeholder="First name" />
+                    <Input placeholder="Last name" />
+                    <Input placeholder="Email" type="email" />
+                </FieldGroup>
+            </div>
+
+            <div class="w-72">
+                <FieldGroup orientation="vertical">
+                    <Input leadingIcon="lucide:user" placeholder="Username" />
+                    <Input leadingIcon="lucide:lock" placeholder="Password" type="password" />
+                    <Button label="Sign in" block />
+                </FieldGroup>
+            </div>
+        </div>
+    </section>
+
+    <!-- Mixed Sizes -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Input + Button Sizes</h2>
+        <p class="text-sm text-on-surface-variant">
+            FieldGroup propagates the <code class="rounded bg-surface-container-highest px-1"
+                >size</code
+            >
+            prop to all children.
+        </p>
+        <div class="flex flex-wrap items-end gap-6 rounded-lg bg-surface-container-high p-4">
+            {#each sizes as size (size)}
+                <div class="flex flex-col items-center gap-2">
+                    <FieldGroup {size}>
+                        <Input placeholder="Search..." />
+                        <Button icon="lucide:search" />
+                    </FieldGroup>
+                    <span class="text-xs text-on-surface-variant">{size}</span>
+                </div>
+            {/each}
         </div>
     </section>
 </div>

--- a/src/routes/input/+page.svelte
+++ b/src/routes/input/+page.svelte
@@ -45,7 +45,11 @@
         </p>
         <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
             <div class="w-full max-w-sm space-y-3">
-                <Input bind:value={bindValue} leadingIcon="lucide:pencil" placeholder="Type something..." />
+                <Input
+                    bind:value={bindValue}
+                    leadingIcon="lucide:pencil"
+                    placeholder="Type something..."
+                />
                 <p class="text-sm text-on-surface-variant">
                     Value: <span class="font-mono text-on-surface">{bindValue || '(empty)'}</span>
                 </p>

--- a/src/routes/input/+page.svelte
+++ b/src/routes/input/+page.svelte
@@ -1,0 +1,279 @@
+<script lang="ts">
+    import { Input, FormField, FieldGroup } from '$lib/index.js'
+
+    const variants = ['outline', 'soft', 'subtle', 'ghost', 'none'] as const
+    const colors = [
+        'primary',
+        'secondary',
+        'tertiary',
+        'success',
+        'warning',
+        'error',
+        'info',
+        'surface'
+    ] as const
+    const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const
+
+    let bindValue = $state('')
+</script>
+
+<div class="space-y-8">
+    <div class="space-y-2">
+        <h1 class="text-2xl font-bold">Input</h1>
+        <p class="text-on-surface-variant">
+            A form input component with variants, colors, icons, and integration with FormField and
+            FieldGroup.
+        </p>
+    </div>
+
+    <!-- Basic Usage -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Basic Usage</h2>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm">
+                <Input placeholder="Enter text..." />
+            </div>
+        </div>
+    </section>
+
+    <!-- Two-way Binding -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Two-way Binding</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1">bind:value</code> for reactive
+            two-way data binding.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm space-y-3">
+                <Input bind:value={bindValue} leadingIcon="lucide:pencil" placeholder="Type something..." />
+                <p class="text-sm text-on-surface-variant">
+                    Value: <span class="font-mono text-on-surface">{bindValue || '(empty)'}</span>
+                </p>
+                <p class="text-sm text-on-surface-variant">
+                    Length: <span class="font-mono text-on-surface">{bindValue.length}</span>
+                </p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Variants × Colors -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Variants &times; Colors</h2>
+        <div class="overflow-x-auto rounded-lg bg-surface-container-high p-4">
+            <table class="w-full border-collapse">
+                <thead>
+                    <tr>
+                        <th class="px-3 py-2 text-left text-xs font-medium text-on-surface-variant"
+                        ></th>
+                        {#each colors as color (color)}
+                            <th
+                                class="px-3 py-2 text-left text-xs font-medium text-on-surface-variant capitalize"
+                                >{color}</th
+                            >
+                        {/each}
+                    </tr>
+                </thead>
+                <tbody>
+                    {#each variants as variant (variant)}
+                        <tr>
+                            <td
+                                class="px-3 py-2 text-xs font-medium text-on-surface-variant capitalize"
+                                >{variant}</td
+                            >
+                            {#each colors as color (color)}
+                                <td class="px-3 py-2">
+                                    <Input {variant} {color} placeholder={color} />
+                                </td>
+                            {/each}
+                        </tr>
+                    {/each}
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <!-- Sizes -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Size</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">size</code> prop to control
+            the dimensions and text size.
+        </p>
+        <div class="flex flex-wrap items-end gap-4 rounded-lg bg-surface-container-high p-4">
+            {#each sizes as size (size)}
+                <div class="w-48">
+                    <Input {size} placeholder="{size} size" />
+                </div>
+            {/each}
+        </div>
+    </section>
+
+    <!-- Icons -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Icons</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1">leadingIcon</code> and
+            <code class="rounded bg-surface-container-highest px-1">trailingIcon</code> to add icons.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-64">
+                <Input leadingIcon="lucide:search" placeholder="Search..." />
+            </div>
+            <div class="w-64">
+                <Input trailingIcon="lucide:eye" placeholder="Password" type="password" />
+            </div>
+            <div class="w-64">
+                <Input
+                    leadingIcon="lucide:mail"
+                    trailingIcon="lucide:check"
+                    placeholder="Email"
+                    type="email"
+                />
+            </div>
+        </div>
+    </section>
+
+    <!-- Icon prop with trailing -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Icon (with trailing)</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">icon</code> prop with
+            <code class="rounded bg-surface-container-highest px-1">trailing</code> to position it.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-64">
+                <Input icon="lucide:user" placeholder="Leading icon" />
+            </div>
+            <div class="w-64">
+                <Input icon="lucide:user" trailing placeholder="Trailing icon" />
+            </div>
+        </div>
+    </section>
+
+    <!-- Avatar -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Avatar</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">avatar</code> prop to display
+            an avatar before the input.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-64">
+                <Input
+                    avatar={{ src: 'https://i.pravatar.cc/120?img=1', alt: 'User' }}
+                    placeholder="With avatar"
+                />
+            </div>
+        </div>
+    </section>
+
+    <!-- Loading -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Loading</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">loading</code> prop to show
+            a loading spinner.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-64">
+                <Input loading placeholder="Loading (leading)..." />
+            </div>
+            <div class="w-64">
+                <Input loading trailing placeholder="Loading (trailing)..." />
+            </div>
+        </div>
+    </section>
+
+    <!-- Disabled -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Disabled</h2>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-64">
+                <Input disabled placeholder="Disabled" />
+            </div>
+            <div class="w-64">
+                <Input disabled value="Disabled with value" />
+            </div>
+        </div>
+    </section>
+
+    <!-- Highlight -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Highlight</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">highlight</code> prop to emphasize
+            the ring color.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            {#each colors as color (color)}
+                <div class="w-48">
+                    <Input highlight {color} placeholder={color} />
+                </div>
+            {/each}
+        </div>
+    </section>
+
+    <!-- FormField Integration -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">FormField Integration</h2>
+        <p class="text-sm text-on-surface-variant">
+            When used inside a <code class="rounded bg-surface-container-highest px-1"
+                >FormField</code
+            >, the Input automatically inherits size, error state, and accessibility attributes.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm space-y-4">
+                <FormField
+                    label="Email"
+                    description="We'll use this to send you notifications."
+                    required
+                >
+                    <Input leadingIcon="lucide:mail" placeholder="Enter your email" type="email" />
+                </FormField>
+
+                <FormField
+                    label="Password"
+                    help="Must be at least 8 characters."
+                    error="Password is too short."
+                >
+                    <Input
+                        trailingIcon="lucide:eye"
+                        placeholder="Enter your password"
+                        type="password"
+                    />
+                </FormField>
+            </div>
+        </div>
+    </section>
+
+    <!-- FieldGroup Integration -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">FieldGroup Integration</h2>
+        <p class="text-sm text-on-surface-variant">
+            When used inside a <code class="rounded bg-surface-container-highest px-1"
+                >FieldGroup</code
+            >, inputs are visually connected.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="space-y-4">
+                <div>
+                    <p class="mb-2 text-xs text-on-surface-variant">Horizontal</p>
+                    <FieldGroup orientation="horizontal">
+                        <Input placeholder="First name" />
+                        <Input placeholder="Last name" />
+                        <Input placeholder="Email" />
+                    </FieldGroup>
+                </div>
+
+                <div>
+                    <p class="mb-2 text-xs text-on-surface-variant">Vertical</p>
+                    <FieldGroup orientation="vertical">
+                        <Input placeholder="Street address" />
+                        <Input placeholder="City" />
+                        <Input placeholder="Zip code" />
+                    </FieldGroup>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>

--- a/src/routes/timeline/+page.svelte
+++ b/src/routes/timeline/+page.svelte
@@ -229,14 +229,16 @@
                 </div>
 
                 <div class="space-y-2">
-                    <label class="text-sm font-medium">Active Step: {playgroundValue}</label>
-                    <input
-                        type="range"
-                        min="1"
-                        max="4"
-                        bind:value={playgroundValue}
-                        class="w-full accent-primary"
-                    />
+                    <label class="text-sm font-medium">
+                        Active Step: {playgroundValue}
+                        <input
+                            type="range"
+                            min="1"
+                            max="4"
+                            bind:value={playgroundValue}
+                            class="w-full accent-primary"
+                        />
+                    </label>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary

- Add new `Input` component with 5 visual variants (`outline`, `soft`, `subtle`, `ghost`, `none`), 8 color schemes, 5 sizes (`xs`–`xl`), leading/trailing icons, avatar support, loading state, and two-way `bind:value` binding
- Integrate with `FormField` context (auto `id`, `name`, `aria-describedby`, error highlight) and `FieldGroup` context (shared size, connected borders via `fieldGroupVariantWithRoot`)
- Add 65 browser-based test cases covering rendering, disabled/loading states, variants, colors, sizes, highlight, icons, avatar, events, accessibility, and combined props
- Add interactive demo page at `/input` with sections for basic usage, two-way binding, variants × colors matrix, sizes, icons, avatar, loading, disabled, highlight, FormField integration, and FieldGroup integration
- Update `FieldGroup` demo page with Input + Button combination examples (horizontal, vertical, size propagation)
- Fix accessibility warnings: associate `<label>` elements with their form controls in timeline and accordion demo pages
- Add `Input` and `FormField` entries to README components table

## New files

| File | Description |
|:-----|:------------|
| `src/lib/Input/input.variants.ts` | Tailwind Variants definition with 8 slots, 5 variants × 8 colors compound matrix, size/leading/trailing/loading/highlight compound variants |
| `src/lib/Input/input.types.ts` | `InputProps` type extending `HTMLInputAttributes` with variant, icon, avatar, slot, and styling props |
| `src/lib/Input/Input.svelte` | Component implementation with FormField/FieldGroup context integration, derived classes, and accessible markup |
| `src/lib/Input/index.ts` | Barrel export for `Input` component and `InputProps` type |
| `src/lib/Input/Input.svelte.spec.ts` | 65 vitest-browser-svelte test cases |
| `src/routes/input/+page.svelte` | Interactive demo page |

## Modified files

| File | Change |
|:-----|:-------|
| `src/lib/index.ts` | Add `Input` re-export |
| `src/routes/+layout.svelte` | Add Input nav item to sidebar |
| `src/routes/field-group/+page.svelte` | Add Input + Button demo sections (horizontal, vertical, sizes) |
| `src/routes/accordion/+page.svelte` | Fix label-control association (a11y) |
| `src/routes/timeline/+page.svelte` | Fix label-control association (a11y) |
| `README.md` | Add Input, FormField to components table |

## Test plan

- [ ] `pnpm check` — TypeScript passes with 0 errors
- [ ] `pnpm test` — All 65 new Input tests pass (1273 total)
- [ ] Navigate to `/input` — verify all demo sections render correctly
- [ ] Verify variant × color matrix, all 5 sizes, leading/trailing icons, avatar, loading spinner
- [ ] Test `bind:value` two-way binding updates live
- [ ] Navigate to `/field-group` — verify Input + Button combinations with connected borders
- [ ] Verify FormField integration: error state auto-highlights Input, aria attributes propagate
- [ ] Verify no "label must be associated with a control" warnings on `/accordion` and `/timeline`