### PR TITLE
feat: add Select component with variants, icons, avatars, and FormField/FieldGroup integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,9 @@ pnpm add sv5ui
 
 | Component                            | Description                                                                         |
 | :----------------------------------- | :---------------------------------------------------------------------------------- |
-| [**Input**](src/lib/Input)           | Text input with 5 variants, icons, avatar, loading state, and FormField integration |
-| [**FormField**](src/lib/FormField)   | Form control wrapper providing label, description, hint, help, and error handling   |
+| [**Input**](src/lib/Input)           | Text input with 5 variants, icons, avatar, loading state, and FormField integration           |
+| [**Select**](src/lib/Select)         | Dropdown select with 5 variants, icons, avatars, groups, descriptions, and FormField support  |
+| [**FormField**](src/lib/FormField)   | Form control wrapper providing label, description, hint, help, and error handling             |
 | [**FieldGroup**](src/lib/FieldGroup) | Groups buttons and inputs with seamless borders and shared size/orientation context |
 | [**Calendar**](src/lib/Calendar)     | Date picker calendar with single, multiple, and range selection modes               |
 

--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ pnpm add sv5ui
 
 ### Form
 
-| Component                            | Description                                                                         |
-| :----------------------------------- | :---------------------------------------------------------------------------------- |
-| [**Input**](src/lib/Input)           | Text input with 5 variants, icons, avatar, loading state, and FormField integration           |
-| [**Select**](src/lib/Select)         | Dropdown select with 5 variants, icons, avatars, groups, descriptions, and FormField support  |
-| [**FormField**](src/lib/FormField)   | Form control wrapper providing label, description, hint, help, and error handling             |
-| [**FieldGroup**](src/lib/FieldGroup) | Groups buttons and inputs with seamless borders and shared size/orientation context |
-| [**Calendar**](src/lib/Calendar)     | Date picker calendar with single, multiple, and range selection modes               |
+| Component                            | Description                                                                                  |
+| :----------------------------------- | :------------------------------------------------------------------------------------------- |
+| [**Input**](src/lib/Input)           | Text input with 5 variants, icons, avatar, loading state, and FormField integration          |
+| [**Select**](src/lib/Select)         | Dropdown select with 5 variants, icons, avatars, groups, descriptions, and FormField support |
+| [**FormField**](src/lib/FormField)   | Form control wrapper providing label, description, hint, help, and error handling            |
+| [**FieldGroup**](src/lib/FieldGroup) | Groups buttons and inputs with seamless borders and shared size/orientation context          |
+| [**Calendar**](src/lib/Calendar)     | Date picker calendar with single, multiple, and range selection modes                        |
 
 ## Theming
 

--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -125,11 +125,7 @@
     const displayIcon = $derived(selectedItem?.icon ?? leadingIcon ?? icon)
     const isLeading = $derived(!!leadingSlot || !!displayAvatar || !!displayIcon)
     const leadingIconName = $derived(
-        loading && isLeading
-            ? loadingIcon
-            : !displayAvatar
-              ? displayIcon
-              : undefined
+        loading && isLeading ? loadingIcon : !displayAvatar ? displayIcon : undefined
     )
 
     // ---- bits-ui items for typeahead ----
@@ -372,10 +368,7 @@
             </span>
         {:else}
             <span class={trailingClass}>
-                <Icon
-                    name={trailingIconName}
-                    class="{trailingIconBaseClass} {trailingIconClass}"
-                />
+                <Icon name={trailingIconName} class="{trailingIconBaseClass} {trailingIconClass}" />
             </span>
         {/if}
     </div>

