### PR TITLE
feat: add Switch component with variants, icons, and FormField integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,13 +122,14 @@ pnpm add sv5ui
 
 ### Form
 
-| Component                            | Description                                                                                  |
-| :----------------------------------- | :------------------------------------------------------------------------------------------- |
-| [**Input**](src/lib/Input)           | Text input with 5 variants, icons, avatar, loading state, and FormField integration          |
-| [**Select**](src/lib/Select)         | Dropdown select with 5 variants, icons, avatars, groups, descriptions, and FormField support |
-| [**FormField**](src/lib/FormField)   | Form control wrapper providing label, description, hint, help, and error handling            |
-| [**FieldGroup**](src/lib/FieldGroup) | Groups buttons and inputs with seamless borders and shared size/orientation context          |
-| [**Calendar**](src/lib/Calendar)     | Date picker calendar with single, multiple, and range selection modes                        |
+| Component                            | Description                                                                                             |
+| :----------------------------------- | :------------------------------------------------------------------------------------------------------ |
+| [**Input**](src/lib/Input)           | Text input with 5 variants, icons, avatar, loading state, and FormField integration                     |
+| [**Select**](src/lib/Select)         | Dropdown select with 5 variants, icons, avatars, groups, descriptions, and FormField support            |
+| [**Switch**](src/lib/Switch)         | Toggle switch with 8 colors, 5 sizes, checked/unchecked icons, loading state, and FormField integration |
+| [**FormField**](src/lib/FormField)   | Form control wrapper providing label, description, hint, help, and error handling                       |
+| [**FieldGroup**](src/lib/FieldGroup) | Groups buttons and inputs with seamless borders and shared size/orientation context                     |
+| [**Calendar**](src/lib/Calendar)     | Date picker calendar with single, multiple, and range selection modes                                   |
 
 ## Theming
 

