### PR TITLE
feat: add Textarea component with variants, icons, and FormField integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ pnpm add sv5ui
 | Component                            | Description                                                                                             |
 | :----------------------------------- | :------------------------------------------------------------------------------------------------------ |
 | [**Input**](src/lib/Input)           | Text input with 5 variants, icons, avatar, loading state, and FormField integration                     |
+| [**Textarea**](src/lib/Textarea)     | Multi-line text input with 5 variants, icons, autoresize with maxrows, and FormField integration        |
 | [**Select**](src/lib/Select)         | Dropdown select with 5 variants, icons, avatars, groups, descriptions, and FormField support            |
 | [**Switch**](src/lib/Switch)         | Toggle switch with 8 colors, 5 sizes, checked/unchecked icons, loading state, and FormField integration |
 | [**FormField**](src/lib/FormField)   | Form control wrapper providing label, description, hint, help, and error handling                       |

--- a/src/lib/Textarea/Textarea.svelte
+++ b/src/lib/Textarea/Textarea.svelte
@@ -1,0 +1,196 @@
+<script lang="ts" module>
+    import type { TextareaProps } from './textarea.types.js'
+
+    export type Props = TextareaProps
+</script>
+
+<script lang="ts">
+    import { textareaVariants, textareaDefaults } from './textarea.variants.js'
+    import { getComponentConfig, iconsDefaults } from '../config.js'
+    import { getContext } from 'svelte'
+    import {
+        fieldGroupVariantWithRoot,
+        type FieldGroupVariantProps
+    } from '../FieldGroup/field-group.variants.js'
+    import Icon from '../Icon/Icon.svelte'
+    import type { FormFieldProps } from '../FormField/form-field.types.js'
+
+    const config = getComponentConfig('textarea', textareaDefaults)
+    const icons = getComponentConfig('icons', iconsDefaults)
+
+    let {
+        ref = $bindable(null),
+        value = $bindable(),
+        ui,
+        id,
+        name,
+        color = config.defaultVariants.color,
+        variant = config.defaultVariants.variant,
+        size,
+        highlight,
+        loading = false,
+        loadingIcon = icons.loading,
+        disabled = false,
+        icon,
+        leadingIcon,
+        trailingIcon,
+        trailing = false,
+        leadingSlot,
+        trailingSlot,
+        autoresize = false,
+        rows = 3,
+        maxrows = 0,
+        class: className,
+        ...restProps
+    }: Props = $props()
+
+    const formFieldContext = getContext<
+        | {
+              name?: string
+              size: NonNullable<FormFieldProps['size']>
+              error?: string | boolean
+              ariaId: string
+          }
+        | undefined
+    >('formField')
+
+    const fieldGroupContext = getContext<
+        | {
+              orientation: NonNullable<FieldGroupVariantProps['orientation']>
+              size: NonNullable<FieldGroupVariantProps['size']>
+          }
+        | undefined
+    >('fieldGroup')
+
+    const hasError = $derived(
+        formFieldContext?.error !== undefined && formFieldContext?.error !== false
+    )
+    const resolvedSize = $derived(
+        size ?? formFieldContext?.size ?? fieldGroupContext?.size ?? config.defaultVariants.size
+    )
+    const resolvedColor = $derived(hasError ? 'error' : color)
+    const resolvedHighlight = $derived(highlight ?? hasError)
+    const fieldGroupClass = $derived(
+        fieldGroupContext
+            ? fieldGroupVariantWithRoot.fieldGroup[fieldGroupContext.orientation ?? 'horizontal']
+            : undefined
+    )
+
+    const resolvedId = $derived(id ?? formFieldContext?.ariaId)
+    const resolvedName = $derived(name ?? formFieldContext?.name)
+
+    const isLeading = $derived((!!icon && !trailing) || (loading && !trailing) || !!leadingIcon)
+    const isTrailing = $derived((!!icon && trailing) || (loading && trailing) || !!trailingIcon)
+
+    const leadingIconName = $derived(
+        loading && isLeading
+            ? loadingIcon
+            : leadingIcon || (isLeading && !trailing ? icon : undefined)
+    )
+    const trailingIconName = $derived(
+        loading && isTrailing ? loadingIcon : trailingIcon || (trailing ? icon : undefined)
+    )
+
+    const ariaDescribedBy = $derived.by(() => {
+        if (!formFieldContext) return undefined
+        const id = formFieldContext.ariaId
+        if (hasError) return `${id}-error`
+        return `${id}-description ${id}-help`
+    })
+
+    const classes = $derived.by(() => {
+        const slots = textareaVariants({
+            variant,
+            color: resolvedColor,
+            size: resolvedSize,
+            leading: isLeading,
+            trailing: isTrailing,
+            loading,
+            highlight: resolvedHighlight,
+            autoresize
+        })
+        return {
+            root: slots.root({
+                class: [config.slots.root, fieldGroupClass?.root, className, ui?.root]
+            }),
+            base: slots.base({
+                class: [config.slots.base, fieldGroupClass?.base, ui?.base]
+            }),
+            leading: slots.leading({ class: [config.slots.leading, ui?.leading] }),
+            leadingIcon: slots.leadingIcon({
+                class: [config.slots.leadingIcon, ui?.leadingIcon]
+            }),
+            trailing: slots.trailing({ class: [config.slots.trailing, ui?.trailing] }),
+            trailingIcon: slots.trailingIcon({
+                class: [config.slots.trailingIcon, ui?.trailingIcon]
+            })
+        }
+    })
+
+    let cachedMaxHeight = $state(0)
+
+    $effect(() => {
+        if (!autoresize || !ref || maxrows <= 0) {
+            cachedMaxHeight = 0
+            return
+        }
+
+        const style = window.getComputedStyle(ref)
+        cachedMaxHeight =
+            parseFloat(style.lineHeight) * maxrows +
+            parseFloat(style.paddingTop) +
+            parseFloat(style.paddingBottom)
+    })
+
+    $effect(() => {
+        if (!autoresize || !ref) return
+
+        void value
+
+        ref.style.height = 'auto'
+        const scrollHeight = ref.scrollHeight
+
+        if (cachedMaxHeight > 0 && scrollHeight > cachedMaxHeight) {
+            ref.style.height = `${cachedMaxHeight}px`
+            ref.style.overflowY = 'auto'
+        } else {
+            ref.style.height = `${scrollHeight}px`
+            ref.style.overflowY = 'hidden'
+        }
+    })
+</script>
+
+<div class={classes.root}>
+    {#if leadingSlot}
+        <span class={classes.leading}>
+            {@render leadingSlot()}
+        </span>
+    {:else if isLeading && leadingIconName}
+        <span class={classes.leading}>
+            <Icon name={leadingIconName} class={classes.leadingIcon} />
+        </span>
+    {/if}
+
+    <textarea
+        bind:this={ref}
+        bind:value
+        {rows}
+        id={resolvedId}
+        name={resolvedName}
+        disabled={disabled || loading}
+        aria-describedby={ariaDescribedBy}
+        aria-invalid={resolvedHighlight ? true : undefined}
+        class={classes.base}
+        {...restProps}
+    ></textarea>
+
+    {#if trailingSlot}
+        <span class={classes.trailing}>
+            {@render trailingSlot()}
+        </span>
+    {:else if isTrailing && trailingIconName}
+        <span class={classes.trailing}>
+            <Icon name={trailingIconName} class={classes.trailingIcon} />
+        </span>
+    {/if}
+</div>

--- a/src/lib/Textarea/Textarea.svelte.spec.ts
+++ b/src/lib/Textarea/Textarea.svelte.spec.ts
@@ -1,0 +1,429 @@
+import { page } from 'vitest/browser'
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-svelte'
+import Textarea from './Textarea.svelte'
+
+const getTextarea = () => document.querySelector('textarea') as HTMLTextAreaElement | null
+
+describe('Textarea', () => {
+    // ==================== RENDERING ====================
+
+    describe('rendering', () => {
+        it('should render a textarea element', async () => {
+            render(Textarea)
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toBeInTheDocument()
+        })
+
+        it('should render with placeholder', async () => {
+            render(Textarea, { placeholder: 'Enter text...' })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toBeInTheDocument()
+            expect(getTextarea()!.placeholder).toBe('Enter text...')
+        })
+
+        it('should render with id', () => {
+            render(Textarea, { id: 'my-textarea' })
+            expect(getTextarea()!.id).toBe('my-textarea')
+        })
+
+        it('should render with name', () => {
+            render(Textarea, { name: 'description' })
+            expect(getTextarea()!.name).toBe('description')
+        })
+
+        it('should render with value', async () => {
+            render(Textarea, { value: 'hello' })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveValue('hello')
+        })
+
+        it('should render with default rows of 3', () => {
+            render(Textarea)
+            expect(getTextarea()!.rows).toBe(3)
+        })
+
+        it('should render with custom rows', () => {
+            render(Textarea, { rows: 5 })
+            expect(getTextarea()!.rows).toBe(5)
+        })
+    })
+
+    // ==================== DISABLED STATE ====================
+
+    describe('disabled', () => {
+        it('should be disabled when disabled prop is true', async () => {
+            render(Textarea, { disabled: true })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toBeDisabled()
+        })
+
+        it('should not be disabled by default', async () => {
+            render(Textarea)
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toBeEnabled()
+        })
+
+        it('should apply disabled styling', async () => {
+            render(Textarea, { disabled: true })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/disabled:cursor-not-allowed/)
+        })
+    })
+
+    // ==================== LOADING STATE ====================
+
+    describe('loading', () => {
+        it('should be disabled when loading', async () => {
+            render(Textarea, { loading: true })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toBeDisabled()
+        })
+
+        it('should render loading icon on leading side by default', () => {
+            const { container } = render(Textarea, { loading: true })
+            const spans = container.querySelectorAll('span')
+            expect(spans.length).toBeGreaterThanOrEqual(1)
+        })
+
+        it('should render loading icon on trailing side when trailing is true', () => {
+            const { container } = render(Textarea, { loading: true, trailing: true })
+            const spans = container.querySelectorAll('span')
+            expect(spans.length).toBeGreaterThanOrEqual(1)
+        })
+    })
+
+    // ==================== VARIANTS ====================
+
+    describe('variants', () => {
+        const variants = ['outline', 'soft', 'subtle', 'ghost', 'none'] as const
+
+        for (const variant of variants) {
+            it(`should render with variant="${variant}"`, async () => {
+                render(Textarea, { variant })
+                const textarea = page.getByRole('textbox')
+                await expect.element(textarea).toBeInTheDocument()
+            })
+        }
+
+        it('should apply outline variant classes by default', async () => {
+            render(Textarea)
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/ring/)
+            await expect.element(textarea).toHaveClass(/ring-inset/)
+        })
+
+        it('should apply soft variant classes', async () => {
+            render(Textarea, { variant: 'soft', color: 'primary' })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/bg-primary-container/)
+        })
+
+        it('should apply ghost variant classes', async () => {
+            render(Textarea, { variant: 'ghost', color: 'primary' })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/bg-transparent/)
+        })
+
+        it('should apply none variant classes', async () => {
+            render(Textarea, { variant: 'none' })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/bg-transparent/)
+        })
+    })
+
+    // ==================== COLORS ====================
+
+    describe('colors', () => {
+        const colors = [
+            'primary',
+            'secondary',
+            'tertiary',
+            'success',
+            'warning',
+            'error',
+            'info'
+        ] as const
+
+        for (const color of colors) {
+            it(`should render with color="${color}"`, async () => {
+                render(Textarea, { color })
+                const textarea = page.getByRole('textbox')
+                await expect.element(textarea).toHaveClass(new RegExp(`ring-${color}`))
+            })
+        }
+
+        it('should apply surface color with outline variant', async () => {
+            render(Textarea, { color: 'surface', variant: 'outline' })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/ring-outline-variant/)
+        })
+    })
+
+    // ==================== SIZES ====================
+
+    describe('sizes', () => {
+        it('should apply xs size classes', async () => {
+            render(Textarea, { size: 'xs' })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/text-xs/)
+            await expect.element(textarea).toHaveClass(/py-1/)
+        })
+
+        it('should apply sm size classes', async () => {
+            render(Textarea, { size: 'sm' })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/text-xs/)
+        })
+
+        it('should apply md size classes by default', async () => {
+            render(Textarea, { size: 'md' })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/text-sm/)
+        })
+
+        it('should apply lg size classes', async () => {
+            render(Textarea, { size: 'lg' })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/text-sm/)
+        })
+
+        it('should apply xl size classes', async () => {
+            render(Textarea, { size: 'xl' })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/text-base/)
+        })
+    })
+
+    // ==================== HIGHLIGHT ====================
+
+    describe('highlight', () => {
+        it('should apply highlight ring when highlight is true', async () => {
+            render(Textarea, { highlight: true, color: 'primary' })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/ring-2/)
+            await expect.element(textarea).toHaveClass(/ring-primary/)
+        })
+
+        it('should apply error highlight ring', async () => {
+            render(Textarea, { highlight: true, color: 'error' })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/ring-2/)
+            await expect.element(textarea).toHaveClass(/ring-error/)
+        })
+
+        it('should set aria-invalid when highlight is true', () => {
+            render(Textarea, { highlight: true })
+            expect(getTextarea()!.getAttribute('aria-invalid')).toBe('true')
+        })
+
+        it('should not set aria-invalid when highlight is false', () => {
+            render(Textarea)
+            expect(getTextarea()!.getAttribute('aria-invalid')).toBeNull()
+        })
+    })
+
+    // ==================== ICONS ====================
+
+    describe('icons', () => {
+        it('should render with leadingIcon and adjust padding', async () => {
+            render(Textarea, { leadingIcon: 'lucide:search' })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toBeInTheDocument()
+            await expect.element(textarea).toHaveClass(/ps-9/)
+        })
+
+        it('should render with trailingIcon and adjust padding', async () => {
+            render(Textarea, { trailingIcon: 'lucide:eye' })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toBeInTheDocument()
+            await expect.element(textarea).toHaveClass(/pe-9/)
+        })
+
+        it('should render icon on leading side by default', async () => {
+            render(Textarea, { icon: 'lucide:user' })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/ps-9/)
+        })
+
+        it('should render icon on trailing side when trailing is true', async () => {
+            render(Textarea, { icon: 'lucide:user', trailing: true })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/pe-9/)
+        })
+
+        it('should render both leading and trailing icons', async () => {
+            render(Textarea, {
+                leadingIcon: 'lucide:mail',
+                trailingIcon: 'lucide:check'
+            })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/ps-9/)
+            await expect.element(textarea).toHaveClass(/pe-9/)
+        })
+
+        it('should adjust leading padding per size', async () => {
+            render(Textarea, { leadingIcon: 'lucide:search', size: 'xs' })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/ps-7/)
+        })
+
+        it('should adjust trailing padding per size', async () => {
+            render(Textarea, { trailingIcon: 'lucide:eye', size: 'xl' })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/pe-12/)
+        })
+    })
+
+    // ==================== AUTORESIZE ====================
+
+    describe('autoresize', () => {
+        it('should apply resize-none class when autoresize is true', async () => {
+            render(Textarea, { autoresize: true })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/resize-none/)
+        })
+
+        it('should not apply resize-none class when autoresize is false', async () => {
+            render(Textarea, { autoresize: false })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).not.toHaveClass(/resize-none/)
+        })
+    })
+
+    // ==================== EVENTS ====================
+
+    describe('events', () => {
+        it('should handle input events', async () => {
+            const oninput = vi.fn()
+            render(Textarea, { oninput })
+            const textarea = page.getByRole('textbox')
+            await textarea.fill('hello')
+            expect(oninput).toHaveBeenCalled()
+        })
+
+        it('should handle focus events', async () => {
+            const onfocus = vi.fn()
+            render(Textarea, { onfocus })
+            const textarea = page.getByRole('textbox')
+            await textarea.click()
+            expect(onfocus).toHaveBeenCalledOnce()
+        })
+
+        it('should handle blur events', async () => {
+            const onblur = vi.fn()
+            render(Textarea, { onblur })
+            await page.getByRole('textbox').click()
+            getTextarea()!.blur()
+            expect(onblur).toHaveBeenCalledOnce()
+        })
+    })
+
+    // ==================== CUSTOM CLASS ====================
+
+    describe('custom class', () => {
+        it('should apply custom class to root element', () => {
+            const { container } = render(Textarea, { class: 'my-custom-class' })
+            const root = container.firstElementChild as HTMLElement
+            expect(root.className).toContain('my-custom-class')
+        })
+
+        it('should apply ui slot overrides to textarea element', async () => {
+            render(Textarea, { ui: { base: 'my-textarea-class' } })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/my-textarea-class/)
+        })
+
+        it('should apply ui slot overrides to root element', () => {
+            const { container } = render(Textarea, { ui: { root: 'my-root-class' } })
+            const root = container.firstElementChild as HTMLElement
+            expect(root.className).toContain('my-root-class')
+        })
+    })
+
+    // ==================== ACCESSIBILITY ====================
+
+    describe('accessibility', () => {
+        it('should support aria-label', () => {
+            render(Textarea, { 'aria-label': 'Description input' })
+            expect(getTextarea()!.getAttribute('aria-label')).toBe('Description input')
+        })
+
+        it('should support readonly', () => {
+            render(Textarea, { readonly: true })
+            expect(getTextarea()!.readOnly).toBe(true)
+        })
+
+        it('should support required', () => {
+            render(Textarea, { required: true })
+            expect(getTextarea()!.required).toBe(true)
+        })
+
+        it('should support autocomplete', () => {
+            render(Textarea, { autocomplete: 'off' })
+            expect(getTextarea()!.autocomplete).toBe('off')
+        })
+    })
+
+    // ==================== COMBINED PROPS ====================
+
+    describe('combined props', () => {
+        it('should render with multiple props combined', async () => {
+            render(Textarea, {
+                variant: 'outline',
+                color: 'error',
+                size: 'lg',
+                highlight: true
+            })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toBeInTheDocument()
+            await expect.element(textarea).toHaveClass(/ring-2/)
+            await expect.element(textarea).toHaveClass(/ring-error/)
+            await expect.element(textarea).toHaveClass(/text-sm/)
+        })
+
+        it('should render loading with leadingIcon', async () => {
+            render(Textarea, {
+                leadingIcon: 'lucide:search',
+                loading: true
+            })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toBeDisabled()
+            await expect.element(textarea).toHaveClass(/ps-9/)
+        })
+
+        it('should render disabled with highlight', async () => {
+            render(Textarea, {
+                disabled: true,
+                highlight: true,
+                color: 'error'
+            })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toBeDisabled()
+            await expect.element(textarea).toHaveClass(/ring-error/)
+        })
+
+        it('should render with both icons and highlight', async () => {
+            render(Textarea, {
+                leadingIcon: 'lucide:mail',
+                trailingIcon: 'lucide:check',
+                highlight: true,
+                color: 'success'
+            })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/ps-9/)
+            await expect.element(textarea).toHaveClass(/pe-9/)
+            await expect.element(textarea).toHaveClass(/ring-success/)
+        })
+
+        it('should render autoresize with custom rows', async () => {
+            render(Textarea, {
+                autoresize: true,
+                rows: 5
+            })
+            const textarea = page.getByRole('textbox')
+            await expect.element(textarea).toHaveClass(/resize-none/)
+            expect(getTextarea()!.rows).toBe(5)
+        })
+    })
+})

