### PR TITLE
feat: add Checkbox component with variants, indeterminate state, and FormField integration

### DIFF
--- a/src/lib/Checkbox/Checkbox.svelte
+++ b/src/lib/Checkbox/Checkbox.svelte
@@ -1,0 +1,138 @@
+<script lang="ts" module>
+    import type { CheckboxProps } from './checkbox.types.js'
+
+    export type Props = CheckboxProps
+</script>
+
+<script lang="ts">
+    import { Checkbox, Label, useId } from 'bits-ui'
+    import { checkboxVariants, checkboxDefaults } from './checkbox.variants.js'
+    import { getComponentConfig, iconsDefaults } from '../config.js'
+    import { getContext } from 'svelte'
+    import Icon from '../Icon/Icon.svelte'
+    import type { FormFieldProps } from '../FormField/form-field.types.js'
+
+    const config = getComponentConfig('checkbox', checkboxDefaults)
+    const icons = getComponentConfig('icons', iconsDefaults)
+
+    let {
+        checked = $bindable(false),
+        onCheckedChange,
+        indeterminate = $bindable(false),
+        onIndeterminateChange,
+        ui,
+        id,
+        name,
+        value,
+        color = config.defaultVariants.color,
+        size,
+        disabled = false,
+        required = false,
+        loading = false,
+        loadingIcon = icons.loading,
+        icon = icons.check,
+        indeterminateIcon = 'lucide:minus',
+        label,
+        description,
+        labelSlot,
+        descriptionSlot,
+        class: className
+    }: Props = $props()
+
+    const formFieldContext = getContext<
+        | {
+              name?: string
+              size: NonNullable<FormFieldProps['size']>
+              error?: string | boolean
+              ariaId: string
+          }
+        | undefined
+    >('formField')
+
+    const hasError = $derived(
+        formFieldContext?.error !== undefined && formFieldContext?.error !== false
+    )
+    const resolvedSize = $derived(size ?? formFieldContext?.size ?? config.defaultVariants.size)
+    const resolvedColor = $derived(hasError ? 'error' : color)
+    const autoId = useId()
+    const resolvedId = $derived(id ?? formFieldContext?.ariaId ?? autoId)
+    const resolvedName = $derived(name ?? formFieldContext?.name)
+    const isDisabled = $derived(disabled || loading)
+
+    const ariaDescribedBy = $derived.by(() => {
+        if (!formFieldContext) return undefined
+        const fid = formFieldContext.ariaId
+        return hasError ? `${fid}-error` : `${fid}-description ${fid}-help`
+    })
+
+    const resolvedIcon = $derived(loading ? loadingIcon : indeterminate ? indeterminateIcon : icon)
+
+    const classes = $derived.by(() => {
+        const slots = checkboxVariants({
+            color: resolvedColor,
+            size: resolvedSize,
+            loading,
+            required,
+            disabled: isDisabled ? true : undefined
+        })
+        return {
+            root: slots.root({ class: [config.slots.root, className, ui?.root] }),
+            base: slots.base({ class: [config.slots.base, ui?.base] }),
+            container: slots.container({ class: [config.slots.container, ui?.container] }),
+            indicator: slots.indicator({ class: [config.slots.indicator, ui?.indicator] }),
+            icon: slots.icon({ class: [config.slots.icon, ui?.icon] }),
+            wrapper: slots.wrapper({ class: [config.slots.wrapper, ui?.wrapper] }),
+            label: slots.label({ class: [config.slots.label, ui?.label] }),
+            description: slots.description({
+                class: [config.slots.description, ui?.description]
+            })
+        }
+    })
+</script>
+
+<div class={classes.root}>
+    <div class={classes.container}>
+        <Checkbox.Root
+            bind:checked
+            {onCheckedChange}
+            bind:indeterminate
+            {onIndeterminateChange}
+            id={resolvedId}
+            name={resolvedName}
+            {value}
+            disabled={isDisabled}
+            {required}
+            aria-describedby={ariaDescribedBy}
+            aria-invalid={hasError ? true : undefined}
+            class={classes.base}
+        >
+            {#snippet children({ checked: isChecked, indeterminate: isIndeterminate })}
+                {#if isChecked || isIndeterminate || loading}
+                    <span class={classes.indicator}>
+                        {#if resolvedIcon}
+                            <Icon name={resolvedIcon} class={classes.icon} />
+                        {/if}
+                    </span>
+                {/if}
+            {/snippet}
+        </Checkbox.Root>
+    </div>
+
+    {#if label || description || labelSlot || descriptionSlot}
+        <div class={classes.wrapper}>
+            {#if labelSlot}
+                {@render labelSlot({ label })}
+            {:else if label}
+                <Label.Root for={resolvedId} class={classes.label}>
+                    {label}
+                </Label.Root>
+            {/if}
+
+            {#if descriptionSlot}
+                {@render descriptionSlot({ description })}
+            {:else if description}
+                <p class={classes.description}>{description}</p>
+            {/if}
+        </div>
+    {/if}
+</div>

--- a/src/lib/Checkbox/Checkbox.svelte.spec.ts
+++ b/src/lib/Checkbox/Checkbox.svelte.spec.ts
@@ -1,0 +1,400 @@
+import { page } from 'vitest/browser'
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-svelte'
+import Checkbox from './Checkbox.svelte'
+
+const getCheckbox = () =>
+    document.querySelector('button[role="checkbox"]') as HTMLButtonElement | null
+
+describe('Checkbox', () => {
+    // ==================== RENDERING ====================
+
+    describe('rendering', () => {
+        it('should render a checkbox element', async () => {
+            render(Checkbox)
+            const cb = page.getByRole('checkbox')
+            await expect.element(cb).toBeInTheDocument()
+        })
+
+        it('should render unchecked by default', () => {
+            render(Checkbox)
+            expect(getCheckbox()!.getAttribute('data-state')).toBe('unchecked')
+        })
+
+        it('should render checked when checked prop is true', () => {
+            render(Checkbox, { checked: true })
+            expect(getCheckbox()!.getAttribute('data-state')).toBe('checked')
+        })
+
+        it('should render with id', () => {
+            render(Checkbox, { id: 'my-checkbox' })
+            expect(getCheckbox()!.id).toBe('my-checkbox')
+        })
+
+        it('should generate an id automatically', () => {
+            render(Checkbox)
+            expect(getCheckbox()!.id).toBeTruthy()
+        })
+
+        it('should render with name attribute', () => {
+            const { container } = render(Checkbox, { name: 'accept-terms' })
+            const hidden = container.querySelector('input[name="accept-terms"]')
+            expect(hidden).toBeTruthy()
+        })
+    })
+
+    // ==================== CHECKED STATE ====================
+
+    describe('checked state', () => {
+        it('should toggle on click', async () => {
+            render(Checkbox)
+            const cb = page.getByRole('checkbox')
+            expect(getCheckbox()!.getAttribute('data-state')).toBe('unchecked')
+            await cb.click()
+            expect(getCheckbox()!.getAttribute('data-state')).toBe('checked')
+        })
+
+        it('should call onCheckedChange callback', async () => {
+            const onCheckedChange = vi.fn()
+            render(Checkbox, { onCheckedChange })
+            const cb = page.getByRole('checkbox')
+            await cb.click()
+            expect(onCheckedChange).toHaveBeenCalledWith(true)
+        })
+
+        it('should render check icon when checked', async () => {
+            render(Checkbox, { checked: true })
+            const cb = getCheckbox()!
+            await vi.waitFor(() => {
+                expect(cb.querySelector('svg')).not.toBeNull()
+            })
+        })
+
+        it('should not render icon when unchecked', () => {
+            render(Checkbox)
+            const cb = getCheckbox()!
+            expect(cb.querySelector('svg')).toBeNull()
+        })
+    })
+
+    // ==================== INDETERMINATE STATE ====================
+
+    describe('indeterminate state', () => {
+        it('should render indeterminate state', () => {
+            render(Checkbox, { indeterminate: true })
+            expect(getCheckbox()!.getAttribute('data-state')).toBe('indeterminate')
+        })
+
+        it('should render indeterminate icon', async () => {
+            render(Checkbox, { indeterminate: true })
+            const cb = getCheckbox()!
+            await vi.waitFor(() => {
+                expect(cb.querySelector('svg')).not.toBeNull()
+            })
+        })
+    })
+
+    // ==================== DISABLED STATE ====================
+
+    describe('disabled', () => {
+        it('should be disabled when disabled prop is true', async () => {
+            render(Checkbox, { disabled: true })
+            const cb = page.getByRole('checkbox')
+            await expect.element(cb).toBeDisabled()
+        })
+
+        it('should not be disabled by default', async () => {
+            render(Checkbox)
+            const cb = page.getByRole('checkbox')
+            await expect.element(cb).toBeEnabled()
+        })
+
+        it('should apply disabled styling to root', () => {
+            const { container } = render(Checkbox, { disabled: true })
+            const root = container.firstElementChild as HTMLElement
+            expect(root.className).toMatch(/opacity-75/)
+        })
+
+        it('should apply cursor-not-allowed to base', () => {
+            render(Checkbox, { disabled: true })
+            expect(getCheckbox()!.className).toMatch(/cursor-not-allowed/)
+        })
+
+        it('should not toggle when disabled', async () => {
+            render(Checkbox, { disabled: true })
+            const cb = page.getByRole('checkbox')
+            await cb.click({ force: true })
+            expect(getCheckbox()!.getAttribute('data-state')).toBe('unchecked')
+        })
+    })
+
+    // ==================== LOADING STATE ====================
+
+    describe('loading', () => {
+        it('should be disabled when loading', async () => {
+            render(Checkbox, { loading: true })
+            const cb = page.getByRole('checkbox')
+            await expect.element(cb).toBeDisabled()
+        })
+
+        it('should render loading icon', async () => {
+            render(Checkbox, { loading: true })
+            const cb = getCheckbox()!
+            await vi.waitFor(() => {
+                expect(cb.querySelector('svg')).not.toBeNull()
+            })
+        })
+
+        it('should not toggle when loading', async () => {
+            render(Checkbox, { loading: true })
+            const cb = page.getByRole('checkbox')
+            await cb.click({ force: true })
+            expect(getCheckbox()!.getAttribute('data-state')).toBe('unchecked')
+        })
+    })
+
+    // ==================== COLORS ====================
+
+    describe('colors', () => {
+        const colors = [
+            'primary',
+            'secondary',
+            'tertiary',
+            'success',
+            'warning',
+            'error',
+            'info'
+        ] as const
+
+        for (const color of colors) {
+            it(`should render with color="${color}"`, () => {
+                render(Checkbox, { color, checked: true })
+                expect(getCheckbox()!.className).toMatch(new RegExp(`bg-${color}`))
+            })
+        }
+
+        it('should apply surface color', () => {
+            render(Checkbox, { color: 'surface', checked: true })
+            expect(getCheckbox()!.className).toMatch(/bg-on-surface/)
+        })
+
+        it('should apply focus-visible outline per color', () => {
+            render(Checkbox, { color: 'primary' })
+            expect(getCheckbox()!.className).toMatch(/outline-primary/)
+        })
+    })
+
+    // ==================== SIZES ====================
+
+    describe('sizes', () => {
+        it('should apply xs size classes', () => {
+            render(Checkbox, { size: 'xs' })
+            expect(getCheckbox()!.className).toMatch(/size-3\.5/)
+        })
+
+        it('should apply sm size classes', () => {
+            render(Checkbox, { size: 'sm' })
+            expect(getCheckbox()!.className).toMatch(/size-4/)
+        })
+
+        it('should apply md size classes by default', () => {
+            render(Checkbox)
+            expect(getCheckbox()!.className).toMatch(/size-4\.5/)
+        })
+
+        it('should apply lg size classes', () => {
+            render(Checkbox, { size: 'lg' })
+            expect(getCheckbox()!.className).toMatch(/size-5/)
+        })
+
+        it('should apply xl size classes', () => {
+            render(Checkbox, { size: 'xl' })
+            expect(getCheckbox()!.className).toMatch(/size-5\.5/)
+        })
+
+        it('should apply wrapper text size per size variant', () => {
+            const { container } = render(Checkbox, { size: 'xs', label: 'Test' })
+            const wrapper = container.querySelector('.ms-2') as HTMLElement
+            expect(wrapper.className).toMatch(/text-xs/)
+        })
+    })
+
+    // ==================== LABEL & DESCRIPTION ====================
+
+    describe('label & description', () => {
+        it('should render label text', async () => {
+            render(Checkbox, { label: 'Accept terms' })
+            const label = page.getByText('Accept terms')
+            await expect.element(label).toBeInTheDocument()
+        })
+
+        it('should render description text', async () => {
+            render(Checkbox, { description: 'You agree to the terms' })
+            const desc = page.getByText('You agree to the terms')
+            await expect.element(desc).toBeInTheDocument()
+        })
+
+        it('should render both label and description', () => {
+            const { container } = render(Checkbox, {
+                label: 'Dark mode',
+                description: 'Toggle theme appearance'
+            })
+            const label = container.querySelector('label') as HTMLElement
+            const desc = container.querySelector('p') as HTMLElement
+            expect(label.textContent).toBe('Dark mode')
+            expect(desc.textContent).toBe('Toggle theme appearance')
+        })
+
+        it('should not render wrapper when no label or description', () => {
+            const { container } = render(Checkbox)
+            expect(container.querySelector('.ms-2')).toBeNull()
+        })
+
+        it('should associate label with checkbox via for attribute', () => {
+            render(Checkbox, { id: 'test-checkbox', label: 'My Label' })
+            const label = document.querySelector('label') as HTMLLabelElement
+            expect(label.getAttribute('for')).toBe('test-checkbox')
+        })
+
+        it('should apply required asterisk styling to label', () => {
+            render(Checkbox, { label: 'Accept terms', required: true })
+            const label = document.querySelector('label') as HTMLElement
+            expect(label.className).toMatch(/after:content/)
+        })
+
+        it('should apply cursor-not-allowed to label when disabled', () => {
+            render(Checkbox, { label: 'Disabled', disabled: true })
+            const label = document.querySelector('label') as HTMLElement
+            expect(label.className).toMatch(/cursor-not-allowed/)
+        })
+
+        it('should apply cursor-not-allowed to description when disabled', () => {
+            render(Checkbox, { description: 'Desc', disabled: true })
+            const desc = document.querySelector('p') as HTMLElement
+            expect(desc.className).toMatch(/cursor-not-allowed/)
+        })
+    })
+
+    // ==================== CUSTOM CLASS & UI ====================
+
+    describe('custom class & ui', () => {
+        it('should apply custom class to root element', () => {
+            const { container } = render(Checkbox, { class: 'my-custom-class' })
+            const root = container.firstElementChild as HTMLElement
+            expect(root.className).toContain('my-custom-class')
+        })
+
+        it('should apply ui slot override to base', () => {
+            render(Checkbox, { ui: { base: 'my-base-class' } })
+            expect(getCheckbox()!.className).toContain('my-base-class')
+        })
+
+        it('should apply ui slot override to root', () => {
+            const { container } = render(Checkbox, { ui: { root: 'my-root-class' } })
+            const root = container.firstElementChild as HTMLElement
+            expect(root.className).toContain('my-root-class')
+        })
+
+        it('should apply ui slot override to label', () => {
+            render(Checkbox, { label: 'Test', ui: { label: 'my-label-class' } })
+            const label = document.querySelector('label') as HTMLElement
+            expect(label.className).toContain('my-label-class')
+        })
+
+        it('should apply ui slot override to description', () => {
+            render(Checkbox, { description: 'Desc', ui: { description: 'my-desc-class' } })
+            const desc = document.querySelector('p') as HTMLElement
+            expect(desc.className).toContain('my-desc-class')
+        })
+
+        it('should apply ui slot override to wrapper', () => {
+            const { container } = render(Checkbox, {
+                label: 'Test',
+                ui: { wrapper: 'my-wrapper-class' }
+            })
+            const wrapper = container.querySelector('.ms-2') as HTMLElement
+            expect(wrapper.className).toContain('my-wrapper-class')
+        })
+    })
+
+    // ==================== ACCESSIBILITY ====================
+
+    describe('accessibility', () => {
+        it('should have role="checkbox"', async () => {
+            render(Checkbox)
+            const cb = page.getByRole('checkbox')
+            await expect.element(cb).toBeInTheDocument()
+        })
+
+        it('should set aria-checked based on checked state', () => {
+            render(Checkbox, { checked: true })
+            expect(getCheckbox()!.getAttribute('aria-checked')).toBe('true')
+        })
+
+        it('should set aria-checked false when unchecked', () => {
+            render(Checkbox)
+            expect(getCheckbox()!.getAttribute('aria-checked')).toBe('false')
+        })
+
+        it('should set aria-checked mixed when indeterminate', () => {
+            render(Checkbox, { indeterminate: true })
+            expect(getCheckbox()!.getAttribute('aria-checked')).toBe('mixed')
+        })
+
+        it('should support required attribute', () => {
+            render(Checkbox, { required: true })
+            expect(getCheckbox()!.getAttribute('aria-required')).toBe('true')
+        })
+    })
+
+    // ==================== COMBINED PROPS ====================
+
+    describe('combined props', () => {
+        it('should render with label, description, and checked', () => {
+            const { container } = render(Checkbox, {
+                label: 'Email alerts',
+                description: 'Receive email when updates arrive',
+                checked: true
+            })
+            const label = container.querySelector('label') as HTMLElement
+            const desc = container.querySelector('p') as HTMLElement
+            expect(label.textContent).toBe('Email alerts')
+            expect(desc.textContent).toBe('Receive email when updates arrive')
+            expect(getCheckbox()!.getAttribute('data-state')).toBe('checked')
+        })
+
+        it('should render disabled with checked state', () => {
+            render(Checkbox, { disabled: true, checked: true })
+            expect(getCheckbox()!.getAttribute('data-state')).toBe('checked')
+            expect(getCheckbox()!.disabled).toBe(true)
+        })
+
+        it('should render with color and size combined', () => {
+            render(Checkbox, { color: 'success', size: 'xl', checked: true })
+            const cb = getCheckbox()!
+            expect(cb.className).toMatch(/bg-success/)
+            expect(cb.className).toMatch(/size-5\.5/)
+        })
+
+        it('should render with all props combined', () => {
+            const { container } = render(Checkbox, {
+                checked: true,
+                color: 'error',
+                size: 'lg',
+                label: 'Critical setting',
+                description: 'Handle with care',
+                required: true,
+                id: 'full-checkbox'
+            })
+            const cb = getCheckbox()!
+            expect(cb.id).toBe('full-checkbox')
+            expect(cb.getAttribute('data-state')).toBe('checked')
+            expect(cb.className).toMatch(/bg-error/)
+            expect(cb.className).toMatch(/size-5/)
+            const label = container.querySelector('label') as HTMLElement
+            const desc = container.querySelector('p') as HTMLElement
+            expect(label.textContent).toBe('Critical setting')
+            expect(desc.textContent).toBe('Handle with care')
+        })
+    })
+})

--- a/src/lib/Checkbox/checkbox.types.ts
+++ b/src/lib/Checkbox/checkbox.types.ts
@@ -1,0 +1,102 @@
+import type { Snippet } from 'svelte'
+import type { Checkbox as CheckboxPrimitive } from 'bits-ui'
+import type { ClassNameValue } from 'tailwind-merge'
+import type { CheckboxVariantProps, CheckboxSlots } from './checkbox.variants.js'
+
+export type CheckboxProps = Pick<
+    CheckboxPrimitive.RootProps,
+    'disabled' | 'name' | 'value' | 'required'
+> & {
+    /**
+     * The checked state of the checkbox. Supports two-way binding with `bind:checked`.
+     * @default false
+     */
+    checked?: boolean
+
+    /**
+     * Callback when the checked state changes.
+     */
+    onCheckedChange?: (checked: boolean) => void
+
+    /**
+     * Whether the checkbox is in an indeterminate state.
+     * @default false
+     */
+    indeterminate?: boolean
+
+    /**
+     * Callback when the indeterminate state changes.
+     */
+    onIndeterminateChange?: (indeterminate: boolean) => void
+
+    /**
+     * Sets the color scheme for the checkbox.
+     * @default 'primary'
+     */
+    color?: NonNullable<CheckboxVariantProps['color']>
+
+    /**
+     * Controls the dimensions of the checkbox.
+     * @default 'md'
+     */
+    size?: NonNullable<CheckboxVariantProps['size']>
+
+    /**
+     * Renders a loading spinner inside the checkbox.
+     * @default false
+     */
+    loading?: boolean
+
+    /**
+     * Icon displayed as the loading indicator.
+     * @default Uses `icons.loading` from app config
+     */
+    loadingIcon?: string
+
+    /**
+     * Icon displayed when checked.
+     * @default Uses `icons.check` from app config
+     */
+    icon?: string
+
+    /**
+     * Icon displayed when in indeterminate state.
+     * @default 'lucide:minus'
+     */
+    indeterminateIcon?: string
+
+    /**
+     * Label text displayed next to the checkbox.
+     */
+    label?: string
+
+    /**
+     * Description text displayed below the label.
+     */
+    description?: string
+
+    /**
+     * The HTML id attribute for the checkbox.
+     */
+    id?: string
+
+    /**
+     * Custom snippet for the label.
+     */
+    labelSlot?: Snippet<[{ label?: string }]>
+
+    /**
+     * Custom snippet for the description.
+     */
+    descriptionSlot?: Snippet<[{ description?: string }]>
+
+    /**
+     * Additional CSS classes for the root element.
+     */
+    class?: ClassNameValue
+
+    /**
+     * Override styles for specific checkbox slots.
+     */
+    ui?: Partial<Record<CheckboxSlots, ClassNameValue>>
+}

--- a/src/lib/Checkbox/checkbox.variants.ts
+++ b/src/lib/Checkbox/checkbox.variants.ts
@@ -1,0 +1,145 @@
+import { tv, type VariantProps } from 'tailwind-variants'
+
+export const checkboxVariants = tv({
+    slots: {
+        root: 'relative flex items-start',
+        base: [
+            'inline-flex items-center justify-center shrink-0 rounded-md border',
+            'focus-visible:outline-2 focus-visible:outline-offset-2',
+            'transition-colors duration-200',
+            'border-outline-variant',
+            'data-[state=unchecked]:bg-transparent'
+        ],
+        container: 'flex items-center',
+        indicator: 'flex items-center justify-center',
+        icon: 'shrink-0 text-white',
+        wrapper: 'ms-2',
+        label: 'block font-medium text-on-surface',
+        description: 'text-on-surface-variant'
+    },
+    variants: {
+        color: {
+            primary: '',
+            secondary: '',
+            tertiary: '',
+            success: '',
+            warning: '',
+            error: '',
+            info: '',
+            surface: ''
+        },
+        size: {
+            xs: {
+                base: 'size-3.5 rounded',
+                container: 'h-4',
+                icon: 'size-2.5',
+                wrapper: 'text-xs'
+            },
+            sm: {
+                base: 'size-4 rounded',
+                container: 'h-4',
+                icon: 'size-3',
+                wrapper: 'text-xs'
+            },
+            md: {
+                base: 'size-4.5 rounded-md',
+                container: 'h-5',
+                icon: 'size-3.5',
+                wrapper: 'text-sm'
+            },
+            lg: {
+                base: 'size-5 rounded-md',
+                container: 'h-5',
+                icon: 'size-4',
+                wrapper: 'text-sm'
+            },
+            xl: {
+                base: 'size-5.5 rounded-md',
+                container: 'h-6',
+                icon: 'size-4.5',
+                wrapper: 'text-base'
+            }
+        },
+        loading: {
+            true: {
+                icon: 'animate-spin'
+            }
+        },
+        required: {
+            true: {
+                label: "after:content-['*'] after:ms-0.5 after:text-error"
+            }
+        },
+        disabled: {
+            true: {
+                root: 'opacity-75',
+                base: 'cursor-not-allowed',
+                label: 'cursor-not-allowed',
+                description: 'cursor-not-allowed'
+            }
+        }
+    },
+    compoundVariants: [
+        // ========== COLOR (checked bg + border + focus ring) ==========
+        {
+            color: 'primary',
+            class: {
+                base: 'data-[state=checked]:bg-primary data-[state=checked]:border-primary data-[state=indeterminate]:bg-primary data-[state=indeterminate]:border-primary focus-visible:outline-primary'
+            }
+        },
+        {
+            color: 'secondary',
+            class: {
+                base: 'data-[state=checked]:bg-secondary data-[state=checked]:border-secondary data-[state=indeterminate]:bg-secondary data-[state=indeterminate]:border-secondary focus-visible:outline-secondary'
+            }
+        },
+        {
+            color: 'tertiary',
+            class: {
+                base: 'data-[state=checked]:bg-tertiary data-[state=checked]:border-tertiary data-[state=indeterminate]:bg-tertiary data-[state=indeterminate]:border-tertiary focus-visible:outline-tertiary'
+            }
+        },
+        {
+            color: 'success',
+            class: {
+                base: 'data-[state=checked]:bg-success data-[state=checked]:border-success data-[state=indeterminate]:bg-success data-[state=indeterminate]:border-success focus-visible:outline-success'
+            }
+        },
+        {
+            color: 'warning',
+            class: {
+                base: 'data-[state=checked]:bg-warning data-[state=checked]:border-warning data-[state=indeterminate]:bg-warning data-[state=indeterminate]:border-warning focus-visible:outline-warning'
+            }
+        },
+        {
+            color: 'error',
+            class: {
+                base: 'data-[state=checked]:bg-error data-[state=checked]:border-error data-[state=indeterminate]:bg-error data-[state=indeterminate]:border-error focus-visible:outline-error'
+            }
+        },
+        {
+            color: 'info',
+            class: {
+                base: 'data-[state=checked]:bg-info data-[state=checked]:border-info data-[state=indeterminate]:bg-info data-[state=indeterminate]:border-info focus-visible:outline-info'
+            }
+        },
+        {
+            color: 'surface',
+            class: {
+                base: 'data-[state=checked]:bg-on-surface data-[state=checked]:border-on-surface data-[state=indeterminate]:bg-on-surface data-[state=indeterminate]:border-on-surface focus-visible:outline-outline'
+            }
+        }
+    ],
+    defaultVariants: {
+        color: 'primary',
+        size: 'md'
+    }
+})
+
+export type CheckboxVariantProps = VariantProps<typeof checkboxVariants>
+export type CheckboxSlots = keyof ReturnType<typeof checkboxVariants>
+
+export const checkboxDefaults = {
+    defaultVariants: checkboxVariants.defaultVariants,
+    slots: {} as Partial<Record<CheckboxSlots, string>>
+}

--- a/src/lib/Checkbox/index.ts
+++ b/src/lib/Checkbox/index.ts
@@ -1,0 +1,2 @@
+export { default as Checkbox } from './Checkbox.svelte'
+export type { CheckboxProps } from './checkbox.types.js'

--- a/src/lib/Textarea/textarea.variants.ts
+++ b/src/lib/Textarea/textarea.variants.ts
@@ -55,17 +55,17 @@ export const textareaVariants = tv({
                 trailingIcon: 'size-5'
             },
             lg: {
-                base: 'px-4 py-2.5 text-sm rounded-md',
-                leading: 'ps-4 inset-y-2',
+                base: 'px-3 py-2.5 text-sm rounded-md',
+                leading: 'ps-3 inset-y-2',
                 leadingIcon: 'size-5',
-                trailing: 'pe-4 inset-y-2',
+                trailing: 'pe-3 inset-y-2',
                 trailingIcon: 'size-5'
             },
             xl: {
-                base: 'px-5 py-3 text-base rounded-lg',
-                leading: 'ps-5 inset-y-2',
+                base: 'px-3 py-3 text-base rounded-lg',
+                leading: 'ps-3 inset-y-2',
                 leadingIcon: 'size-6',
-                trailing: 'pe-5 inset-y-2',
+                trailing: 'pe-3 inset-y-2',
                 trailingIcon: 'size-6'
             }
         },

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -34,6 +34,7 @@ export * from './Input/index.js'
 export * from './Textarea/index.js'
 export * from './Select/index.js'
 export * from './Switch/index.js'
+export * from './Checkbox/index.js'
 
 // Configuration
 export { defineConfig } from './config.js'

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -44,7 +44,8 @@
         { href: '/input', label: 'Input', icon: 'lucide:text-cursor' },
         { href: '/textarea', label: 'Textarea', icon: 'lucide:text' },
         { href: '/select', label: 'Select', icon: 'lucide:chevrons-up-down' },
-        { href: '/switch', label: 'Switch', icon: 'lucide:toggle-left' }
+        { href: '/switch', label: 'Switch', icon: 'lucide:toggle-left' },
+        { href: '/checkbox', label: 'Checkbox', icon: 'lucide:square-check' }
     ]
 
     const docItems = [

--- a/src/routes/checkbox/+page.svelte
+++ b/src/routes/checkbox/+page.svelte
@@ -1,0 +1,231 @@
+<script lang="ts">
+    import { Checkbox, FormField } from '$lib/index.js'
+
+    const colors = [
+        'primary',
+        'secondary',
+        'tertiary',
+        'success',
+        'warning',
+        'error',
+        'info',
+        'surface'
+    ] as const
+    const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const
+
+    let bindChecked = $state(false)
+    let indeterminate = $state(true)
+</script>
+
+<div class="space-y-8">
+    <div class="space-y-2">
+        <h1 class="text-2xl font-bold">Checkbox</h1>
+        <p class="text-on-surface-variant">
+            A checkbox component for boolean and indeterminate states with customizable colors,
+            sizes, icons, and FormField integration.
+        </p>
+    </div>
+
+    <!-- Basic Usage -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Basic Usage</h2>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <Checkbox />
+            <Checkbox checked={true} />
+        </div>
+    </section>
+
+    <!-- Two-way Binding -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Two-way Binding</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1">bind:checked</code> for reactive
+            two-way data binding.
+        </p>
+        <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
+            <Checkbox bind:checked={bindChecked} label="Toggle me" />
+            <p class="text-sm text-on-surface-variant">
+                Checked: <span class="font-mono text-on-surface">{bindChecked}</span>
+            </p>
+        </div>
+    </section>
+
+    <!-- With Label & Description -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Label & Description</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1">label</code> and
+            <code class="rounded bg-surface-container-highest px-1">description</code> props to add text
+            next to the checkbox.
+        </p>
+        <div class="flex flex-col gap-4 rounded-lg bg-surface-container-high p-4">
+            <Checkbox label="Accept terms" />
+            <Checkbox
+                label="Marketing emails"
+                description="Receive emails about new products and features."
+            />
+            <Checkbox
+                label="Push notifications"
+                description="Get notified when someone mentions you."
+            />
+        </div>
+    </section>
+
+    <!-- Indeterminate -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Indeterminate</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1">bind:indeterminate</code> for
+            tri-state checkbox behavior, useful for "select all" patterns.
+        </p>
+        <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
+            <Checkbox bind:indeterminate label="Select all" />
+            <p class="text-sm text-on-surface-variant">
+                Indeterminate: <span class="font-mono text-on-surface">{indeterminate}</span>
+            </p>
+        </div>
+    </section>
+
+    <!-- Colors -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Colors</h2>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            {#each colors as color (color)}
+                <div class="flex flex-col items-center gap-2">
+                    <Checkbox {color} checked={true} label={color} />
+                </div>
+            {/each}
+        </div>
+    </section>
+
+    <!-- Sizes -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Sizes</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">size</code> prop to control
+            the dimensions.
+        </p>
+        <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
+            {#each sizes as size (size)}
+                <Checkbox {size} checked={true} label={size} />
+            {/each}
+        </div>
+    </section>
+
+    <!-- Custom Icons -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Icons</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1">icon</code> and
+            <code class="rounded bg-surface-container-highest px-1">indeterminateIcon</code> to customize
+            the icons.
+        </p>
+        <div class="flex flex-col gap-4 rounded-lg bg-surface-container-high p-4">
+            <Checkbox icon="lucide:heart" checked={true} label="Favorite" color="error" />
+            <Checkbox icon="lucide:star" checked={true} label="Starred" color="warning" />
+            <Checkbox icon="lucide:thumbs-up" checked={true} label="Liked" color="success" />
+        </div>
+    </section>
+
+    <!-- Loading -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Loading</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">loading</code> prop to show
+            a loading spinner.
+        </p>
+        <div class="flex flex-col gap-4 rounded-lg bg-surface-container-high p-4">
+            <Checkbox loading label="Syncing..." />
+            <Checkbox loading checked={true} label="Saving preferences..." color="success" />
+        </div>
+    </section>
+
+    <!-- Disabled -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Disabled</h2>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <Checkbox disabled label="Disabled (off)" />
+            <Checkbox disabled checked={true} label="Disabled (on)" />
+        </div>
+    </section>
+
+    <!-- Required -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Required</h2>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <Checkbox required label="Accept terms and conditions" />
+        </div>
+    </section>
+
+    <!-- FormField Integration -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">FormField Integration</h2>
+        <p class="text-sm text-on-surface-variant">
+            When used inside a <code class="rounded bg-surface-container-highest px-1"
+                >FormField</code
+            >, the Checkbox automatically inherits size and error state.
+        </p>
+        <div class="flex flex-col gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm">
+                <FormField label="Preferences" description="Choose your notification preferences.">
+                    <Checkbox label="Email notifications" />
+                </FormField>
+            </div>
+
+            <div class="w-full max-w-sm">
+                <FormField label="Agreement" error="You must accept the terms.">
+                    <Checkbox label="I accept the terms of service" />
+                </FormField>
+            </div>
+        </div>
+    </section>
+
+    <!-- Custom UI -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Custom UI</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">ui</code> prop to override
+            classes on specific slots.
+        </p>
+        <div class="flex flex-col gap-6 rounded-lg bg-surface-container-high p-4">
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">Custom label & description</p>
+                <Checkbox
+                    label="Bold primary label"
+                    description="Italic description text"
+                    checked={true}
+                    ui={{
+                        label: 'font-bold text-primary',
+                        description: 'italic text-tertiary'
+                    }}
+                />
+            </div>
+
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">
+                    Custom root layout & wrapper spacing
+                </p>
+                <Checkbox
+                    label="Wide spacing"
+                    description="More gap between checkbox and text."
+                    ui={{
+                        root: 'gap-1',
+                        wrapper: 'ms-4'
+                    }}
+                />
+            </div>
+
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">Rounded checkbox</p>
+                <Checkbox
+                    label="Fully rounded"
+                    checked={true}
+                    color="tertiary"
+                    ui={{
+                        base: 'rounded-full'
+                    }}
+                />
+            </div>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
Add a new Checkbox component built on bits-ui Checkbox primitive, following
the same architecture as Switch (variants + types + component + tests).

Component features:
- Tri-state support: checked, unchecked, and indeterminate with bind:checked
  and bind:indeterminate for two-way data binding
- 8 color schemes: primary, secondary, tertiary, success, warning, error,
  info, surface with compound variants for checked and indeterminate states
- 5 sizes: xs (3.5), sm (4), md (4.5), lg (5), xl (5.5) with matching
  icon sizes and wrapper text scaling
- Customizable icons: icon (checked), indeterminateIcon (minus), loadingIcon
  with defaults from app config (icons.check, icons.loading)
- Loading state: disables interaction and shows animated spinner icon
- Disabled state: reduces opacity, applies cursor-not-allowed across all slots
- Required state: appends asterisk to label via CSS pseudo-element
- Label and description with custom snippet slots (labelSlot, descriptionSlot)
- Full slot-level style overrides via ui prop: root, base, container,
  indicator, icon, wrapper, label, description
- Global config support via getComponentConfig('checkbox', checkboxDefaults)

FormField integration:
- Auto-inherits size from FormField/FieldGroup context
- Auto-switches color to 'error' when FormField has error state
- Resolves name and id from FormField context
- Sets aria-describedby linking to FormField error/description/help elements
- Sets aria-invalid when FormField has error

Accessibility (WAI-ARIA):
- role="checkbox" with aria-checked true/false/mixed
- aria-required for required checkboxes
- aria-describedby for FormField error/description association
- aria-invalid for error state
- Label associated via for attribute matching checkbox id
- Keyboard navigation handled by bits-ui (Space to toggle)

Files added:
- src/lib/Checkbox/checkbox.variants.ts - tailwind-variants definition with
  8 slots, 8 colors, 5 sizes, compound variants for color × state
- src/lib/Checkbox/checkbox.types.ts - TypeScript props interface picking
  from bits-ui CheckboxPrimitive.RootProps
- src/lib/Checkbox/Checkbox.svelte - Main component with FormField context,
  derived classes, and bits-ui Checkbox.Root integration
- src/lib/Checkbox/index.ts - Public exports (Checkbox, CheckboxProps)
- src/lib/Checkbox/Checkbox.svelte.spec.ts - 58 unit tests covering:
  rendering, checked state, indeterminate, disabled, loading, colors,
  sizes, label & description, custom class & ui, accessibility, combined props
- src/routes/checkbox/+page.svelte - Demo page with 12 interactive sections:
  basic usage, two-way binding, label & description, indeterminate, colors,
  sizes, custom icons, loading, disabled, required, FormField integration,
  custom UI overrides

Files modified:
- src/lib/index.ts - Export Checkbox component and types
- src/routes/+layout.svelte - Add Checkbox to sidebar navigation with
  lucide:square-check icon