--- a/src/lib/Switch/Switch.svelte
+++ b/src/lib/Switch/Switch.svelte
@@ -1,0 +1,157 @@
+<script lang="ts" module>
+    import type { SwitchProps } from './switch.types.js'
+
+    export type Props = SwitchProps
+</script>
+
+<script lang="ts">
+    import { Switch, Label, useId } from 'bits-ui'
+    import { switchVariants, switchDefaults } from './switch.variants.js'
+    import { getComponentConfig, iconsDefaults } from '../config.js'
+    import { getContext } from 'svelte'
+    import Icon from '../Icon/Icon.svelte'
+    import type { FormFieldProps } from '../FormField/form-field.types.js'
+
+    const config = getComponentConfig('switch', switchDefaults)
+    const icons = getComponentConfig('icons', iconsDefaults)
+
+    let {
+        checked = $bindable(false),
+        onCheckedChange,
+        ui,
+        id,
+        name,
+        value,
+        color = config.defaultVariants.color,
+        size,
+        disabled = false,
+        required = false,
+        loading = false,
+        loadingIcon = icons.loading,
+        checkedIcon,
+        uncheckedIcon,
+        label,
+        description,
+        labelSlot,
+        descriptionSlot,
+        class: className
+    }: Props = $props()
+
+    const formFieldContext = getContext<
+        | {
+              name?: string
+              size: NonNullable<FormFieldProps['size']>
+              error?: string | boolean
+              ariaId: string
+          }
+        | undefined
+    >('formField')
+
+    const hasError = $derived(
+        formFieldContext?.error !== undefined && formFieldContext?.error !== false
+    )
+    const resolvedSize = $derived(size ?? formFieldContext?.size ?? config.defaultVariants.size)
+    const resolvedColor = $derived(hasError ? 'error' : color)
+    const autoId = useId()
+    const resolvedId = $derived(id ?? formFieldContext?.ariaId ?? autoId)
+    const resolvedName = $derived(name ?? formFieldContext?.name)
+    const isDisabled = $derived(disabled || loading)
+
+    const ariaDescribedBy = $derived.by(() => {
+        if (!formFieldContext) return undefined
+        const fid = formFieldContext.ariaId
+        return hasError ? `${fid}-error` : `${fid}-description ${fid}-help`
+    })
+
+    const hasCheckedIcon = $derived(loading || !!checkedIcon)
+    const hasUncheckedIcon = $derived(loading || !!uncheckedIcon)
+    const checkedIconName = $derived(loading ? loadingIcon : checkedIcon)
+    const uncheckedIconName = $derived(loading ? loadingIcon : uncheckedIcon)
+
+    const variantOpts = $derived({
+        color: resolvedColor,
+        size: resolvedSize,
+        loading,
+        required,
+        disabled: isDisabled ? true : undefined
+    } as const)
+
+    const classes = $derived.by(() => {
+        const slots = switchVariants(variantOpts)
+        return {
+            root: slots.root({ class: [config.slots.root, className, ui?.root] }),
+            base: slots.base({ class: [config.slots.base, ui?.base] }),
+            container: slots.container({ class: [config.slots.container, ui?.container] }),
+            thumb: slots.thumb({ class: [config.slots.thumb, ui?.thumb] }),
+            wrapper: slots.wrapper({ class: [config.slots.wrapper, ui?.wrapper] }),
+            label: slots.label({ class: [config.slots.label, ui?.label] }),
+            description: slots.description({
+                class: [config.slots.description, ui?.description]
+            })
+        }
+    })
+
+    const iconUiClass = $derived([config.slots.icon, ui?.icon])
+
+    const checkedIconClass = $derived.by(() => {
+        if (!hasCheckedIcon) return undefined
+        return switchVariants({
+            ...variantOpts,
+            checked: true,
+            unchecked: loading ? true : undefined
+        }).icon({ class: iconUiClass })
+    })
+
+    const uncheckedIconClass = $derived.by(() => {
+        if (!hasUncheckedIcon) return undefined
+        return switchVariants({
+            ...variantOpts,
+            unchecked: true,
+            checked: loading ? true : undefined
+        }).icon({ class: iconUiClass })
+    })
+</script>
+
+<div class={classes.root}>
+    <div class={classes.container}>
+        <Switch.Root
+            bind:checked
+            {onCheckedChange}
+            id={resolvedId}
+            name={resolvedName}
+            {value}
+            disabled={isDisabled}
+            {required}
+            aria-describedby={ariaDescribedBy}
+            aria-invalid={hasError ? true : undefined}
+            class={classes.base}
+        >
+            <Switch.Thumb class={classes.thumb}>
+                {#if hasCheckedIcon && checkedIconName}
+                    <Icon name={checkedIconName} class={checkedIconClass} />
+                {/if}
+                {#if hasUncheckedIcon && uncheckedIconName && !loading}
+                    <Icon name={uncheckedIconName} class={uncheckedIconClass} />
+                {/if}
+            </Switch.Thumb>
+        </Switch.Root>
+    </div>
+
+    {#if label || description || labelSlot || descriptionSlot}
+        <div class={classes.wrapper}>
+            {#if labelSlot}
+                {@render labelSlot({ label })}
+            {:else if label}
+                <Label.Root for={resolvedId} class={classes.label}>
+                    {label}
+                </Label.Root>
+            {/if}
+
+            {#if descriptionSlot}
+                {@render descriptionSlot({ description })}
+            {:else if description}
+                <p class={classes.description}>{description}</p>
+            {/if}
+        </div>
+    {/if}
+</div>

--- a/src/lib/Switch/Switch.svelte.spec.ts
+++ b/src/lib/Switch/Switch.svelte.spec.ts
@@ -1,0 +1,454 @@
+import { page } from 'vitest/browser'
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-svelte'
+import Switch from './Switch.svelte'
+
+const getSwitch = () => document.querySelector('button[role="switch"]') as HTMLButtonElement | null
+const getThumb = () => getSwitch()?.querySelector('span') as HTMLElement | null
+
+describe('Switch', () => {
+    // ==================== RENDERING ====================
+
+    describe('rendering', () => {
+        it('should render a switch element', async () => {
+            render(Switch)
+            const sw = page.getByRole('switch')
+            await expect.element(sw).toBeInTheDocument()
+        })
+
+        it('should render unchecked by default', () => {
+            render(Switch)
+            expect(getSwitch()!.getAttribute('data-state')).toBe('unchecked')
+        })
+
+        it('should render checked when checked prop is true', () => {
+            render(Switch, { checked: true })
+            expect(getSwitch()!.getAttribute('data-state')).toBe('checked')
+        })
+
+        it('should render with id', () => {
+            render(Switch, { id: 'my-switch' })
+            expect(getSwitch()!.id).toBe('my-switch')
+        })
+
+        it('should generate an id automatically', () => {
+            render(Switch)
+            expect(getSwitch()!.id).toBeTruthy()
+        })
+
+        it('should render with name attribute', () => {
+            const { container } = render(Switch, { name: 'notifications' })
+            // bits-ui Switch renders a hidden input as sibling of the button for form submission
+            const hidden = container.querySelector('input[name="notifications"]')
+            expect(hidden).toBeTruthy()
+        })
+
+        it('should render thumb element', () => {
+            render(Switch)
+            const thumb = getThumb()
+            expect(thumb).not.toBeNull()
+        })
+    })
+
+    // ==================== CHECKED STATE ====================
+
+    describe('checked state', () => {
+        it('should toggle on click', async () => {
+            render(Switch)
+            const sw = page.getByRole('switch')
+            expect(getSwitch()!.getAttribute('data-state')).toBe('unchecked')
+            await sw.click()
+            expect(getSwitch()!.getAttribute('data-state')).toBe('checked')
+        })
+
+        it('should call onCheckedChange callback', async () => {
+            const onCheckedChange = vi.fn()
+            render(Switch, { onCheckedChange })
+            const sw = page.getByRole('switch')
+            await sw.click()
+            expect(onCheckedChange).toHaveBeenCalledWith(true)
+        })
+    })
+
+    // ==================== DISABLED STATE ====================
+
+    describe('disabled', () => {
+        it('should be disabled when disabled prop is true', async () => {
+            render(Switch, { disabled: true })
+            const sw = page.getByRole('switch')
+            await expect.element(sw).toBeDisabled()
+        })
+
+        it('should not be disabled by default', async () => {
+            render(Switch)
+            const sw = page.getByRole('switch')
+            await expect.element(sw).toBeEnabled()
+        })
+
+        it('should apply disabled styling to root', () => {
+            const { container } = render(Switch, { disabled: true })
+            const root = container.firstElementChild as HTMLElement
+            expect(root.className).toMatch(/opacity-75/)
+        })
+
+        it('should apply cursor-not-allowed to base', () => {
+            render(Switch, { disabled: true })
+            expect(getSwitch()!.className).toMatch(/cursor-not-allowed/)
+        })
+
+        it('should not toggle when disabled', async () => {
+            render(Switch, { disabled: true })
+            const sw = page.getByRole('switch')
+            await sw.click({ force: true })
+            expect(getSwitch()!.getAttribute('data-state')).toBe('unchecked')
+        })
+    })
+
+    // ==================== LOADING STATE ====================
+
+    describe('loading', () => {
+        it('should be disabled when loading', async () => {
+            render(Switch, { loading: true })
+            const sw = page.getByRole('switch')
+            await expect.element(sw).toBeDisabled()
+        })
+
+        it('should render loading icon inside thumb', async () => {
+            render(Switch, { loading: true })
+            const thumb = getThumb()!
+            // @iconify/svelte renders SVG with aria-hidden, wait for it
+            await vi.waitFor(() => {
+                expect(thumb.querySelector('svg')).not.toBeNull()
+            })
+        })
+
+        it('should not toggle when loading', async () => {
+            render(Switch, { loading: true })
+            const sw = page.getByRole('switch')
+            await sw.click({ force: true })
+            expect(getSwitch()!.getAttribute('data-state')).toBe('unchecked')
+        })
+    })
+
+    // ==================== COLORS ====================
+
+    describe('colors', () => {
+        const colors = [
+            'primary',
+            'secondary',
+            'tertiary',
+            'success',
+            'warning',
+            'error',
+            'info'
+        ] as const
+
+        for (const color of colors) {
+            it(`should render with color="${color}"`, () => {
+                render(Switch, { color })
+                expect(getSwitch()!.className).toMatch(new RegExp(`bg-${color}`))
+            })
+        }
+
+        it('should apply surface color', () => {
+            render(Switch, { color: 'surface' })
+            expect(getSwitch()!.className).toMatch(/bg-on-surface/)
+        })
+
+        it('should apply focus-visible outline per color', () => {
+            render(Switch, { color: 'primary' })
+            expect(getSwitch()!.className).toMatch(/outline-primary/)
+        })
+    })
+
+    // ==================== SIZES ====================
+
+    describe('sizes', () => {
+        it('should apply xs size classes', () => {
+            const { container } = render(Switch, { size: 'xs' })
+            expect(getSwitch()!.className).toMatch(/w-7/)
+            const containerEl = container.querySelector('.flex.items-center') as HTMLElement
+            expect(containerEl.className).toMatch(/h-4/)
+        })
+
+        it('should apply sm size classes', () => {
+            render(Switch, { size: 'sm' })
+            expect(getSwitch()!.className).toMatch(/w-8/)
+        })
+
+        it('should apply md size classes by default', () => {
+            render(Switch)
+            expect(getSwitch()!.className).toMatch(/w-9/)
+        })
+
+        it('should apply lg size classes', () => {
+            render(Switch, { size: 'lg' })
+            expect(getSwitch()!.className).toMatch(/w-10/)
+        })
+
+        it('should apply xl size classes', () => {
+            render(Switch, { size: 'xl' })
+            expect(getSwitch()!.className).toMatch(/w-11/)
+        })
+
+        it('should apply wrapper text size per size variant', () => {
+            const { container } = render(Switch, { size: 'xs', label: 'Test' })
+            const wrapper = container.querySelector('.ms-2') as HTMLElement
+            expect(wrapper.className).toMatch(/text-xs/)
+        })
+    })
+
+    // ==================== LABEL & DESCRIPTION ====================
+
+    describe('label & description', () => {
+        it('should render label text', async () => {
+            render(Switch, { label: 'Enable notifications' })
+            const label = page.getByText('Enable notifications')
+            await expect.element(label).toBeInTheDocument()
+        })
+
+        it('should render description text', async () => {
+            render(Switch, { description: 'This controls alerts' })
+            const desc = page.getByText('This controls alerts')
+            await expect.element(desc).toBeInTheDocument()
+        })
+
+        it('should render both label and description', () => {
+            const { container } = render(Switch, {
+                label: 'Dark mode',
+                description: 'Toggle theme appearance'
+            })
+            const label = container.querySelector('label') as HTMLElement
+            const desc = container.querySelector('p') as HTMLElement
+            expect(label.textContent).toBe('Dark mode')
+            expect(desc.textContent).toBe('Toggle theme appearance')
+        })
+
+        it('should not render wrapper when no label or description', () => {
+            const { container } = render(Switch)
+            expect(container.querySelector('.ms-2')).toBeNull()
+        })
+
+        it('should associate label with switch via for attribute', () => {
+            render(Switch, { id: 'test-switch', label: 'My Label' })
+            const label = document.querySelector('label') as HTMLLabelElement
+            expect(label.getAttribute('for')).toBe('test-switch')
+        })
+
+        it('should apply required asterisk styling to label', () => {
+            render(Switch, { label: 'Accept terms', required: true })
+            const label = document.querySelector('label') as HTMLElement
+            expect(label.className).toMatch(/after:content/)
+        })
+
+        it('should apply cursor-not-allowed to label when disabled', () => {
+            render(Switch, { label: 'Disabled', disabled: true })
+            const label = document.querySelector('label') as HTMLElement
+            expect(label.className).toMatch(/cursor-not-allowed/)
+        })
+
+        it('should apply cursor-not-allowed to description when disabled', () => {
+            render(Switch, { description: 'Desc', disabled: true })
+            const desc = document.querySelector('p') as HTMLElement
+            expect(desc.className).toMatch(/cursor-not-allowed/)
+        })
+    })
+
+    // ==================== ICONS ====================
+
+    describe('icons', () => {
+        it('should render checked icon when provided', async () => {
+            render(Switch, { checkedIcon: 'lucide:check' })
+            const thumb = getThumb()!
+            await vi.waitFor(() => {
+                expect(thumb.querySelector('svg')).not.toBeNull()
+            })
+        })
+
+        it('should render unchecked icon when provided', async () => {
+            render(Switch, { uncheckedIcon: 'lucide:x' })
+            const thumb = getThumb()!
+            await vi.waitFor(() => {
+                expect(thumb.querySelector('svg')).not.toBeNull()
+            })
+        })
+
+        it('should render both checked and unchecked icons', async () => {
+            render(Switch, {
+                checkedIcon: 'lucide:check',
+                uncheckedIcon: 'lucide:x'
+            })
+            const thumb = getThumb()!
+            // Both icons rendered simultaneously (CSS controls visibility)
+            await vi.waitFor(() => {
+                expect(thumb.querySelectorAll('svg').length).toBe(2)
+            })
+        })
+
+        it('should not render icons when none provided', () => {
+            render(Switch)
+            const thumb = getThumb()
+            expect(thumb!.children.length).toBe(0)
+        })
+
+        it('should apply checked icon opacity class', async () => {
+            const { container } = render(Switch, { checkedIcon: 'lucide:check' })
+            await vi.waitFor(() => {
+                const iconEl = container.querySelector('[class*="opacity-0"]')
+                expect(iconEl).not.toBeNull()
+                expect(iconEl!.getAttribute('class')).toMatch(
+                    /group-data-\[state=checked\]:opacity-100/
+                )
+            })
+        })
+
+        it('should apply unchecked icon opacity class', async () => {
+            const { container } = render(Switch, { uncheckedIcon: 'lucide:x' })
+            await vi.waitFor(() => {
+                const iconEl = container.querySelector('[class*="opacity-0"]')
+                expect(iconEl).not.toBeNull()
+                expect(iconEl!.getAttribute('class')).toMatch(
+                    /group-data-\[state=unchecked\]:opacity-100/
+                )
+            })
+        })
+    })
+
+    // ==================== CUSTOM CLASS & UI ====================
+
+    describe('custom class & ui', () => {
+        it('should apply custom class to root element', () => {
+            const { container } = render(Switch, { class: 'my-custom-class' })
+            const root = container.firstElementChild as HTMLElement
+            expect(root.className).toContain('my-custom-class')
+        })
+
+        it('should apply ui slot override to base', () => {
+            render(Switch, { ui: { base: 'my-base-class' } })
+            expect(getSwitch()!.className).toContain('my-base-class')
+        })
+
+        it('should apply ui slot override to root', () => {
+            const { container } = render(Switch, { ui: { root: 'my-root-class' } })
+            const root = container.firstElementChild as HTMLElement
+            expect(root.className).toContain('my-root-class')
+        })
+
+        it('should apply ui slot override to thumb', () => {
+            render(Switch, { ui: { thumb: 'my-thumb-class' } })
+            const thumb = getThumb()
+            expect(thumb!.className).toContain('my-thumb-class')
+        })
+
+        it('should apply ui slot override to label', () => {
+            render(Switch, { label: 'Test', ui: { label: 'my-label-class' } })
+            const label = document.querySelector('label') as HTMLElement
+            expect(label.className).toContain('my-label-class')
+        })
+
+        it('should apply ui slot override to description', () => {
+            render(Switch, { description: 'Desc', ui: { description: 'my-desc-class' } })
+            const desc = document.querySelector('p') as HTMLElement
+            expect(desc.className).toContain('my-desc-class')
+        })
+
+        it('should apply ui slot override to wrapper', () => {
+            const { container } = render(Switch, {
+                label: 'Test',
+                ui: { wrapper: 'my-wrapper-class' }
+            })
+            const wrapper = container.querySelector('.ms-2') as HTMLElement
+            expect(wrapper.className).toContain('my-wrapper-class')
+        })
+    })
+
+    // ==================== ACCESSIBILITY ====================
+
+    describe('accessibility', () => {
+        it('should have role="switch"', async () => {
+            render(Switch)
+            const sw = page.getByRole('switch')
+            await expect.element(sw).toBeInTheDocument()
+        })
+
+        it('should set aria-checked based on checked state', () => {
+            render(Switch, { checked: true })
+            expect(getSwitch()!.getAttribute('aria-checked')).toBe('true')
+        })
+
+        it('should set aria-checked false when unchecked', () => {
+            render(Switch)
+            expect(getSwitch()!.getAttribute('aria-checked')).toBe('false')
+        })
+
+        it('should support required attribute', () => {
+            render(Switch, { required: true })
+            expect(getSwitch()!.getAttribute('aria-required')).toBe('true')
+        })
+    })
+
+    // ==================== COMBINED PROPS ====================
+
+    describe('combined props', () => {
+        it('should render with label, description, and checked', () => {
+            const { container } = render(Switch, {
+                label: 'Email alerts',
+                description: 'Receive email when updates arrive',
+                checked: true
+            })
+            const label = container.querySelector('label') as HTMLElement
+            const desc = container.querySelector('p') as HTMLElement
+            expect(label.textContent).toBe('Email alerts')
+            expect(desc.textContent).toBe('Receive email when updates arrive')
+            expect(getSwitch()!.getAttribute('data-state')).toBe('checked')
+        })
+
+        it('should render disabled with checked state', () => {
+            render(Switch, { disabled: true, checked: true })
+            expect(getSwitch()!.getAttribute('data-state')).toBe('checked')
+            expect(getSwitch()!.disabled).toBe(true)
+        })
+
+        it('should render loading with single loading icon', async () => {
+            render(Switch, {
+                loading: true,
+                checkedIcon: 'lucide:check',
+                uncheckedIcon: 'lucide:x'
+            })
+            const thumb = getThumb()!
+            // Loading replaces both icons with a single loading icon
+            await vi.waitFor(() => {
+                expect(thumb.querySelectorAll('svg').length).toBe(1)
+            })
+        })
+
+        it('should render with color and size combined', () => {
+            render(Switch, { color: 'success', size: 'xl' })
+            const sw = getSwitch()!
+            expect(sw.className).toMatch(/bg-success/)
+            expect(sw.className).toMatch(/w-11/)
+        })
+
+        it('should render with all props combined', () => {
+            const { container } = render(Switch, {
+                checked: true,
+                color: 'error',
+                size: 'lg',
+                label: 'Critical setting',
+                description: 'Handle with care',
+                checkedIcon: 'lucide:check',
+                required: true,
+                id: 'full-switch'
+            })
+            const sw = getSwitch()!
+            expect(sw.id).toBe('full-switch')
+            expect(sw.getAttribute('data-state')).toBe('checked')
+            expect(sw.className).toMatch(/bg-error/)
+            expect(sw.className).toMatch(/w-10/)
+            const label = container.querySelector('label') as HTMLElement
+            const desc = container.querySelector('p') as HTMLElement
+            expect(label.textContent).toBe('Critical setting')
+            expect(desc.textContent).toBe('Handle with care')
+        })
+    })
+})

--- a/src/lib/Switch/index.ts
+++ b/src/lib/Switch/index.ts
@@ -1,0 +1,2 @@
+export { default as Switch } from './Switch.svelte'
+export type { SwitchProps } from './switch.types.js'

--- a/src/lib/Switch/switch.types.ts
+++ b/src/lib/Switch/switch.types.ts
@@ -1,0 +1,89 @@
+import type { Snippet } from 'svelte'
+import type { Switch as SwitchPrimitive } from 'bits-ui'
+import type { ClassNameValue } from 'tailwind-merge'
+import type { SwitchVariantProps, SwitchSlots } from './switch.variants.js'
+
+export type SwitchProps = Pick<
+    SwitchPrimitive.RootProps,
+    'disabled' | 'name' | 'value' | 'required'
+> & {
+    /**
+     * The checked state of the switch. Supports two-way binding with `bind:checked`.
+     * @default false
+     */
+    checked?: boolean
+
+    /**
+     * Callback when the checked state changes.
+     */
+    onCheckedChange?: (checked: boolean) => void
+
+    /**
+     * Sets the color scheme for the switch.
+     * @default 'primary'
+     */
+    color?: NonNullable<SwitchVariantProps['color']>
+
+    /**
+     * Controls the dimensions of the switch.
+     * @default 'md'
+     */
+    size?: NonNullable<SwitchVariantProps['size']>
+
+    /**
+     * Renders a loading spinner inside the thumb.
+     * @default false
+     */
+    loading?: boolean
+
+    /**
+     * Icon displayed as the loading indicator.
+     * @default Uses `icons.loading` from app config
+     */
+    loadingIcon?: string
+
+    /**
+     * Icon displayed inside the thumb when checked.
+     */
+    checkedIcon?: string
+
+    /**
+     * Icon displayed inside the thumb when unchecked.
+     */
+    uncheckedIcon?: string
+
+    /**
+     * Label text displayed next to the switch.
+     */
+    label?: string
+
+    /**
+     * Description text displayed below the label.
+     */
+    description?: string
+
+    /**
+     * The HTML id attribute for the switch.
+     */
+    id?: string
+
+    /**
+     * Custom snippet for the label.
+     */
+    labelSlot?: Snippet<[{ label?: string }]>
+
+    /**
+     * Custom snippet for the description.
+     */
+    descriptionSlot?: Snippet<[{ description?: string }]>
+
+    /**
+     * Additional CSS classes for the root element.
+     */
+    class?: ClassNameValue
+
+    /**
+     * Override styles for specific switch slots.
+     */
+    ui?: Partial<Record<SwitchSlots, ClassNameValue>>
+}

--- a/src/lib/Switch/switch.variants.ts
+++ b/src/lib/Switch/switch.variants.ts
@@ -1,0 +1,176 @@
+import { tv, type VariantProps } from 'tailwind-variants'
+
+export const switchVariants = tv({
+    slots: {
+        root: 'relative flex items-start',
+        base: [
+            'inline-flex items-center shrink-0 rounded-full border-2 border-transparent',
+            'focus-visible:outline-2 focus-visible:outline-offset-2',
+            'transition-colors duration-200',
+            'data-[state=unchecked]:bg-surface-container-highest'
+        ],
+        container: 'flex items-center',
+        thumb: [
+            'group pointer-events-none rounded-full bg-white shadow-lg ring-0',
+            'flex items-center justify-center',
+            'transition-transform duration-200',
+            'data-[state=unchecked]:translate-x-0'
+        ],
+        icon: [
+            'absolute shrink-0 opacity-0',
+            'group-data-[state=unchecked]:text-on-surface-variant',
+            'transition-[color,opacity] duration-200'
+        ],
+        wrapper: 'ms-2',
+        label: 'block font-medium text-on-surface',
+        description: 'text-on-surface-variant'
+    },
+    variants: {
+        color: {
+            primary: '',
+            secondary: '',
+            tertiary: '',
+            success: '',
+            warning: '',
+            error: '',
+            info: '',
+            surface: ''
+        },
+        size: {
+            xs: {
+                base: 'w-7',
+                container: 'h-4',
+                thumb: 'size-3 data-[state=checked]:translate-x-3',
+                icon: 'size-2',
+                wrapper: 'text-xs'
+            },
+            sm: {
+                base: 'w-8',
+                container: 'h-4',
+                thumb: 'size-3.5 data-[state=checked]:translate-x-3.5',
+                icon: 'size-2.5',
+                wrapper: 'text-xs'
+            },
+            md: {
+                base: 'w-9',
+                container: 'h-5',
+                thumb: 'size-4 data-[state=checked]:translate-x-4',
+                icon: 'size-3',
+                wrapper: 'text-sm'
+            },
+            lg: {
+                base: 'w-10',
+                container: 'h-5',
+                thumb: 'size-4.5 data-[state=checked]:translate-x-4.5',
+                icon: 'size-3.5',
+                wrapper: 'text-sm'
+            },
+            xl: {
+                base: 'w-11',
+                container: 'h-6',
+                thumb: 'size-5 data-[state=checked]:translate-x-5',
+                icon: 'size-4',
+                wrapper: 'text-base'
+            }
+        },
+        checked: {
+            true: {
+                icon: 'group-data-[state=checked]:opacity-100'
+            }
+        },
+        unchecked: {
+            true: {
+                icon: 'group-data-[state=unchecked]:opacity-100'
+            }
+        },
+        loading: {
+            true: {
+                icon: 'animate-spin'
+            }
+        },
+        required: {
+            true: {
+                label: "after:content-['*'] after:ms-0.5 after:text-error"
+            }
+        },
+        disabled: {
+            true: {
+                root: 'opacity-75',
+                base: 'cursor-not-allowed',
+                label: 'cursor-not-allowed',
+                description: 'cursor-not-allowed'
+            }
+        }
+    },
+    compoundVariants: [
+        // ========== COLOR (checked bg + focus ring + icon color) ==========
+        {
+            color: 'primary',
+            class: {
+                base: 'data-[state=checked]:bg-primary focus-visible:outline-primary',
+                icon: 'group-data-[state=checked]:text-primary'
+            }
+        },
+        {
+            color: 'secondary',
+            class: {
+                base: 'data-[state=checked]:bg-secondary focus-visible:outline-secondary',
+                icon: 'group-data-[state=checked]:text-secondary'
+            }
+        },
+        {
+            color: 'tertiary',
+            class: {
+                base: 'data-[state=checked]:bg-tertiary focus-visible:outline-tertiary',
+                icon: 'group-data-[state=checked]:text-tertiary'
+            }
+        },
+        {
+            color: 'success',
+            class: {
+                base: 'data-[state=checked]:bg-success focus-visible:outline-success',
+                icon: 'group-data-[state=checked]:text-success'
+            }
+        },
+        {
+            color: 'warning',
+            class: {
+                base: 'data-[state=checked]:bg-warning focus-visible:outline-warning',
+                icon: 'group-data-[state=checked]:text-warning'
+            }
+        },
+        {
+            color: 'error',
+            class: {
+                base: 'data-[state=checked]:bg-error focus-visible:outline-error',
+                icon: 'group-data-[state=checked]:text-error'
+            }
+        },
+        {
+            color: 'info',
+            class: {
+                base: 'data-[state=checked]:bg-info focus-visible:outline-info',
+                icon: 'group-data-[state=checked]:text-info'
+            }
+        },
+        {
+            color: 'surface',
+            class: {
+                base: 'data-[state=checked]:bg-on-surface focus-visible:outline-outline',
+                icon: 'group-data-[state=checked]:text-on-surface'
+            }
+        }
+    ],
+    defaultVariants: {
+        color: 'primary',
+        size: 'md'
+    }
+})
+
+export type SwitchVariantProps = VariantProps<typeof switchVariants>
+export type SwitchSlots = keyof ReturnType<typeof switchVariants>
+
+export const switchDefaults = {
+    defaultVariants: switchVariants.defaultVariants,
+    slots: {} as Partial<Record<SwitchSlots, string>>
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -32,6 +32,7 @@ export * from './FieldGroup/index.js'
 export * from './FormField/index.js'
 export * from './Input/index.js'
 export * from './Select/index.js'
+export * from './Switch/index.js'
 
 // Configuration
 export { defineConfig } from './config.js'

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -42,7 +42,8 @@
         { href: '/field-group', label: 'Field Group', icon: 'lucide:group' },
         { href: '/form-field', label: 'Form Field', icon: 'lucide:text-cursor-input' },
         { href: '/input', label: 'Input', icon: 'lucide:text-cursor' },
-        { href: '/select', label: 'Select', icon: 'lucide:chevrons-up-down' }
+        { href: '/select', label: 'Select', icon: 'lucide:chevrons-up-down' },
+        { href: '/switch', label: 'Switch', icon: 'lucide:toggle-left' }
     ]
 
     const docItems = [

--- a/src/routes/switch/+page.svelte
+++ b/src/routes/switch/+page.svelte
@@ -1,0 +1,233 @@
+<script lang="ts">
+    import { Switch, FormField } from '$lib/index.js'
+
+    const colors = [
+        'primary',
+        'secondary',
+        'tertiary',
+        'success',
+        'warning',
+        'error',
+        'info',
+        'surface'
+    ] as const
+    const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const
+
+    let bindChecked = $state(false)
+</script>
+
+<div class="space-y-8">
+    <div class="space-y-2">
+        <h1 class="text-2xl font-bold">Switch</h1>
+        <p class="text-on-surface-variant">
+            A toggle switch component for binary states with customizable colors, sizes, icons, and
+            FormField integration.
+        </p>
+    </div>
+
+    <!-- Basic Usage -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Basic Usage</h2>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <Switch />
+        </div>
+    </section>
+
+    <!-- Two-way Binding -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Two-way Binding</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1">bind:checked</code> for reactive
+            two-way data binding.
+        </p>
+        <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
+            <Switch bind:checked={bindChecked} />
+            <p class="text-sm text-on-surface-variant">
+                Checked: <span class="font-mono text-on-surface">{bindChecked}</span>
+            </p>
+        </div>
+    </section>
+
+    <!-- With Label & Description -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Label & Description</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1">label</code> and
+            <code class="rounded bg-surface-container-highest px-1">description</code> props to add text
+            next to the switch.
+        </p>
+        <div class="flex flex-col gap-4 rounded-lg bg-surface-container-high p-4">
+            <Switch label="Notifications" />
+            <Switch label="Dark mode" description="Enable dark mode for the application." />
+            <Switch
+                label="Marketing emails"
+                description="Receive emails about new products and features."
+            />
+        </div>
+    </section>
+
+    <!-- Colors -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Colors</h2>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            {#each colors as color (color)}
+                <div class="flex flex-col items-center gap-2">
+                    <Switch {color} checked={true} label={color} />
+                </div>
+            {/each}
+        </div>
+    </section>
+
+    <!-- Sizes -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Sizes</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">size</code> prop to control
+            the dimensions.
+        </p>
+        <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
+            {#each sizes as size (size)}
+                <Switch {size} checked={true} label={size} />
+            {/each}
+        </div>
+    </section>
+
+    <!-- With Icons -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Icons</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1">checkedIcon</code> and
+            <code class="rounded bg-surface-container-highest px-1">uncheckedIcon</code> to display icons
+            inside the thumb.
+        </p>
+        <div class="flex flex-col gap-4 rounded-lg bg-surface-container-high p-4">
+            <Switch
+                checkedIcon="lucide:check"
+                uncheckedIcon="lucide:x"
+                label="With check/x icons"
+            />
+            <Switch
+                checkedIcon="lucide:sun"
+                uncheckedIcon="lucide:moon"
+                label="Theme toggle"
+                description="Switch between light and dark mode."
+            />
+            <Switch checkedIcon="lucide:volume-2" uncheckedIcon="lucide:volume-x" label="Sound" />
+        </div>
+    </section>
+
+    <!-- Loading -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Loading</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">loading</code> prop to show
+            a loading spinner inside the thumb.
+        </p>
+        <div class="flex flex-col gap-4 rounded-lg bg-surface-container-high p-4">
+            <Switch loading label="Syncing..." />
+            <Switch loading checked={true} label="Saving preferences..." color="success" />
+        </div>
+    </section>
+
+    <!-- Disabled -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Disabled</h2>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <Switch disabled label="Disabled (off)" />
+            <Switch disabled checked={true} label="Disabled (on)" />
+        </div>
+    </section>
+
+    <!-- Required -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Required</h2>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <Switch required label="Accept terms and conditions" />
+        </div>
+    </section>
+
+    <!-- FormField Integration -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">FormField Integration</h2>
+        <p class="text-sm text-on-surface-variant">
+            When used inside a <code class="rounded bg-surface-container-highest px-1"
+                >FormField</code
+            >, the Switch automatically inherits size and error state.
+        </p>
+        <div class="flex flex-col gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm">
+                <FormField label="Notifications" description="Choose how you want to be notified.">
+                    <Switch label="Push notifications" />
+                </FormField>
+            </div>
+
+            <div class="w-full max-w-sm">
+                <FormField label="Agreement" error="You must accept the terms.">
+                    <Switch label="I accept the terms of service" />
+                </FormField>
+            </div>
+        </div>
+    </section>
+
+    <!-- Custom UI -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Custom UI</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">ui</code> prop to override
+            classes on specific slots.
+        </p>
+        <div class="flex flex-col gap-6 rounded-lg bg-surface-container-high p-4">
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">Custom label & description</p>
+                <Switch
+                    label="Bold primary label"
+                    description="Italic description text"
+                    checked={true}
+                    ui={{
+                        label: 'font-bold text-primary',
+                        description: 'italic text-tertiary'
+                    }}
+                />
+            </div>
+
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">Rounded track with shadow thumb</p>
+                <Switch
+                    label="Elevated switch"
+                    checked={true}
+                    color="success"
+                    ui={{
+                        base: 'shadow-inner rounded-lg',
+                        thumb: 'shadow-xl rounded-lg'
+                    }}
+                />
+            </div>
+
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">
+                    Custom root layout & wrapper spacing
+                </p>
+                <Switch
+                    label="Wide spacing"
+                    description="More gap between switch and text."
+                    ui={{
+                        root: 'gap-1',
+                        wrapper: 'ms-4'
+                    }}
+                />
+            </div>
+
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">Custom container height</p>
+                <Switch
+                    label="Taller container"
+                    checked={true}
+                    color="tertiary"
+                    ui={{
+                        container: 'h-7'
+                    }}
+                />
+            </div>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
## Summary
- Add a new **Switch** toggle component built on `bits-ui` Switch primitive, following the Nuxt UI Switch design patterns
- Support 8 color schemes (primary, secondary, tertiary, success, warning, error, info, surface) and 5 sizes (xs, sm, md, lg, xl)
- Include checked/unchecked icons with CSS-driven opacity transitions, loading state with animated spinner, and disabled state
- Integrate with `FormField` context for automatic size inheritance, error state propagation, and aria attributes
- Add comprehensive test suite (62 tests) and demo page

## New Files
- `src/lib/Switch/Switch.svelte` — Main component using `bits-ui` `Switch.Root` and `Switch.Thumb` primitives with `Label.Root` for accessible labeling
- `src/lib/Switch/switch.variants.ts` — Slot-based styling via `tailwind-variants` with 8 slots (root, base, container, thumb, icon, wrapper, label, description), color/size/state variants, and compound variants for checked background + focus ring + icon color per color scheme
- `src/lib/Switch/switch.types.ts` — TypeScript prop definitions extending `bits-ui` types with `checked` (bindable), `onCheckedChange`, `color`, `size`, `loading`, `checkedIcon`/`uncheckedIcon`, `label`, `description`, `labelSlot`/`descriptionSlot` snippets, and `ui` slot overrides
- `src/lib/Switch/index.ts` — Public exports
- `src/lib/Switch/Switch.svelte.spec.ts` — 62 browser tests covering rendering, checked state toggling, disabled/loading states, all colors, all sizes, label & description with accessibility (for attribute, required asterisk, cursor states), icon rendering with async `@iconify/svelte` handling, custom class/ui slot overrides, aria attributes, and combined prop scenarios
- `src/routes/switch/+page.svelte` — Demo page with sections for basic usage, two-way binding, label & description, colors, sizes, icons, loading, disabled, required, FormField integration (with error state), and custom UI overrides

## Modified Files
- `src/lib/index.ts` — Export Switch component
- `src/routes/+layout.svelte` — Add Switch to sidebar navigation

## Key Implementation Details

### Variant System
- **Color**: Applied via compound variants using `data-[state=checked]:bg-{color}` on the track, `focus-visible:outline-{color}` for focus ring, and `group-data-[state=checked]:text-{color}` for icon color
- **Size**: Width applied to `base` (track), height to `container`, thumb size + translate distance scaled progressively from xs (`w-7`, `size-3`) to xl (`w-11`, `size-5`)
- **Icons**: CSS-driven visibility using `opacity-0` + `group-data-[state=checked]:opacity-100` / `group-data-[state=unchecked]:opacity-100` — both icons always rendered, CSS controls which is visible
- **Loading**: Replaces both checked/unchecked icons with a single animated spinner icon, disables interaction

### Performance Optimizations
- Shared `variantOpts` derived to avoid redundant variant computation
- Separate `checkedIconClass` / `uncheckedIconClass` deriveds with early return when no icons present
- Extracted `iconUiClass` to avoid re-creating array each render cycle

### FormField Integration
- Inherits `size`, `name`, and `error` state from `FormField` context
- Auto-generates accessible `id` via `bits-ui` `useId()` when no explicit `id` or `FormField` context
- Sets `aria-describedby` and `aria-invalid` based on FormField error state

## Test Plan
- [x] All 62 unit tests pass (`npx vitest run src/lib/Switch/Switch.svelte.spec.ts`)
- [ ] Visual verification on `/switch` demo page across all variants
- [ ] Verify FormField integration with error state propagation
- [ ] Verify label click toggles switch correctly (via `for` attribute + auto-generated `id`)
- [ ] Verify keyboard accessibility (Space/Enter to toggle, Tab to focus)