--- a/src/lib/Textarea/index.ts
+++ b/src/lib/Textarea/index.ts
@@ -1,0 +1,2 @@
+export { default as Textarea } from './Textarea.svelte'
+export type { TextareaProps } from './textarea.types.js'

--- a/src/lib/Textarea/textarea.types.ts
+++ b/src/lib/Textarea/textarea.types.ts
@@ -1,0 +1,122 @@
+import type { Snippet } from 'svelte'
+import type { HTMLTextareaAttributes } from 'svelte/elements'
+import type { ClassNameValue } from 'tailwind-merge'
+import type { TextareaVariantProps, TextareaSlots } from './textarea.variants.js'
+
+export type TextareaProps = Omit<HTMLTextareaAttributes, 'class' | 'size'> & {
+    /**
+     * Bind a reference to the underlying HTMLTextAreaElement.
+     */
+    ref?: HTMLTextAreaElement | null
+
+    /**
+     * The current value of the textarea. Supports two-way binding with `bind:value`.
+     */
+    value?: string
+
+    /**
+     * Controls the visual style of the textarea.
+     * @default 'outline'
+     */
+    variant?: NonNullable<TextareaVariantProps['variant']>
+
+    /**
+     * Sets the color scheme for focus ring and highlight.
+     * @default 'primary'
+     */
+    color?: NonNullable<TextareaVariantProps['color']>
+
+    /**
+     * Controls the dimensions and text size of the textarea.
+     * @default 'md'
+     */
+    size?: NonNullable<TextareaVariantProps['size']>
+
+    /**
+     * Emphasizes ring color like focus state, even when not focused.
+     * Automatically enabled when used inside a FormField with an error.
+     * @default false
+     */
+    highlight?: boolean
+
+    /**
+     * Renders a loading spinner and optionally disables interaction.
+     * @default false
+     */
+    loading?: boolean
+
+    /**
+     * Icon displayed as the loading indicator.
+     * Supports any valid Iconify icon name.
+     * @default Uses `icons.loading` from app config
+     */
+    loadingIcon?: string
+
+    /**
+     * Icon displayed on the leading or trailing side.
+     * Position controlled by the `trailing` prop.
+     * Supports any valid Iconify icon name.
+     */
+    icon?: string
+
+    /**
+     * Icon placed before the textarea value.
+     * Supports any valid Iconify icon name.
+     */
+    leadingIcon?: string
+
+    /**
+     * Icon placed after the textarea value.
+     * Supports any valid Iconify icon name.
+     */
+    trailingIcon?: string
+
+    /**
+     * Moves the icon to the trailing (right) side.
+     * Only takes effect when using the `icon` prop.
+     * @default false
+     */
+    trailing?: boolean
+
+    /**
+     * Custom content rendered before the textarea.
+     * Takes precedence over `leadingIcon`.
+     */
+    leadingSlot?: Snippet
+
+    /**
+     * Custom content rendered after the textarea.
+     * Takes precedence over `trailingIcon`.
+     */
+    trailingSlot?: Snippet
+
+    /**
+     * Automatically adjusts textarea height based on content.
+     * Disables manual resizing when enabled.
+     * @default false
+     */
+    autoresize?: boolean
+
+    /**
+     * The number of visible text lines.
+     * @default 3
+     */
+    rows?: number
+
+    /**
+     * Maximum number of rows when autoresizing.
+     * Set to 0 for unlimited growth.
+     * @default 0
+     */
+    maxrows?: number
+
+    /**
+     * Additional CSS classes for the root element.
+     */
+    class?: ClassNameValue
+
+    /**
+     * Override styles for specific textarea slots.
+     */
+    ui?: Partial<Record<TextareaSlots, ClassNameValue>>
+}

