### PR TITLE
fix: replace external pravatar URLs with inline data URIs in tests

### DIFF
--- a/src/lib/Avatar/Avatar.svelte.spec.ts
+++ b/src/lib/Avatar/Avatar.svelte.spec.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from 'vitest'
 import { render } from 'vitest-browser-svelte'
 import Avatar from './Avatar.svelte'
 
+const AVATAR_SRC =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+
 /** Helper: get a locator for a data-attribute element inside the render container */
 function getByData(container: HTMLElement, attr: string) {
     const el = container.querySelector(`[${attr}]`)
@@ -81,25 +84,25 @@ describe('Avatar', () => {
 
     describe('image', () => {
         it('should render img element when src is provided', async () => {
-            render(Avatar, { src: 'https://i.pravatar.cc/64', alt: 'User photo' })
+            render(Avatar, { src: AVATAR_SRC, alt: 'User photo' })
             const img = page.getByRole('img', { name: 'User photo' })
             await expect.element(img).toBeInTheDocument()
         })
 
         it('should set alt attribute on img', async () => {
-            render(Avatar, { src: 'https://i.pravatar.cc/64', alt: 'Profile pic' })
+            render(Avatar, { src: AVATAR_SRC, alt: 'Profile pic' })
             const img = page.getByRole('img', { name: 'Profile pic' })
             await expect.element(img).toHaveAttribute('alt', 'Profile pic')
         })
 
         it('should set empty alt when alt is not provided', async () => {
-            const { container } = render(Avatar, { src: 'https://i.pravatar.cc/64' })
+            const { container } = render(Avatar, { src: AVATAR_SRC })
             const img = page.elementLocator(container.querySelector('img')!)
             await expect.element(img).toHaveAttribute('alt', '')
         })
 
         it('should set width and height based on size', async () => {
-            render(Avatar, { src: 'https://i.pravatar.cc/64', alt: 'User', size: 'lg' })
+            render(Avatar, { src: AVATAR_SRC, alt: 'User', size: 'lg' })
             const img = page.getByRole('img', { name: 'User' })
             await expect.element(img).toHaveAttribute('width', '36')
             await expect.element(img).toHaveAttribute('height', '36')
@@ -107,7 +110,7 @@ describe('Avatar', () => {
 
         it('should still render fallback alongside img', async () => {
             const { container } = render(Avatar, {
-                src: 'https://i.pravatar.cc/64',
+                src: AVATAR_SRC,
                 alt: 'John Doe'
             })
             const fallback = getByData(container, 'data-avatar-fallback')
@@ -163,7 +166,7 @@ describe('Avatar', () => {
 
         for (const { size, px } of sizePxMap) {
             it(`should set img width/height to ${px}px for size="${size}"`, async () => {
-                render(Avatar, { src: 'https://i.pravatar.cc/64', alt: 'User', size })
+                render(Avatar, { src: AVATAR_SRC, alt: 'User', size })
                 const img = page.getByRole('img', { name: 'User' })
                 await expect.element(img).toHaveAttribute('width', px)
                 await expect.element(img).toHaveAttribute('height', px)
@@ -201,7 +204,7 @@ describe('Avatar', () => {
 
         it('should apply ui.image class', async () => {
             render(Avatar, {
-                src: 'https://i.pravatar.cc/64',
+                src: AVATAR_SRC,
                 alt: 'User',
                 ui: { image: 'custom-img' }
             })

--- a/src/lib/AvatarGroup/AvatarGroup.svelte.spec.ts
+++ b/src/lib/AvatarGroup/AvatarGroup.svelte.spec.ts
@@ -3,12 +3,15 @@ import { describe, expect, it } from 'vitest'
 import { render } from 'vitest-browser-svelte'
 import AvatarGroup from './AvatarGroup.svelte'
 
+const avatarSrc = (id: number) =>
+    `data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"><rect fill="%23${String(id).padStart(6, '0')}"/></svg>`
+
 const avatars = [
-    { src: 'https://i.pravatar.cc/150?img=1', alt: 'User 1' },
-    { src: 'https://i.pravatar.cc/150?img=2', alt: 'User 2' },
-    { src: 'https://i.pravatar.cc/150?img=3', alt: 'User 3' },
-    { src: 'https://i.pravatar.cc/150?img=4', alt: 'User 4' },
-    { src: 'https://i.pravatar.cc/150?img=5', alt: 'User 5' }
+    { src: avatarSrc(1), alt: 'User 1' },
+    { src: avatarSrc(2), alt: 'User 2' },
+    { src: avatarSrc(3), alt: 'User 3' },
+    { src: avatarSrc(4), alt: 'User 4' },
+    { src: avatarSrc(5), alt: 'User 5' }
 ]
 
 describe('AvatarGroup', () => {

--- a/src/lib/Button/Button.svelte.spec.ts
+++ b/src/lib/Button/Button.svelte.spec.ts
@@ -3,6 +3,9 @@ import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-svelte'
 import Button from './Button.svelte'
 
+const AVATAR_SRC =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+
 describe('Button', () => {
     // ==================== RENDERING ====================
 
@@ -245,7 +248,7 @@ describe('Button', () => {
         it('should render avatar with src as img element', async () => {
             render(Button, {
                 label: 'Photo',
-                avatar: { src: 'https://i.pravatar.cc/64', alt: 'User avatar' }
+                avatar: { src: AVATAR_SRC, alt: 'User avatar' }
             })
             const btn = page.getByRole('button', { name: 'Photo' })
             await expect.element(btn).toBeInTheDocument()

--- a/src/lib/Empty/Empty.svelte.spec.ts
+++ b/src/lib/Empty/Empty.svelte.spec.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from 'vitest'
 import { render } from 'vitest-browser-svelte'
 import Empty from './Empty.svelte'
 
+const AVATAR_SRC =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+
 describe('Empty', () => {
     // ==================== RENDERING ====================
 
@@ -101,7 +104,7 @@ describe('Empty', () => {
         it('should render avatar with src', async () => {
             const { container } = render(Empty, {
                 title: 'Test',
-                avatar: { src: 'https://i.pravatar.cc/150', alt: 'User Avatar' }
+                avatar: { src: AVATAR_SRC, alt: 'User Avatar' }
             })
             const avatar = container.querySelector('[data-avatar-root]')
             expect(avatar).not.toBeNull()

--- a/src/lib/Input/Input.svelte.spec.ts
+++ b/src/lib/Input/Input.svelte.spec.ts
@@ -3,6 +3,9 @@ import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-svelte'
 import Input from './Input.svelte'
 
+const AVATAR_SRC =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+
 const getInput = () => document.querySelector('input') as HTMLInputElement | null
 
 describe('Input', () => {
@@ -287,7 +290,7 @@ describe('Input', () => {
 
         it('should render avatar with src as img element', async () => {
             render(Input, {
-                avatar: { src: 'https://i.pravatar.cc/64', alt: 'User avatar' }
+                avatar: { src: AVATAR_SRC, alt: 'User avatar' }
             })
             const img = page.getByRole('img', { name: 'User avatar' })
             await expect.element(img).toBeInTheDocument()


### PR DESCRIPTION
## Summary
- Replace all `i.pravatar.cc` URLs with inline data URIs (base64 PNG / SVG) across 5 test files
- Eliminate external service dependency that causes flaky tests and ~15s timeouts (bits-ui Avatar waits for image `onload` before rendering)
- Use unique SVG data URIs for AvatarGroup tests to avoid Svelte `each_key_duplicate` error

## Files changed
- `src/lib/Avatar/Avatar.svelte.spec.ts`
- `src/lib/AvatarGroup/AvatarGroup.svelte.spec.ts`
- `src/lib/Button/Button.svelte.spec.ts`
- `src/lib/Input/Input.svelte.spec.ts`
- `src/lib/Empty/Empty.svelte.spec.ts`

## Test plan
- [x] All 231 tests pass
- [x] No external network requests during test execution
- [x] Tests run in ~4s (previously ~15s+ due to pravatar timeouts)