--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -1,0 +1,390 @@
+<script lang="ts" module>
+    import type { SelectProps, SelectItem, SelectItemType } from './select.types.js'
+
+    export type Props = SelectProps
+</script>
+
+<script lang="ts">
+    import { Select } from 'bits-ui'
+    import { selectVariants, selectDefaults } from './select.variants.js'
+    import { getComponentConfig, iconsDefaults } from '../config.js'
+    import { getContext } from 'svelte'
+    import {
+        fieldGroupVariantWithRoot,
+        type FieldGroupVariantProps
+    } from '../FieldGroup/field-group.variants.js'
+    import Icon from '../Icon/Icon.svelte'
+    import Avatar from '../Avatar/Avatar.svelte'
+    import type { AvatarSize } from '../Avatar/avatar.types.js'
+    import type { FormFieldProps } from '../FormField/form-field.types.js'
+
+    const config = getComponentConfig('select', selectDefaults)
+    const icons = getComponentConfig('icons', iconsDefaults)
+
+    let {
+        value = $bindable(),
+        open = $bindable(false),
+        onOpenChange,
+        items = [],
+        placeholder,
+        name,
+        required = false,
+        disabled = false,
+        ui,
+        id,
+        color = config.defaultVariants.color,
+        variant = config.defaultVariants.variant,
+        size,
+        highlight,
+        loading = false,
+        loadingIcon = icons.loading,
+        icon,
+        leadingIcon,
+        trailingIcon = icons.chevronDown,
+        selectedIcon = icons.check,
+        avatar,
+        transition = config.defaultVariants.transition ?? true,
+        portal = true,
+        side = config.defaultVariants.side ?? 'bottom',
+        sideOffset = 4,
+        align = 'start',
+        alignOffset = 0,
+        avoidCollisions = true,
+        collisionBoundary,
+        collisionPadding = 8,
+        onEscapeKeydown,
+        onInteractOutside,
+        forceMount,
+        loop = true,
+        class: className,
+        leadingSlot,
+        trailingSlot,
+        item: itemSlot,
+        itemLeading,
+        itemLabel: itemLabelSlot,
+        itemTrailing,
+        content: contentSlot
+    }: Props = $props()
+
+    // ---- Form context ----
+    const formFieldContext = getContext<
+        | {
+              name?: string
+              size: NonNullable<FormFieldProps['size']>
+              error?: string | boolean
+              ariaId: string
+          }
+        | undefined
+    >('formField')
+
+    const fieldGroupContext = getContext<
+        | {
+              orientation: NonNullable<FieldGroupVariantProps['orientation']>
+              size: NonNullable<FieldGroupVariantProps['size']>
+          }
+        | undefined
+    >('fieldGroup')
+
+    const hasError = $derived(
+        formFieldContext?.error !== undefined && formFieldContext?.error !== false
+    )
+    const resolvedSize = $derived(
+        size ?? formFieldContext?.size ?? fieldGroupContext?.size ?? config.defaultVariants.size
+    )
+    const resolvedColor = $derived(hasError ? 'error' : color)
+    const resolvedHighlight = $derived(highlight ?? hasError)
+    const fieldGroupClass = $derived(
+        fieldGroupContext
+            ? fieldGroupVariantWithRoot.fieldGroup[fieldGroupContext.orientation ?? 'horizontal']
+            : undefined
+    )
+    const resolvedId = $derived(id ?? formFieldContext?.ariaId)
+    const resolvedName = $derived(name ?? formFieldContext?.name)
+
+    // ---- ARIA ----
+    const ariaDescribedBy = $derived.by(() => {
+        if (!formFieldContext) return undefined
+        const fid = formFieldContext.ariaId
+        return hasError ? `${fid}-error` : `${fid}-description ${fid}-help`
+    })
+
+    // ---- Items lookup (O(1) via Map) ----
+    const itemsMap = $derived(
+        new Map(
+            (items as SelectItemType[])
+                .filter((i): i is SelectItem => !('type' in i))
+                .map((i) => [i.value, i])
+        )
+    )
+
+    const selectedItem = $derived(value ? itemsMap.get(value) : undefined)
+    const displayLabel = $derived(selectedItem?.label ?? selectedItem?.value ?? '')
+
+    // ---- Leading / trailing ----
+    const displayAvatar = $derived(selectedItem?.avatar ?? avatar)
+    const displayIcon = $derived(selectedItem?.icon ?? leadingIcon ?? icon)
+    const isLeading = $derived(!!leadingSlot || !!displayAvatar || !!displayIcon)
+    const leadingIconName = $derived(
+        loading && isLeading
+            ? loadingIcon
+            : !displayAvatar
+              ? displayIcon
+              : undefined
+    )
+
+    // ---- bits-ui items for typeahead ----
+    const bitsItems = $derived(
+        [...itemsMap.values()].map((i) => ({
+            value: i.value,
+            label: i.label ?? i.value,
+            disabled: i.disabled
+        }))
+    )
+
+    // ---- Trailing icon ----
+    const trailingIconName = $derived(loading && !isLeading ? loadingIcon : trailingIcon)
+    const trailingIconClass = $derived(
+        `${loading && !isLeading ? 'animate-spin' : 'transition-transform'} ${open && !loading ? 'rotate-180' : ''}`
+    )
+
+    // ---- Variant slots ----
+    const variantSlots = $derived(
+        selectVariants({
+            variant,
+            color: resolvedColor,
+            size: resolvedSize,
+            leading: isLeading,
+            trailing: true,
+            loading,
+            highlight: resolvedHighlight,
+            side,
+            transition
+        })
+    )
+
+    // ---- Trigger classes (root, base, leading, trailing, value, placeholder) ----
+    const rootClass = $derived(
+        variantSlots.root({
+            class: [config.slots.root, fieldGroupClass?.root, className, ui?.root]
+        })
+    )
+    const baseClass = $derived(
+        variantSlots.base({
+            class: [config.slots.base, fieldGroupClass?.base, ui?.base]
+        })
+    )
+    const leadingClass = $derived(
+        variantSlots.leading({ class: [config.slots.leading, ui?.leading] })
+    )
+    const leadingIconClass = $derived(
+        variantSlots.leadingIcon({ class: [config.slots.leadingIcon, ui?.leadingIcon] })
+    )
+    const leadingAvatarClass = $derived(
+        variantSlots.leadingAvatar({ class: [config.slots.leadingAvatar, ui?.leadingAvatar] })
+    )
+    const leadingAvatarSizeClass = $derived(variantSlots.leadingAvatarSize() as AvatarSize)
+    const trailingClass = $derived(
+        variantSlots.trailing({ class: [config.slots.trailing, ui?.trailing] })
+    )
+    const trailingIconBaseClass = $derived(
+        variantSlots.trailingIcon({ class: [config.slots.trailingIcon, ui?.trailingIcon] })
+    )
+    const valueClass = $derived(variantSlots.value({ class: [config.slots.value, ui?.value] }))
+    const placeholderClass = $derived(
+        variantSlots.placeholder({ class: [config.slots.placeholder, ui?.placeholder] })
+    )
+
+    // ---- Content classes ----
+    const contentClass = $derived(
+        variantSlots.content({ class: [config.slots.content, ui?.content] })
+    )
+    const viewportClass = $derived(
+        variantSlots.viewport({ class: [config.slots.viewport, ui?.viewport] })
+    )
+    const groupLabelClass = $derived(
+        variantSlots.groupLabel({ class: [config.slots.groupLabel, ui?.groupLabel] })
+    )
+    const separatorClass = $derived(
+        variantSlots.separator({ class: [config.slots.separator, ui?.separator] })
+    )
+
+    // ---- Item classes ----
+    const itemClass = $derived(variantSlots.item({ class: [config.slots.item, ui?.item] }))
+    const itemIconClass = $derived(
+        variantSlots.itemIcon({ class: [config.slots.itemIcon, ui?.itemIcon] })
+    )
+    const itemAvatarClass = $derived(
+        variantSlots.itemAvatar({ class: [config.slots.itemAvatar, ui?.itemAvatar] })
+    )
+    const itemAvatarSizeClass = $derived(variantSlots.itemAvatarSize() as AvatarSize)
+    const itemLabelClass = $derived(
+        variantSlots.itemLabel({ class: [config.slots.itemLabel, ui?.itemLabel] })
+    )
+    const itemDescriptionClass = $derived(
+        variantSlots.itemDescription({
+            class: [config.slots.itemDescription, ui?.itemDescription]
+        })
+    )
+    const itemIndicatorClass = $derived(
+        variantSlots.itemIndicator({ class: [config.slots.itemIndicator, ui?.itemIndicator] })
+    )
+
+    // ---- Type guards ----
+    function isSelectItem(item: SelectItemType): item is SelectItem {
+        return !('type' in item)
+    }
+
+    function isSeparator(item: SelectItemType): item is { type: 'separator' } {
+        return 'type' in item && item.type === 'separator'
+    }
+
+    function isLabel(item: SelectItemType): item is { type: 'label'; label: string } {
+        return 'type' in item && item.type === 'label'
+    }
+</script>
+
+{#snippet renderItem(item: SelectItem, index: number)}
+    {@const isSelected = value === item.value}
+    <Select.Item
+        value={item.value}
+        label={item.label ?? item.value}
+        disabled={item.disabled}
+        class={itemClass}
+    >
+        {#if itemLeading}
+            {@render itemLeading({ item, index, selected: isSelected })}
+        {:else if item.avatar}
+            <Avatar {...item.avatar} size={itemAvatarSizeClass} class={itemAvatarClass} />
+        {:else if item.icon}
+            <Icon name={item.icon} class={itemIconClass} />
+        {/if}
+
+        {#if itemLabelSlot}
+            {@render itemLabelSlot({ item, index, selected: isSelected })}
+        {:else}
+            <div class={item.description ? 'flex flex-col' : undefined}>
+                <span class={itemLabelClass}>{item.label ?? item.value}</span>
+                {#if item.description}
+                    <span class={itemDescriptionClass}>{item.description}</span>
+                {/if}
+            </div>
+        {/if}
+
+        {#if itemTrailing}
+            {@render itemTrailing({ item, index, selected: isSelected })}
+        {:else if isSelected}
+            <Icon name={selectedIcon} class={itemIndicatorClass} />
+        {/if}
+    </Select.Item>
+{/snippet}
+
+{#snippet selectContentEl()}
+    <Select.Content
+        {side}
+        {sideOffset}
+        {align}
+        {alignOffset}
+        {avoidCollisions}
+        {collisionBoundary}
+        {collisionPadding}
+        {onEscapeKeydown}
+        {onInteractOutside}
+        {forceMount}
+        {loop}
+        class={contentClass}
+    >
+        <Select.Viewport class={viewportClass}>
+            {#if contentSlot}
+                {@render contentSlot({ open })}
+            {:else}
+                {#each items as selectItem, index (index)}
+                    {#if isSeparator(selectItem)}
+                        <div role="separator" class={separatorClass}></div>
+                    {:else if isLabel(selectItem)}
+                        <Select.Group>
+                            <Select.GroupHeading class={groupLabelClass}
+                                >{selectItem.label}</Select.GroupHeading
+                            >
+                        </Select.Group>
+                    {:else if isSelectItem(selectItem)}
+                        {#if itemSlot}
+                            {@render itemSlot({
+                                item: selectItem,
+                                index,
+                                selected: value === selectItem.value
+                            })}
+                        {:else}
+                            {@render renderItem(selectItem, index)}
+                        {/if}
+                    {/if}
+                {/each}
+            {/if}
+        </Select.Viewport>
+    </Select.Content>
+{/snippet}
+
+<Select.Root
+    type="single"
+    bind:open
+    onOpenChange={(val) => onOpenChange?.(val)}
+    {disabled}
+    {required}
+    items={bitsItems}
+    {value}
+    onValueChange={(val) => (value = val)}
+>
+    <div class={rootClass}>
+        {#if leadingSlot}
+            <span class={leadingClass}>
+                {@render leadingSlot()}
+            </span>
+        {:else if isLeading && leadingIconName}
+            <span class={leadingClass}>
+                <Icon name={leadingIconName} class={leadingIconClass} />
+            </span>
+        {:else if displayAvatar}
+            <span class={leadingClass}>
+                <Avatar
+                    {...displayAvatar}
+                    size={leadingAvatarSizeClass}
+                    class={leadingAvatarClass}
+                />
+            </span>
+        {/if}
+
+        <Select.Trigger
+            id={resolvedId}
+            name={resolvedName}
+            aria-describedby={ariaDescribedBy}
+            aria-invalid={resolvedHighlight ? true : undefined}
+            class={baseClass}
+        >
+            {#if value && displayLabel}
+                <span class={valueClass}>{displayLabel}</span>
+            {:else if placeholder}
+                <span class={placeholderClass}>{placeholder}</span>
+            {/if}
+        </Select.Trigger>
+
+        {#if trailingSlot}
+            <span class={trailingClass}>
+                {@render trailingSlot()}
+            </span>
+        {:else}
+            <span class={trailingClass}>
+                <Icon
+                    name={trailingIconName}
+                    class="{trailingIconBaseClass} {trailingIconClass}"
+                />
+            </span>
+        {/if}
+    </div>
+
+    {#if portal}
+        <Select.Portal>
+            {@render selectContentEl()}
+        </Select.Portal>
+    {:else}
+        {@render selectContentEl()}
+    {/if}
+</Select.Root>

--- a/src/lib/Select/index.ts
+++ b/src/lib/Select/index.ts
@@ -1,0 +1,2 @@
+export { default as Select } from './Select.svelte'
+export type { SelectProps, SelectItem, SelectItemType } from './select.types.js'

--- a/src/lib/Select/select.types.ts
+++ b/src/lib/Select/select.types.ts
@@ -1,0 +1,313 @@
+import type { Snippet } from 'svelte'
+import type { ClassNameValue } from 'tailwind-merge'
+import type { SelectVariantProps, SelectSlots } from './select.variants.js'
+import type { AvatarProps } from '../Avatar/avatar.types.js'
+import type {
+    SelectRootPropsWithoutHTML,
+    SelectContentPropsWithoutHTML
+} from 'bits-ui'
+
+// ============================================================================
+// Item Types
+// ============================================================================
+
+/**
+ * A single selectable option within the Select.
+ */
+export interface SelectItem {
+    /**
+     * The value submitted on form submission or returned via binding.
+     */
+    value: string
+
+    /**
+     * The display text for this item.
+     * Falls back to `value` when not provided.
+     */
+    label?: string
+
+    /**
+     * Optional description shown below the label.
+     */
+    description?: string
+
+    /**
+     * Icon displayed before the label.
+     * Supports any Iconify icon name.
+     */
+    icon?: string
+
+    /**
+     * Avatar displayed before the label.
+     * Takes precedence over `icon`.
+     */
+    avatar?: AvatarProps
+
+    /**
+     * Whether this item is disabled.
+     * @default false
+     */
+    disabled?: boolean
+}
+
+/**
+ * A visual separator between items.
+ */
+export interface SelectItemSeparator {
+    type: 'separator'
+}
+
+/**
+ * A non-selectable group label/heading.
+ */
+export interface SelectItemLabel {
+    type: 'label'
+
+    /**
+     * The text displayed as the group label.
+     */
+    label: string
+}
+
+/**
+ * Union type for all possible select items.
+ */
+export type SelectItemType = SelectItem | SelectItemSeparator | SelectItemLabel
+
+// ============================================================================
+// Slot Props Types
+// ============================================================================
+
+/**
+ * Props passed to select item snippet slots.
+ */
+export interface SelectItemSlotProps {
+    /** The current select item data */
+    item: SelectItem
+    /** Zero-based index of the item */
+    index: number
+    /** Whether the item is currently selected */
+    selected?: boolean
+}
+
+// ============================================================================
+// Component Props
+// ============================================================================
+
+type RootProps = Pick<
+    SelectRootPropsWithoutHTML,
+    'open' | 'onOpenChange' | 'name' | 'required' | 'disabled'
+>
+
+type ContentProps = Pick<
+    SelectContentPropsWithoutHTML,
+    | 'side'
+    | 'sideOffset'
+    | 'align'
+    | 'alignOffset'
+    | 'avoidCollisions'
+    | 'collisionBoundary'
+    | 'collisionPadding'
+    | 'onEscapeKeydown'
+    | 'onInteractOutside'
+    | 'forceMount'
+    | 'loop'
+>
+
+/**
+ * Props for the Select component.
+ *
+ * @example
+ * ```svelte
+ * <Select
+ *   items={[
+ *     { value: 'apple', label: 'Apple' },
+ *     { value: 'banana', label: 'Banana' },
+ *   ]}
+ *   placeholder="Pick a fruit"
+ * />
+ * ```
+ *
+ * @see https://bits-ui.com/docs/components/select
+ */
+export interface SelectProps extends RootProps, ContentProps {
+    // -------------------------------------------------------------------------
+    // Data
+    // -------------------------------------------------------------------------
+
+    /**
+     * The currently selected value. Supports two-way binding with `bind:value`.
+     */
+    value?: string
+
+    /**
+     * The default selected value when uncontrolled.
+     */
+    defaultValue?: string
+
+    /**
+     * Array of items to display in the select dropdown.
+     */
+    items?: SelectItemType[]
+
+    /**
+     * Placeholder text shown when no value is selected.
+     */
+    placeholder?: string
+
+    // -------------------------------------------------------------------------
+    // Visual
+    // -------------------------------------------------------------------------
+
+    /**
+     * Controls the visual style of the select trigger.
+     * @default 'outline'
+     */
+    variant?: NonNullable<SelectVariantProps['variant']>
+
+    /**
+     * Sets the color scheme for focus ring and highlight.
+     * @default 'primary'
+     */
+    color?: NonNullable<SelectVariantProps['color']>
+
+    /**
+     * Controls the dimensions and text size.
+     * @default 'md'
+     */
+    size?: NonNullable<SelectVariantProps['size']>
+
+    /**
+     * Emphasizes ring color like focus state, even when not focused.
+     * Automatically enabled when used inside a FormField with an error.
+     * @default false
+     */
+    highlight?: boolean
+
+    // -------------------------------------------------------------------------
+    // Icons & Avatars
+    // -------------------------------------------------------------------------
+
+    /**
+     * Icon displayed on the leading side of the trigger.
+     * Supports any valid Iconify icon name.
+     */
+    icon?: string
+
+    /**
+     * Icon placed before the selected value.
+     * Supports any valid Iconify icon name.
+     */
+    leadingIcon?: string
+
+    /**
+     * Icon placed after the selected value (chevron area).
+     * @default 'lucide:chevron-down'
+     */
+    trailingIcon?: string
+
+    /**
+     * Icon displayed next to selected items in the dropdown.
+     * @default 'lucide:check'
+     */
+    selectedIcon?: string
+
+    /**
+     * Renders a loading spinner.
+     * @default false
+     */
+    loading?: boolean
+
+    /**
+     * Icon displayed as the loading indicator.
+     * @default Uses `icons.loading` from app config
+     */
+    loadingIcon?: string
+
+    /**
+     * Avatar displayed before the selected value on the trigger.
+     * Takes precedence over `leadingIcon`.
+     */
+    avatar?: AvatarProps
+
+    // -------------------------------------------------------------------------
+    // Behavior
+    // -------------------------------------------------------------------------
+
+    /**
+     * Animate the dropdown on open and close.
+     * @default true
+     */
+    transition?: SelectVariantProps['transition']
+
+    /**
+     * Render the dropdown content in a portal.
+     * @default true
+     */
+    portal?: boolean
+
+    /**
+     * The HTML `id` attribute for the trigger element.
+     */
+    id?: string
+
+    // -------------------------------------------------------------------------
+    // Styling
+    // -------------------------------------------------------------------------
+
+    /**
+     * Additional CSS classes for the root wrapper.
+     */
+    class?: ClassNameValue
+
+    /**
+     * Override classes for specific select slots.
+     */
+    ui?: Partial<Record<SelectSlots, ClassNameValue>>
+
+    // -------------------------------------------------------------------------
+    // Slots (Snippets)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Custom content rendered before the selected value in the trigger.
+     * Takes precedence over `avatar` and `leadingIcon`.
+     */
+    leadingSlot?: Snippet
+
+    /**
+     * Custom content rendered after the selected value in the trigger.
+     * Takes precedence over `trailingIcon`.
+     */
+    trailingSlot?: Snippet
+
+    /**
+     * Custom snippet for rendering individual items in the dropdown.
+     * When provided, replaces the default item rendering.
+     */
+    item?: Snippet<[SelectItemSlotProps]>
+
+    /**
+     * Custom snippet for the leading section of items.
+     * Replaces the default icon/avatar when provided.
+     */
+    itemLeading?: Snippet<[SelectItemSlotProps]>
+
+    /**
+     * Custom snippet for the label section of items.
+     * Replaces the default label text when provided.
+     */
+    itemLabel?: Snippet<[SelectItemSlotProps]>
+
+    /**
+     * Custom snippet for the trailing section of items (selected indicator area).
+     * Replaces the default check icon when provided.
+     */
+    itemTrailing?: Snippet<[SelectItemSlotProps]>
+
+    /**
+     * Custom dropdown content.
+     * When provided, replaces the default items rendering entirely.
+     */
+    content?: Snippet<[{ open: boolean }]>
+}

--- a/src/lib/Select/select.types.ts
+++ b/src/lib/Select/select.types.ts
@@ -2,10 +2,7 @@ import type { Snippet } from 'svelte'
 import type { ClassNameValue } from 'tailwind-merge'
 import type { SelectVariantProps, SelectSlots } from './select.variants.js'
 import type { AvatarProps } from '../Avatar/avatar.types.js'
-import type {
-    SelectRootPropsWithoutHTML,
-    SelectContentPropsWithoutHTML
-} from 'bits-ui'
+import type { SelectRootPropsWithoutHTML, SelectContentPropsWithoutHTML } from 'bits-ui'
 
 // ============================================================================
 // Item Types

--- a/src/lib/Select/select.variants.ts
+++ b/src/lib/Select/select.variants.ts
@@ -1,0 +1,500 @@
+import { tv, type VariantProps } from 'tailwind-variants'
+
+export const selectVariants = tv({
+    slots: {
+        root: 'relative w-full inline-flex items-center',
+        base: [
+            'w-full rounded-md border-0 bg-surface text-on-surface',
+            'disabled:cursor-not-allowed disabled:opacity-75',
+            'transition-colors',
+            'focus:outline-none',
+            'inline-flex items-center'
+        ],
+        leading: 'absolute inset-y-0 start-0 flex items-center pointer-events-none',
+        leadingIcon: 'shrink-0 text-on-surface-variant/75',
+        leadingAvatar: 'shrink-0',
+        leadingAvatarSize: '',
+        trailing: 'absolute inset-y-0 end-0 flex items-center pointer-events-none',
+        trailingIcon: 'shrink-0 text-on-surface-variant/75',
+        value: 'truncate',
+        placeholder: 'truncate text-on-surface-variant/50',
+        content: [
+            'z-50 min-w-(--bits-select-anchor-width)',
+            'bg-surface-container-low text-on-surface',
+            'rounded-md',
+            'ring ring-outline-variant/50',
+            'shadow-lg',
+            'focus:outline-none',
+            'overflow-hidden'
+        ],
+        viewport: 'p-1',
+        group: '',
+        groupLabel: 'px-2 py-1.5 text-xs font-semibold text-on-surface-variant',
+        item: [
+            'group relative flex items-center gap-2 w-full rounded-sm px-2 cursor-pointer select-none',
+            'focus:outline-none',
+            'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+            'data-[highlighted]:bg-surface-container-highest'
+        ],
+        itemIcon: 'shrink-0',
+        itemAvatar: 'shrink-0',
+        itemAvatarSize: '',
+        itemLabel: 'flex-1 truncate',
+        itemDescription: 'text-on-surface-variant',
+        itemIndicator: 'ml-auto shrink-0',
+        separator: '-mx-1 my-1 h-px bg-outline-variant'
+    },
+    variants: {
+        variant: {
+            outline: '',
+            soft: '',
+            subtle: '',
+            ghost: '',
+            none: ''
+        },
+        color: {
+            primary: '',
+            secondary: '',
+            tertiary: '',
+            success: '',
+            warning: '',
+            error: '',
+            info: '',
+            surface: ''
+        },
+        size: {
+            xs: {
+                base: 'px-2 py-1 text-xs rounded',
+                leading: 'ps-2',
+                leadingIcon: 'size-3.5',
+                leadingAvatarSize: '3xs',
+                trailing: 'pe-2',
+                trailingIcon: 'size-3.5',
+                item: 'py-1 text-xs',
+                itemIcon: 'size-3',
+                itemAvatarSize: '3xs',
+                itemIndicator: 'size-3',
+                itemDescription: 'text-[10px]',
+                groupLabel: 'text-[10px]'
+            },
+            sm: {
+                base: 'px-2.5 py-1.5 text-xs rounded-md',
+                leading: 'ps-2.5',
+                leadingIcon: 'size-4',
+                leadingAvatarSize: '3xs',
+                trailing: 'pe-2.5',
+                trailingIcon: 'size-4',
+                item: 'py-1.5 text-xs',
+                itemIcon: 'size-3.5',
+                itemAvatarSize: '3xs',
+                itemIndicator: 'size-3.5',
+                itemDescription: 'text-[11px]',
+                groupLabel: 'text-[11px]'
+            },
+            md: {
+                base: 'px-3 py-2 text-sm rounded-md',
+                leading: 'ps-3',
+                leadingIcon: 'size-5',
+                leadingAvatarSize: '2xs',
+                trailing: 'pe-3',
+                trailingIcon: 'size-5',
+                item: 'py-1.5 text-sm',
+                itemIcon: 'size-4',
+                itemAvatarSize: '2xs',
+                itemIndicator: 'size-4',
+                itemDescription: 'text-xs'
+            },
+            lg: {
+                base: 'px-4 py-2.5 text-sm rounded-md',
+                leading: 'ps-4',
+                leadingIcon: 'size-5',
+                leadingAvatarSize: '2xs',
+                trailing: 'pe-4',
+                trailingIcon: 'size-5',
+                item: 'py-2 text-sm',
+                itemIcon: 'size-5',
+                itemAvatarSize: '2xs',
+                itemIndicator: 'size-5',
+                itemDescription: 'text-xs'
+            },
+            xl: {
+                base: 'px-5 py-3 text-base rounded-lg',
+                leading: 'ps-5',
+                leadingIcon: 'size-6',
+                leadingAvatarSize: 'xs',
+                trailing: 'pe-5',
+                trailingIcon: 'size-6',
+                item: 'py-2.5 text-base',
+                itemIcon: 'size-5',
+                itemAvatarSize: 'xs',
+                itemIndicator: 'size-5',
+                itemDescription: 'text-sm'
+            }
+        },
+        leading: {
+            true: ''
+        },
+        trailing: {
+            true: ''
+        },
+        loading: {
+            true: ''
+        },
+        highlight: {
+            true: ''
+        },
+        side: {
+            top: {
+                content:
+                    'data-[state=open]:animate-[slide-in-from-bottom_150ms_ease-out] data-[state=closed]:animate-[slide-in-from-top_100ms_ease-in_reverse]'
+            },
+            right: {
+                content:
+                    'data-[state=open]:animate-[slide-in-from-left_150ms_ease-out] data-[state=closed]:animate-[slide-in-from-right_100ms_ease-in_reverse]'
+            },
+            bottom: {
+                content:
+                    'data-[state=open]:animate-[slide-in-from-top_150ms_ease-out] data-[state=closed]:animate-[slide-in-from-bottom_100ms_ease-in_reverse]'
+            },
+            left: {
+                content:
+                    'data-[state=open]:animate-[slide-in-from-right_150ms_ease-out] data-[state=closed]:animate-[slide-in-from-left_100ms_ease-in_reverse]'
+            }
+        },
+        transition: {
+            true: {
+                content:
+                    'data-[state=open]:animate-[fade-in_150ms_ease-out,scale-in_150ms_ease-out] data-[state=closed]:animate-[fade-out_100ms_ease-in,scale-out_100ms_ease-in]'
+            }
+        }
+    },
+    compoundVariants: [
+        // ========== OUTLINE VARIANTS ==========
+        {
+            variant: 'outline',
+            color: 'primary',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-primary data-[state=open]:ring-2 data-[state=open]:ring-primary'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'secondary',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-secondary data-[state=open]:ring-2 data-[state=open]:ring-secondary'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'tertiary',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-tertiary data-[state=open]:ring-2 data-[state=open]:ring-tertiary'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'success',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-success data-[state=open]:ring-2 data-[state=open]:ring-success'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'warning',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-warning data-[state=open]:ring-2 data-[state=open]:ring-warning'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'error',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-error data-[state=open]:ring-2 data-[state=open]:ring-error'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'info',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-info data-[state=open]:ring-2 data-[state=open]:ring-info'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'surface',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-outline data-[state=open]:ring-2 data-[state=open]:ring-outline'
+            }
+        },
+
+        // ========== SOFT VARIANTS ==========
+        {
+            variant: 'soft',
+            color: 'primary',
+            class: {
+                base: 'bg-primary-container/50 focus:bg-primary-container/75 focus:ring-2 focus:ring-inset focus:ring-primary data-[state=open]:bg-primary-container/75 data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-primary'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'secondary',
+            class: {
+                base: 'bg-secondary-container/50 focus:bg-secondary-container/75 focus:ring-2 focus:ring-inset focus:ring-secondary data-[state=open]:bg-secondary-container/75 data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-secondary'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'tertiary',
+            class: {
+                base: 'bg-tertiary-container/50 focus:bg-tertiary-container/75 focus:ring-2 focus:ring-inset focus:ring-tertiary data-[state=open]:bg-tertiary-container/75 data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-tertiary'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'success',
+            class: {
+                base: 'bg-success-container/50 focus:bg-success-container/75 focus:ring-2 focus:ring-inset focus:ring-success data-[state=open]:bg-success-container/75 data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-success'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'warning',
+            class: {
+                base: 'bg-warning-container/50 focus:bg-warning-container/75 focus:ring-2 focus:ring-inset focus:ring-warning data-[state=open]:bg-warning-container/75 data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-warning'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'error',
+            class: {
+                base: 'bg-error-container/50 focus:bg-error-container/75 focus:ring-2 focus:ring-inset focus:ring-error data-[state=open]:bg-error-container/75 data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-error'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'info',
+            class: {
+                base: 'bg-info-container/50 focus:bg-info-container/75 focus:ring-2 focus:ring-inset focus:ring-info data-[state=open]:bg-info-container/75 data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-info'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'surface',
+            class: {
+                base: 'bg-surface-container-highest/50 focus:bg-surface-container-highest/75 focus:ring-2 focus:ring-inset focus:ring-outline data-[state=open]:bg-surface-container-highest/75 data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-outline'
+            }
+        },
+
+        // ========== SUBTLE VARIANTS ==========
+        {
+            variant: 'subtle',
+            color: 'primary',
+            class: {
+                base: 'ring ring-inset ring-primary/25 bg-primary-container/50 focus:ring-2 focus:ring-primary data-[state=open]:ring-2 data-[state=open]:ring-primary'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'secondary',
+            class: {
+                base: 'ring ring-inset ring-secondary/25 bg-secondary-container/50 focus:ring-2 focus:ring-secondary data-[state=open]:ring-2 data-[state=open]:ring-secondary'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'tertiary',
+            class: {
+                base: 'ring ring-inset ring-tertiary/25 bg-tertiary-container/50 focus:ring-2 focus:ring-tertiary data-[state=open]:ring-2 data-[state=open]:ring-tertiary'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'success',
+            class: {
+                base: 'ring ring-inset ring-success/25 bg-success-container/50 focus:ring-2 focus:ring-success data-[state=open]:ring-2 data-[state=open]:ring-success'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'warning',
+            class: {
+                base: 'ring ring-inset ring-warning/25 bg-warning-container/50 focus:ring-2 focus:ring-warning data-[state=open]:ring-2 data-[state=open]:ring-warning'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'error',
+            class: {
+                base: 'ring ring-inset ring-error/25 bg-error-container/50 focus:ring-2 focus:ring-error data-[state=open]:ring-2 data-[state=open]:ring-error'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'info',
+            class: {
+                base: 'ring ring-inset ring-info/25 bg-info-container/50 focus:ring-2 focus:ring-info data-[state=open]:ring-2 data-[state=open]:ring-info'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'surface',
+            class: {
+                base: 'ring ring-inset ring-outline-variant bg-surface-container-highest/50 focus:ring-2 focus:ring-outline data-[state=open]:ring-2 data-[state=open]:ring-outline'
+            }
+        },
+
+        // ========== GHOST VARIANTS ==========
+        {
+            variant: 'ghost',
+            color: 'primary',
+            class: {
+                base: 'bg-transparent hover:bg-primary-container/50 focus:ring-2 focus:ring-inset focus:ring-primary data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-primary'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'secondary',
+            class: {
+                base: 'bg-transparent hover:bg-secondary-container/50 focus:ring-2 focus:ring-inset focus:ring-secondary data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-secondary'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'tertiary',
+            class: {
+                base: 'bg-transparent hover:bg-tertiary-container/50 focus:ring-2 focus:ring-inset focus:ring-tertiary data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-tertiary'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'success',
+            class: {
+                base: 'bg-transparent hover:bg-success-container/50 focus:ring-2 focus:ring-inset focus:ring-success data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-success'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'warning',
+            class: {
+                base: 'bg-transparent hover:bg-warning-container/50 focus:ring-2 focus:ring-inset focus:ring-warning data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-warning'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'error',
+            class: {
+                base: 'bg-transparent hover:bg-error-container/50 focus:ring-2 focus:ring-inset focus:ring-error data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-error'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'info',
+            class: {
+                base: 'bg-transparent hover:bg-info-container/50 focus:ring-2 focus:ring-inset focus:ring-info data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-info'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'surface',
+            class: {
+                base: 'bg-transparent hover:bg-surface-container-highest/50 focus:ring-2 focus:ring-inset focus:ring-outline data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-outline'
+            }
+        },
+
+        // ========== NONE VARIANT ==========
+        {
+            variant: 'none',
+            class: {
+                base: 'bg-transparent focus:ring-0'
+            }
+        },
+
+        // ========== HIGHLIGHT VARIANTS ==========
+        {
+            highlight: true,
+            color: 'primary',
+            class: { base: 'ring-2 ring-inset ring-primary' }
+        },
+        {
+            highlight: true,
+            color: 'secondary',
+            class: { base: 'ring-2 ring-inset ring-secondary' }
+        },
+        {
+            highlight: true,
+            color: 'tertiary',
+            class: { base: 'ring-2 ring-inset ring-tertiary' }
+        },
+        {
+            highlight: true,
+            color: 'success',
+            class: { base: 'ring-2 ring-inset ring-success' }
+        },
+        {
+            highlight: true,
+            color: 'warning',
+            class: { base: 'ring-2 ring-inset ring-warning' }
+        },
+        {
+            highlight: true,
+            color: 'error',
+            class: { base: 'ring-2 ring-inset ring-error' }
+        },
+        {
+            highlight: true,
+            color: 'info',
+            class: { base: 'ring-2 ring-inset ring-info' }
+        },
+        {
+            highlight: true,
+            color: 'surface',
+            class: { base: 'ring-2 ring-inset ring-outline' }
+        },
+
+        // ========== LEADING PADDING ADJUSTMENTS ==========
+        { leading: true, size: 'xs', class: { base: 'ps-7' } },
+        { leading: true, size: 'sm', class: { base: 'ps-8' } },
+        { leading: true, size: 'md', class: { base: 'ps-9' } },
+        { leading: true, size: 'lg', class: { base: 'ps-10' } },
+        { leading: true, size: 'xl', class: { base: 'ps-12' } },
+
+        // ========== TRAILING PADDING ADJUSTMENTS ==========
+        { trailing: true, size: 'xs', class: { base: 'pe-7' } },
+        { trailing: true, size: 'sm', class: { base: 'pe-8' } },
+        { trailing: true, size: 'md', class: { base: 'pe-9' } },
+        { trailing: true, size: 'lg', class: { base: 'pe-10' } },
+        { trailing: true, size: 'xl', class: { base: 'pe-12' } },
+
+        // ========== LOADING ICON ANIMATION ==========
+        {
+            loading: true,
+            leading: true,
+            class: {
+                leadingIcon: 'animate-spin'
+            }
+        },
+        {
+            loading: true,
+            leading: false,
+            trailing: true,
+            class: {
+                trailingIcon: 'animate-spin'
+            }
+        }
+    ],
+    defaultVariants: {
+        variant: 'outline',
+        color: 'primary',
+        size: 'md',
+        side: 'bottom',
+        transition: true
+    }
+})
+
+export type SelectVariantProps = VariantProps<typeof selectVariants>
+export type SelectSlots = keyof ReturnType<typeof selectVariants>
+
+export const selectDefaults = {
+    defaultVariants: selectVariants.defaultVariants,
+    slots: {} as Partial<Record<SelectSlots, string>>
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -31,6 +31,7 @@ export * from './Pagination/index.js'
 export * from './FieldGroup/index.js'
 export * from './FormField/index.js'
 export * from './Input/index.js'
+export * from './Select/index.js'
 
 // Configuration
 export { defineConfig } from './config.js'

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -41,7 +41,8 @@
         { href: '/pagination', label: 'Pagination', icon: 'lucide:chevrons-left-right-ellipsis' },
         { href: '/field-group', label: 'Field Group', icon: 'lucide:group' },
         { href: '/form-field', label: 'Form Field', icon: 'lucide:text-cursor-input' },
-        { href: '/input', label: 'Input', icon: 'lucide:text-cursor' }
+        { href: '/input', label: 'Input', icon: 'lucide:text-cursor' },
+        { href: '/select', label: 'Select', icon: 'lucide:chevrons-up-down' }
     ]
 
     const docItems = [

--- a/src/routes/select/+page.svelte
+++ b/src/routes/select/+page.svelte
@@ -152,12 +152,7 @@
                             >
                             {#each colors as color (color)}
                                 <td class="px-3 py-2">
-                                    <Select
-                                        {variant}
-                                        {color}
-                                        items={fruits}
-                                        placeholder={color}
-                                    />
+                                    <Select {variant} {color} items={fruits} placeholder={color} />
                                 </td>
                             {/each}
                         </tr>
@@ -187,8 +182,8 @@
     <section class="space-y-3">
         <h2 class="text-lg font-semibold">Icons</h2>
         <p class="text-sm text-on-surface-variant">
-            Use <code class="rounded bg-surface-container-highest px-1">leadingIcon</code> to add an
-            icon before the value.
+            Use <code class="rounded bg-surface-container-highest px-1">leadingIcon</code> to add an icon
+            before the value.
         </p>
         <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
             <div class="w-64">
@@ -203,9 +198,7 @@
     <!-- Items with Icons -->
     <section class="space-y-3">
         <h2 class="text-lg font-semibold">Items with Icons</h2>
-        <p class="text-sm text-on-surface-variant">
-            Each item can have its own icon.
-        </p>
+        <p class="text-sm text-on-surface-variant">Each item can have its own icon.</p>
         <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
             <div class="w-64">
                 <Select items={iconItems} placeholder="Choose a page..." />
@@ -262,9 +255,7 @@
     <!-- Disabled Items -->
     <section class="space-y-3">
         <h2 class="text-lg font-semibold">Disabled Items</h2>
-        <p class="text-sm text-on-surface-variant">
-            Individual items can be disabled.
-        </p>
+        <p class="text-sm text-on-surface-variant">Individual items can be disabled.</p>
         <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
             <div class="w-64">
                 <Select items={disabledItems} placeholder="Select status..." />
@@ -303,8 +294,8 @@
     <section class="space-y-3">
         <h2 class="text-lg font-semibold">Highlight</h2>
         <p class="text-sm text-on-surface-variant">
-            Use the <code class="rounded bg-surface-container-highest px-1">highlight</code> prop to
-            emphasize the ring color.
+            Use the <code class="rounded bg-surface-container-highest px-1">highlight</code> prop to emphasize
+            the ring color.
         </p>
         <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
             {#each colors as color (color)}
@@ -319,16 +310,13 @@
     <section class="space-y-3">
         <h2 class="text-lg font-semibold">FormField Integration</h2>
         <p class="text-sm text-on-surface-variant">
-            When used inside a <code class="rounded bg-surface-container-highest px-1">FormField</code>,
-            the Select automatically inherits size, error state, and accessibility attributes.
+            When used inside a <code class="rounded bg-surface-container-highest px-1"
+                >FormField</code
+            >, the Select automatically inherits size, error state, and accessibility attributes.
         </p>
         <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
             <div class="w-full max-w-sm space-y-4">
-                <FormField
-                    label="Country"
-                    description="Select your country of residence."
-                    required
-                >
+                <FormField label="Country" description="Select your country of residence." required>
                     <Select
                         leadingIcon="lucide:globe"
                         items={[
@@ -410,7 +398,8 @@
     <section class="space-y-3">
         <h2 class="text-lg font-semibold">FieldGroup Integration</h2>
         <p class="text-sm text-on-surface-variant">
-            When used inside a <code class="rounded bg-surface-container-highest px-1">FieldGroup</code
+            When used inside a <code class="rounded bg-surface-container-highest px-1"
+                >FieldGroup</code
             >, selects are visually connected.
         </p>
         <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">

--- a/src/routes/select/+page.svelte
+++ b/src/routes/select/+page.svelte
@@ -1,0 +1,436 @@
+<script lang="ts">
+    import { Select, FormField, FieldGroup } from '$lib/index.js'
+    import type { SelectItem, SelectItemType } from '$lib/index.js'
+
+    const variants = ['outline', 'soft', 'subtle', 'ghost', 'none'] as const
+    const colors = [
+        'primary',
+        'secondary',
+        'tertiary',
+        'success',
+        'warning',
+        'error',
+        'info',
+        'surface'
+    ] as const
+    const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const
+
+    let bindValue = $state('')
+
+    const fruits: SelectItem[] = [
+        { value: 'apple', label: 'Apple' },
+        { value: 'banana', label: 'Banana' },
+        { value: 'cherry', label: 'Cherry' },
+        { value: 'grape', label: 'Grape' },
+        { value: 'orange', label: 'Orange' }
+    ]
+
+    const iconItems: SelectItem[] = [
+        { value: 'home', label: 'Home', icon: 'lucide:home' },
+        { value: 'settings', label: 'Settings', icon: 'lucide:settings' },
+        { value: 'profile', label: 'Profile', icon: 'lucide:user' },
+        { value: 'notifications', label: 'Notifications', icon: 'lucide:bell' }
+    ]
+
+    const avatarItems: SelectItem[] = [
+        {
+            value: 'alice',
+            label: 'Alice',
+            avatar: { src: 'https://i.pravatar.cc/120?img=1', alt: 'Alice' }
+        },
+        {
+            value: 'bob',
+            label: 'Bob',
+            avatar: { src: 'https://i.pravatar.cc/120?img=3', alt: 'Bob' }
+        },
+        {
+            value: 'charlie',
+            label: 'Charlie',
+            avatar: { src: 'https://i.pravatar.cc/120?img=5', alt: 'Charlie' }
+        }
+    ]
+
+    const descriptionItems: SelectItem[] = [
+        {
+            value: 'standard',
+            label: 'Standard',
+            description: 'Free shipping, 5-7 business days'
+        },
+        {
+            value: 'express',
+            label: 'Express',
+            description: 'Paid shipping, 2-3 business days'
+        },
+        {
+            value: 'overnight',
+            label: 'Overnight',
+            description: 'Premium shipping, next business day'
+        }
+    ]
+
+    const groupedItems: SelectItemType[] = [
+        { type: 'label', label: 'Fruits' },
+        { value: 'apple', label: 'Apple' },
+        { value: 'banana', label: 'Banana' },
+        { type: 'separator' },
+        { type: 'label', label: 'Vegetables' },
+        { value: 'carrot', label: 'Carrot' },
+        { value: 'broccoli', label: 'Broccoli' }
+    ]
+
+    const disabledItems: SelectItem[] = [
+        { value: 'active', label: 'Active' },
+        { value: 'disabled', label: 'Disabled', disabled: true },
+        { value: 'pending', label: 'Pending' }
+    ]
+</script>
+
+<div class="space-y-8">
+    <div class="space-y-2">
+        <h1 class="text-2xl font-bold">Select</h1>
+        <p class="text-on-surface-variant">
+            A dropdown select component with variants, colors, icons, avatars, and integration with
+            FormField and FieldGroup.
+        </p>
+    </div>
+
+    <!-- Basic Usage -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Basic Usage</h2>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm">
+                <Select items={fruits} placeholder="Pick a fruit..." />
+            </div>
+        </div>
+    </section>
+
+    <!-- Two-way Binding -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Two-way Binding</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1">bind:value</code> for reactive
+            two-way data binding.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm space-y-3">
+                <Select
+                    bind:value={bindValue}
+                    items={fruits}
+                    placeholder="Select a fruit..."
+                    leadingIcon="lucide:apple"
+                />
+                <p class="text-sm text-on-surface-variant">
+                    Value: <span class="font-mono text-on-surface">{bindValue || '(empty)'}</span>
+                </p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Variants × Colors -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Variants &times; Colors</h2>
+        <div class="overflow-x-auto rounded-lg bg-surface-container-high p-4">
+            <table class="w-full border-collapse">
+                <thead>
+                    <tr>
+                        <th class="px-3 py-2 text-left text-xs font-medium text-on-surface-variant"
+                        ></th>
+                        {#each colors as color (color)}
+                            <th
+                                class="px-3 py-2 text-left text-xs font-medium text-on-surface-variant capitalize"
+                                >{color}</th
+                            >
+                        {/each}
+                    </tr>
+                </thead>
+                <tbody>
+                    {#each variants as variant (variant)}
+                        <tr>
+                            <td
+                                class="px-3 py-2 text-xs font-medium text-on-surface-variant capitalize"
+                                >{variant}</td
+                            >
+                            {#each colors as color (color)}
+                                <td class="px-3 py-2">
+                                    <Select
+                                        {variant}
+                                        {color}
+                                        items={fruits}
+                                        placeholder={color}
+                                    />
+                                </td>
+                            {/each}
+                        </tr>
+                    {/each}
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <!-- Sizes -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Size</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">size</code> prop to control
+            the dimensions and text size.
+        </p>
+        <div class="flex flex-wrap items-end gap-4 rounded-lg bg-surface-container-high p-4">
+            {#each sizes as size (size)}
+                <div class="w-48">
+                    <Select {size} items={fruits} placeholder="{size} size" />
+                </div>
+            {/each}
+        </div>
+    </section>
+
+    <!-- Icons -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Icons</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1">leadingIcon</code> to add an
+            icon before the value.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-64">
+                <Select leadingIcon="lucide:search" items={fruits} placeholder="Search..." />
+            </div>
+            <div class="w-64">
+                <Select leadingIcon="lucide:globe" items={fruits} placeholder="Language" />
+            </div>
+        </div>
+    </section>
+
+    <!-- Items with Icons -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Items with Icons</h2>
+        <p class="text-sm text-on-surface-variant">
+            Each item can have its own icon.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-64">
+                <Select items={iconItems} placeholder="Choose a page..." />
+            </div>
+        </div>
+    </section>
+
+    <!-- Avatar -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Avatar</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">avatar</code> prop on the
+            trigger, or provide avatars on individual items.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-64">
+                <Select
+                    avatar={{ src: 'https://i.pravatar.cc/120?img=1', alt: 'User' }}
+                    items={avatarItems}
+                    placeholder="Assign to..."
+                />
+            </div>
+        </div>
+    </section>
+
+    <!-- Item Descriptions -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Item Descriptions</h2>
+        <p class="text-sm text-on-surface-variant">
+            Items can include descriptions shown below the label.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-80">
+                <Select items={descriptionItems} placeholder="Choose shipping..." />
+            </div>
+        </div>
+    </section>
+
+    <!-- Grouped Items -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Grouped Items</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1">type: 'label'</code> and
+            <code class="rounded bg-surface-container-highest px-1">type: 'separator'</code> to organize
+            items into groups.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-64">
+                <Select items={groupedItems} placeholder="Pick an item..." />
+            </div>
+        </div>
+    </section>
+
+    <!-- Disabled Items -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Disabled Items</h2>
+        <p class="text-sm text-on-surface-variant">
+            Individual items can be disabled.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-64">
+                <Select items={disabledItems} placeholder="Select status..." />
+            </div>
+        </div>
+    </section>
+
+    <!-- Loading -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Loading</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">loading</code> prop to show
+            a loading spinner.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-64">
+                <Select loading items={fruits} placeholder="Loading..." />
+            </div>
+        </div>
+    </section>
+
+    <!-- Disabled -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Disabled</h2>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-64">
+                <Select disabled items={fruits} placeholder="Disabled" />
+            </div>
+            <div class="w-64">
+                <Select disabled items={fruits} value="apple" />
+            </div>
+        </div>
+    </section>
+
+    <!-- Highlight -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Highlight</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">highlight</code> prop to
+            emphasize the ring color.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            {#each colors as color (color)}
+                <div class="w-48">
+                    <Select highlight {color} items={fruits} placeholder={color} />
+                </div>
+            {/each}
+        </div>
+    </section>
+
+    <!-- FormField Integration -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">FormField Integration</h2>
+        <p class="text-sm text-on-surface-variant">
+            When used inside a <code class="rounded bg-surface-container-highest px-1">FormField</code>,
+            the Select automatically inherits size, error state, and accessibility attributes.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm space-y-4">
+                <FormField
+                    label="Country"
+                    description="Select your country of residence."
+                    required
+                >
+                    <Select
+                        leadingIcon="lucide:globe"
+                        items={[
+                            { value: 'us', label: 'United States' },
+                            { value: 'uk', label: 'United Kingdom' },
+                            { value: 'ca', label: 'Canada' },
+                            { value: 'au', label: 'Australia' }
+                        ]}
+                        placeholder="Choose a country"
+                    />
+                </FormField>
+
+                <FormField label="Role" error="Please select a role.">
+                    <Select
+                        items={[
+                            { value: 'admin', label: 'Admin' },
+                            { value: 'editor', label: 'Editor' },
+                            { value: 'viewer', label: 'Viewer' }
+                        ]}
+                        placeholder="Choose a role"
+                    />
+                </FormField>
+            </div>
+        </div>
+    </section>
+
+    <!-- Custom UI -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Custom UI</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">ui</code> prop to override
+            classes on specific slots.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-72">
+                <p class="mb-2 text-xs text-on-surface-variant">Custom trigger & content</p>
+                <Select
+                    items={fruits}
+                    placeholder="Pick a fruit..."
+                    leadingIcon="lucide:apple"
+                    ui={{
+                        base: 'rounded-full shadow-md',
+                        content: 'rounded-xl shadow-2xl',
+                        item: 'rounded-lg',
+                        placeholder: 'italic'
+                    }}
+                />
+            </div>
+
+            <div class="w-72">
+                <p class="mb-2 text-xs text-on-surface-variant">Custom leading & trailing icons</p>
+                <Select
+                    items={iconItems}
+                    placeholder="Choose a page..."
+                    ui={{
+                        leadingIcon: 'text-primary',
+                        trailingIcon: 'text-primary',
+                        value: 'font-semibold'
+                    }}
+                />
+            </div>
+
+            <div class="w-80">
+                <p class="mb-2 text-xs text-on-surface-variant">Custom item label & description</p>
+                <Select
+                    items={descriptionItems}
+                    placeholder="Choose shipping..."
+                    ui={{
+                        itemLabel: 'font-medium text-primary',
+                        itemDescription: 'italic',
+                        itemIndicator: 'text-success'
+                    }}
+                />
+            </div>
+        </div>
+    </section>
+
+    <!-- FieldGroup Integration -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">FieldGroup Integration</h2>
+        <p class="text-sm text-on-surface-variant">
+            When used inside a <code class="rounded bg-surface-container-highest px-1">FieldGroup</code
+            >, selects are visually connected.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="space-y-4">
+                <div>
+                    <p class="mb-2 text-xs text-on-surface-variant">Horizontal</p>
+                    <FieldGroup orientation="horizontal">
+                        <Select
+                            items={[
+                                { value: 'mr', label: 'Mr.' },
+                                { value: 'mrs', label: 'Mrs.' },
+                                { value: 'ms', label: 'Ms.' }
+                            ]}
+                            placeholder="Title"
+                        />
+                        <Select items={fruits} placeholder="First" />
+                        <Select items={fruits} placeholder="Last" />
+                    </FieldGroup>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
## Summary
- Add Select component built on bits-ui Select primitives with 5 variants (outline, soft, subtle, ghost, none), 8 colors, 5 sizes
- Support leading icons/avatars on trigger that dynamically reflect the selected item
- Support item descriptions, group labels, separators, disabled items, loading state
- Integrate with FormField (error, size, name, aria) and FieldGroup (orientation, seamless borders)
- Add comprehensive demo page with all features including custom `ui` prop usage
- Update README with Select component entry

## Test plan
- [ ] Verify basic select open/close and value selection
- [ ] Verify all variant × color combinations render correctly
- [ ] Verify all 5 sizes (xs, sm, md, lg, xl)
- [ ] Verify leading icon and avatar update on item selection
- [ ] Verify item descriptions, group labels, and separators
- [ ] Verify disabled items are not selectable
- [ ] Verify loading spinner on trigger
- [ ] Verify FormField integration (error state, aria attributes)
- [ ] Verify FieldGroup integration (horizontal seamless borders)
- [ ] Verify custom `ui` prop slot overrides
- [ ] Verify dropdown width matches trigger width