--- a/src/lib/Textarea/textarea.variants.ts
+++ b/src/lib/Textarea/textarea.variants.ts
@@ -1,0 +1,417 @@
+import { tv, type VariantProps } from 'tailwind-variants'
+
+export const textareaVariants = tv({
+    slots: {
+        root: 'relative w-full inline-flex items-start',
+        base: [
+            'w-full rounded-md border-0 bg-surface text-on-surface placeholder:text-on-surface-variant/50',
+            'disabled:cursor-not-allowed disabled:opacity-75',
+            'transition-colors',
+            'focus:outline-none'
+        ],
+        leading: 'absolute start-0 flex items-start pointer-events-none',
+        leadingIcon: 'shrink-0 text-on-surface-variant/75',
+        trailing: 'absolute end-0 flex items-start pointer-events-none',
+        trailingIcon: 'shrink-0 text-on-surface-variant/75'
+    },
+    variants: {
+        variant: {
+            outline: '',
+            soft: '',
+            subtle: '',
+            ghost: '',
+            none: ''
+        },
+        color: {
+            primary: '',
+            secondary: '',
+            tertiary: '',
+            success: '',
+            warning: '',
+            error: '',
+            info: '',
+            surface: ''
+        },
+        size: {
+            xs: {
+                base: 'px-2 py-1 text-xs rounded',
+                leading: 'ps-2 inset-y-1',
+                leadingIcon: 'size-3.5',
+                trailing: 'pe-2 inset-y-1',
+                trailingIcon: 'size-3.5'
+            },
+            sm: {
+                base: 'px-2.5 py-1.5 text-xs rounded-md',
+                leading: 'ps-2.5 inset-y-1.5',
+                leadingIcon: 'size-4',
+                trailing: 'pe-2.5 inset-y-1.5',
+                trailingIcon: 'size-4'
+            },
+            md: {
+                base: 'px-3 py-2 text-sm rounded-md',
+                leading: 'ps-3 inset-y-1.5',
+                leadingIcon: 'size-5',
+                trailing: 'pe-3 inset-y-1.5',
+                trailingIcon: 'size-5'
+            },
+            lg: {
+                base: 'px-4 py-2.5 text-sm rounded-md',
+                leading: 'ps-4 inset-y-2',
+                leadingIcon: 'size-5',
+                trailing: 'pe-4 inset-y-2',
+                trailingIcon: 'size-5'
+            },
+            xl: {
+                base: 'px-5 py-3 text-base rounded-lg',
+                leading: 'ps-5 inset-y-2',
+                leadingIcon: 'size-6',
+                trailing: 'pe-5 inset-y-2',
+                trailingIcon: 'size-6'
+            }
+        },
+        leading: {
+            true: ''
+        },
+        trailing: {
+            true: ''
+        },
+        loading: {
+            true: ''
+        },
+        highlight: {
+            true: ''
+        },
+        autoresize: {
+            true: {
+                base: 'resize-none'
+            }
+        }
+    },
+    compoundVariants: [
+        // ========== OUTLINE VARIANTS ==========
+        {
+            variant: 'outline',
+            color: 'primary',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-primary'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'secondary',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-secondary'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'tertiary',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-tertiary'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'success',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-success'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'warning',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-warning'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'error',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-error'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'info',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-info'
+            }
+        },
+        {
+            variant: 'outline',
+            color: 'surface',
+            class: {
+                base: 'ring ring-inset ring-outline-variant focus:ring-2 focus:ring-outline'
+            }
+        },
+
+        // ========== SOFT VARIANTS ==========
+        {
+            variant: 'soft',
+            color: 'primary',
+            class: {
+                base: 'bg-primary-container/50 focus:bg-primary-container/75 focus:ring-2 focus:ring-inset focus:ring-primary'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'secondary',
+            class: {
+                base: 'bg-secondary-container/50 focus:bg-secondary-container/75 focus:ring-2 focus:ring-inset focus:ring-secondary'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'tertiary',
+            class: {
+                base: 'bg-tertiary-container/50 focus:bg-tertiary-container/75 focus:ring-2 focus:ring-inset focus:ring-tertiary'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'success',
+            class: {
+                base: 'bg-success-container/50 focus:bg-success-container/75 focus:ring-2 focus:ring-inset focus:ring-success'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'warning',
+            class: {
+                base: 'bg-warning-container/50 focus:bg-warning-container/75 focus:ring-2 focus:ring-inset focus:ring-warning'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'error',
+            class: {
+                base: 'bg-error-container/50 focus:bg-error-container/75 focus:ring-2 focus:ring-inset focus:ring-error'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'info',
+            class: {
+                base: 'bg-info-container/50 focus:bg-info-container/75 focus:ring-2 focus:ring-inset focus:ring-info'
+            }
+        },
+        {
+            variant: 'soft',
+            color: 'surface',
+            class: {
+                base: 'bg-surface-container-highest/50 focus:bg-surface-container-highest/75 focus:ring-2 focus:ring-inset focus:ring-outline'
+            }
+        },
+
+        // ========== SUBTLE VARIANTS ==========
+        {
+            variant: 'subtle',
+            color: 'primary',
+            class: {
+                base: 'ring ring-inset ring-primary/25 bg-primary-container/50 focus:ring-2 focus:ring-primary'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'secondary',
+            class: {
+                base: 'ring ring-inset ring-secondary/25 bg-secondary-container/50 focus:ring-2 focus:ring-secondary'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'tertiary',
+            class: {
+                base: 'ring ring-inset ring-tertiary/25 bg-tertiary-container/50 focus:ring-2 focus:ring-tertiary'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'success',
+            class: {
+                base: 'ring ring-inset ring-success/25 bg-success-container/50 focus:ring-2 focus:ring-success'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'warning',
+            class: {
+                base: 'ring ring-inset ring-warning/25 bg-warning-container/50 focus:ring-2 focus:ring-warning'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'error',
+            class: {
+                base: 'ring ring-inset ring-error/25 bg-error-container/50 focus:ring-2 focus:ring-error'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'info',
+            class: {
+                base: 'ring ring-inset ring-info/25 bg-info-container/50 focus:ring-2 focus:ring-info'
+            }
+        },
+        {
+            variant: 'subtle',
+            color: 'surface',
+            class: {
+                base: 'ring ring-inset ring-outline-variant bg-surface-container-highest/50 focus:ring-2 focus:ring-outline'
+            }
+        },
+
+        // ========== GHOST VARIANTS ==========
+        {
+            variant: 'ghost',
+            color: 'primary',
+            class: {
+                base: 'bg-transparent hover:bg-primary-container/50 focus:ring-2 focus:ring-inset focus:ring-primary'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'secondary',
+            class: {
+                base: 'bg-transparent hover:bg-secondary-container/50 focus:ring-2 focus:ring-inset focus:ring-secondary'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'tertiary',
+            class: {
+                base: 'bg-transparent hover:bg-tertiary-container/50 focus:ring-2 focus:ring-inset focus:ring-tertiary'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'success',
+            class: {
+                base: 'bg-transparent hover:bg-success-container/50 focus:ring-2 focus:ring-inset focus:ring-success'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'warning',
+            class: {
+                base: 'bg-transparent hover:bg-warning-container/50 focus:ring-2 focus:ring-inset focus:ring-warning'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'error',
+            class: {
+                base: 'bg-transparent hover:bg-error-container/50 focus:ring-2 focus:ring-inset focus:ring-error'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'info',
+            class: {
+                base: 'bg-transparent hover:bg-info-container/50 focus:ring-2 focus:ring-inset focus:ring-info'
+            }
+        },
+        {
+            variant: 'ghost',
+            color: 'surface',
+            class: {
+                base: 'bg-transparent hover:bg-surface-container-highest/50 focus:ring-2 focus:ring-inset focus:ring-outline'
+            }
+        },
+
+        // ========== NONE VARIANT ==========
+        {
+            variant: 'none',
+            class: {
+                base: 'bg-transparent focus:ring-0'
+            }
+        },
+
+        // ========== HIGHLIGHT VARIANTS ==========
+        {
+            highlight: true,
+            color: 'primary',
+            class: { base: 'ring-2 ring-inset ring-primary' }
+        },
+        {
+            highlight: true,
+            color: 'secondary',
+            class: { base: 'ring-2 ring-inset ring-secondary' }
+        },
+        {
+            highlight: true,
+            color: 'tertiary',
+            class: { base: 'ring-2 ring-inset ring-tertiary' }
+        },
+        {
+            highlight: true,
+            color: 'success',
+            class: { base: 'ring-2 ring-inset ring-success' }
+        },
+        {
+            highlight: true,
+            color: 'warning',
+            class: { base: 'ring-2 ring-inset ring-warning' }
+        },
+        {
+            highlight: true,
+            color: 'error',
+            class: { base: 'ring-2 ring-inset ring-error' }
+        },
+        {
+            highlight: true,
+            color: 'info',
+            class: { base: 'ring-2 ring-inset ring-info' }
+        },
+        {
+            highlight: true,
+            color: 'surface',
+            class: { base: 'ring-2 ring-inset ring-outline' }
+        },
+
+        // ========== LEADING PADDING ADJUSTMENTS ==========
+        { leading: true, size: 'xs', class: { base: 'ps-7' } },
+        { leading: true, size: 'sm', class: { base: 'ps-8' } },
+        { leading: true, size: 'md', class: { base: 'ps-9' } },
+        { leading: true, size: 'lg', class: { base: 'ps-10' } },
+        { leading: true, size: 'xl', class: { base: 'ps-12' } },
+
+        // ========== TRAILING PADDING ADJUSTMENTS ==========
+        { trailing: true, size: 'xs', class: { base: 'pe-7' } },
+        { trailing: true, size: 'sm', class: { base: 'pe-8' } },
+        { trailing: true, size: 'md', class: { base: 'pe-9' } },
+        { trailing: true, size: 'lg', class: { base: 'pe-10' } },
+        { trailing: true, size: 'xl', class: { base: 'pe-12' } },
+
+        // ========== LOADING ICON ANIMATION ==========
+        {
+            loading: true,
+            leading: true,
+            class: {
+                leadingIcon: 'animate-spin'
+            }
+        },
+        {
+            loading: true,
+            leading: false,
+            trailing: true,
+            class: {
+                trailingIcon: 'animate-spin'
+            }
+        }
+    ],
+    defaultVariants: {
+        variant: 'outline',
+        color: 'primary',
+        size: 'md'
+    }
+})
+
+export type TextareaVariantProps = VariantProps<typeof textareaVariants>
+export type TextareaSlots = keyof ReturnType<typeof textareaVariants>
+
+export const textareaDefaults = {
+    defaultVariants: textareaVariants.defaultVariants,
+    slots: {} as Partial<Record<TextareaSlots, string>>
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -31,6 +31,7 @@ export * from './Pagination/index.js'
 export * from './FieldGroup/index.js'
 export * from './FormField/index.js'
 export * from './Input/index.js'
+export * from './Textarea/index.js'
 export * from './Select/index.js'
 export * from './Switch/index.js'
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -42,6 +42,7 @@
         { href: '/field-group', label: 'Field Group', icon: 'lucide:group' },
         { href: '/form-field', label: 'Form Field', icon: 'lucide:text-cursor-input' },
         { href: '/input', label: 'Input', icon: 'lucide:text-cursor' },
+        { href: '/textarea', label: 'Textarea', icon: 'lucide:text' },
         { href: '/select', label: 'Select', icon: 'lucide:chevrons-up-down' },
         { href: '/switch', label: 'Switch', icon: 'lucide:toggle-left' }
     ]

--- a/src/routes/textarea/+page.svelte
+++ b/src/routes/textarea/+page.svelte
@@ -1,0 +1,346 @@
+<script lang="ts">
+    import { Textarea, FormField, FieldGroup } from '$lib/index.js'
+
+    const variants = ['outline', 'soft', 'subtle', 'ghost', 'none'] as const
+    const colors = [
+        'primary',
+        'secondary',
+        'tertiary',
+        'success',
+        'warning',
+        'error',
+        'info',
+        'surface'
+    ] as const
+    const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const
+
+    let bindValue = $state('')
+</script>
+
+<div class="space-y-8">
+    <div class="space-y-2">
+        <h1 class="text-2xl font-bold">Textarea</h1>
+        <p class="text-on-surface-variant">
+            A multi-line text input component with variants, colors, icons, autoresize, and
+            integration with FormField and FieldGroup.
+        </p>
+    </div>
+
+    <!-- Basic Usage -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Basic Usage</h2>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm">
+                <Textarea placeholder="Enter text..." />
+            </div>
+        </div>
+    </section>
+
+    <!-- Two-way Binding -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Two-way Binding</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1">bind:value</code> for reactive
+            two-way data binding.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm space-y-3">
+                <Textarea
+                    bind:value={bindValue}
+                    leadingIcon="lucide:pencil"
+                    placeholder="Type something..."
+                />
+                <p class="text-sm text-on-surface-variant">
+                    Value: <span class="font-mono text-on-surface">{bindValue || '(empty)'}</span>
+                </p>
+                <p class="text-sm text-on-surface-variant">
+                    Length: <span class="font-mono text-on-surface">{bindValue.length}</span>
+                </p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Variants × Colors -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Variants &times; Colors</h2>
+        <div class="overflow-x-auto rounded-lg bg-surface-container-high p-4">
+            <table class="w-full border-collapse">
+                <thead>
+                    <tr>
+                        <th class="px-3 py-2 text-left text-xs font-medium text-on-surface-variant"
+                        ></th>
+                        {#each colors as color (color)}
+                            <th
+                                class="px-3 py-2 text-left text-xs font-medium text-on-surface-variant capitalize"
+                                >{color}</th
+                            >
+                        {/each}
+                    </tr>
+                </thead>
+                <tbody>
+                    {#each variants as variant (variant)}
+                        <tr>
+                            <td
+                                class="px-3 py-2 text-xs font-medium text-on-surface-variant capitalize"
+                                >{variant}</td
+                            >
+                            {#each colors as color (color)}
+                                <td class="px-3 py-2">
+                                    <Textarea {variant} {color} placeholder={color} rows={2} />
+                                </td>
+                            {/each}
+                        </tr>
+                    {/each}
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <!-- Sizes -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Size</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">size</code> prop to control
+            the dimensions and text size.
+        </p>
+        <div class="flex flex-wrap items-end gap-4 rounded-lg bg-surface-container-high p-4">
+            {#each sizes as size (size)}
+                <div class="w-48">
+                    <Textarea {size} placeholder="{size} size" rows={2} />
+                </div>
+            {/each}
+        </div>
+    </section>
+
+    <!-- Rows -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Rows</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">rows</code> prop to set the
+            number of visible text lines.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-64">
+                <Textarea rows={2} placeholder="2 rows" />
+            </div>
+            <div class="w-64">
+                <Textarea rows={4} placeholder="4 rows" />
+            </div>
+            <div class="w-64">
+                <Textarea rows={6} placeholder="6 rows" />
+            </div>
+        </div>
+    </section>
+
+    <!-- Autoresize -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Autoresize</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">autoresize</code> prop
+            to automatically adjust the height based on content. Combine with
+            <code class="rounded bg-surface-container-highest px-1">maxrows</code> to limit growth.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm">
+                <p class="mb-2 text-xs text-on-surface-variant">Unlimited autoresize</p>
+                <Textarea autoresize placeholder="Type to grow..." rows={1} />
+            </div>
+            <div class="w-full max-w-sm">
+                <p class="mb-2 text-xs text-on-surface-variant">Autoresize with maxrows=5</p>
+                <Textarea autoresize maxrows={5} placeholder="Grows up to 5 rows..." rows={1} />
+            </div>
+        </div>
+    </section>
+
+    <!-- Icons -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Icons</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1">leadingIcon</code> and
+            <code class="rounded bg-surface-container-highest px-1">trailingIcon</code> to add icons.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-64">
+                <Textarea leadingIcon="lucide:message-square" placeholder="Comment..." rows={2} />
+            </div>
+            <div class="w-64">
+                <Textarea trailingIcon="lucide:send" placeholder="Message..." rows={2} />
+            </div>
+            <div class="w-64">
+                <Textarea
+                    leadingIcon="lucide:file-text"
+                    trailingIcon="lucide:check"
+                    placeholder="Description..."
+                    rows={2}
+                />
+            </div>
+        </div>
+    </section>
+
+    <!-- Icon prop with trailing -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Icon (with trailing)</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">icon</code> prop with
+            <code class="rounded bg-surface-container-highest px-1">trailing</code> to position it.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-64">
+                <Textarea icon="lucide:pencil" placeholder="Leading icon" rows={2} />
+            </div>
+            <div class="w-64">
+                <Textarea icon="lucide:pencil" trailing placeholder="Trailing icon" rows={2} />
+            </div>
+        </div>
+    </section>
+
+    <!-- Loading -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Loading</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">loading</code> prop to show
+            a loading spinner.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-64">
+                <Textarea loading placeholder="Loading (leading)..." rows={2} />
+            </div>
+            <div class="w-64">
+                <Textarea loading trailing placeholder="Loading (trailing)..." rows={2} />
+            </div>
+        </div>
+    </section>
+
+    <!-- Disabled -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Disabled</h2>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-64">
+                <Textarea disabled placeholder="Disabled" rows={2} />
+            </div>
+            <div class="w-64">
+                <Textarea disabled value="Disabled with value" rows={2} />
+            </div>
+        </div>
+    </section>
+
+    <!-- Highlight -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Highlight</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">highlight</code> prop to emphasize
+            the ring color.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            {#each colors as color (color)}
+                <div class="w-48">
+                    <Textarea highlight {color} placeholder={color} rows={2} />
+                </div>
+            {/each}
+        </div>
+    </section>
+
+    <!-- FormField Integration -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">FormField Integration</h2>
+        <p class="text-sm text-on-surface-variant">
+            When used inside a <code class="rounded bg-surface-container-highest px-1"
+                >FormField</code
+            >, the Textarea automatically inherits size, error state, and accessibility attributes.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm space-y-4">
+                <FormField
+                    label="Description"
+                    description="Provide a detailed description of the issue."
+                    required
+                >
+                    <Textarea leadingIcon="lucide:file-text" placeholder="Describe the issue..." />
+                </FormField>
+
+                <FormField
+                    label="Notes"
+                    help="Optional additional notes."
+                    error="Notes cannot be empty."
+                >
+                    <Textarea placeholder="Enter notes..." />
+                </FormField>
+            </div>
+        </div>
+    </section>
+
+    <!-- Custom UI -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Custom UI</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">ui</code> prop to
+            override classes on specific slots:
+            <code class="rounded bg-surface-container-highest px-1">root</code>,
+            <code class="rounded bg-surface-container-highest px-1">base</code>,
+            <code class="rounded bg-surface-container-highest px-1">leading</code>,
+            <code class="rounded bg-surface-container-highest px-1">leadingIcon</code>,
+            <code class="rounded bg-surface-container-highest px-1">trailing</code>,
+            <code class="rounded bg-surface-container-highest px-1">trailingIcon</code>.
+        </p>
+        <div class="flex flex-wrap gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm">
+                <p class="mb-2 text-xs text-on-surface-variant">Custom base & root</p>
+                <Textarea
+                    placeholder="Rounded with shadow..."
+                    rows={2}
+                    ui={{
+                        root: 'shadow-lg rounded-xl',
+                        base: 'rounded-xl'
+                    }}
+                />
+            </div>
+            <div class="w-full max-w-sm">
+                <p class="mb-2 text-xs text-on-surface-variant">Custom icon colors</p>
+                <Textarea
+                    leadingIcon="lucide:sparkles"
+                    trailingIcon="lucide:send"
+                    placeholder="Colorful icons..."
+                    rows={2}
+                    ui={{
+                        leadingIcon: 'text-primary',
+                        trailingIcon: 'text-success'
+                    }}
+                />
+            </div>
+            <div class="w-full max-w-sm">
+                <p class="mb-2 text-xs text-on-surface-variant">Custom font & background</p>
+                <Textarea
+                    variant="soft"
+                    color="tertiary"
+                    placeholder="Italic monospace..."
+                    rows={2}
+                    ui={{
+                        base: 'font-mono italic'
+                    }}
+                />
+            </div>
+        </div>
+    </section>
+
+    <!-- FieldGroup Integration -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">FieldGroup Integration</h2>
+        <p class="text-sm text-on-surface-variant">
+            When used inside a <code class="rounded bg-surface-container-highest px-1"
+                >FieldGroup</code
+            >, textareas are visually connected.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="space-y-4">
+                <div>
+                    <p class="mb-2 text-xs text-on-surface-variant">Vertical</p>
+                    <FieldGroup orientation="vertical">
+                        <Textarea placeholder="Title" rows={1} />
+                        <Textarea placeholder="Description" rows={3} />
+                        <Textarea placeholder="Additional notes" rows={2} />
+                    </FieldGroup>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
## Summary
- Add new `Textarea` component with full variant system (outline, soft, subtle, ghost, none), 8 color schemes, 5 sizes, icons (leading/trailing), highlight, loading states, and autoresize support with optional `maxrows` limit
- Integrate with `FormField` (error state, aria attributes) and `FieldGroup` (visually connected fields)
- Add demo page with all feature showcases and sidebar navigation entry

## Test plan
- [x] 63 unit tests covering rendering, disabled, loading, variants, colors, sizes, highlight, icons, autoresize, events, custom classes, accessibility, and combined props
- [ ] Verify demo page at `/textarea` renders all sections correctly
- [ ] Test autoresize behavior by typing multi-line content
- [ ] Test `maxrows` limit prevents infinite growth
- [ ] Verify FormField integration shows error state and aria attributes
- [ ] Verify FieldGroup integration connects textareas visually
