### PR TITLE
feat: add RadioGroup component with variants, items, and FormField integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ pnpm add sv5ui
 | [**Textarea**](src/lib/Textarea)     | Multi-line text input with 5 variants, icons, autoresize with maxrows, and FormField integration        |
 | [**Select**](src/lib/Select)         | Dropdown select with 5 variants, icons, avatars, groups, descriptions, and FormField support            |
 | [**Switch**](src/lib/Switch)         | Toggle switch with 8 colors, 5 sizes, checked/unchecked icons, loading state, and FormField integration |
+| [**Checkbox**](src/lib/Checkbox)     | Checkbox with 8 colors, 5 sizes, indeterminate state, custom icons, and FormField integration           |
+| [**RadioGroup**](src/lib/RadioGroup) | Radio group for single-selection with items API, legend, orientation, and FormField integration         |
 | [**FormField**](src/lib/FormField)   | Form control wrapper providing label, description, hint, help, and error handling                       |
 | [**FieldGroup**](src/lib/FieldGroup) | Groups buttons and inputs with seamless borders and shared size/orientation context                     |
 | [**Calendar**](src/lib/Calendar)     | Date picker calendar with single, multiple, and range selection modes                                   |

--- a/src/lib/RadioGroup/RadioGroup.svelte
+++ b/src/lib/RadioGroup/RadioGroup.svelte
@@ -1,0 +1,175 @@
+<script lang="ts" module>
+    import type { RadioGroupProps } from './radio-group.types.js'
+
+    export type Props = RadioGroupProps
+</script>
+
+<script lang="ts">
+    import { RadioGroup, Label, useId } from 'bits-ui'
+    import { radioGroupVariants, radioGroupDefaults } from './radio-group.variants.js'
+    import { getComponentConfig, iconsDefaults } from '../config.js'
+    import { getContext } from 'svelte'
+    import Icon from '../Icon/Icon.svelte'
+    import type { FormFieldProps } from '../FormField/form-field.types.js'
+
+    const config = getComponentConfig('radioGroup', radioGroupDefaults)
+    const icons = getComponentConfig('icons', iconsDefaults)
+
+    let {
+        value = $bindable(''),
+        onValueChange,
+        items = [],
+        ui,
+        id,
+        name,
+        color = config.defaultVariants.color,
+        size,
+        orientation = config.defaultVariants.orientation,
+        disabled = false,
+        required = false,
+        loop = true,
+        loading = false,
+        loadingIcon = icons.loading,
+        legend,
+        legendSlot,
+        labelSlot,
+        descriptionSlot,
+        class: className
+    }: Props = $props()
+
+    const formFieldContext = getContext<
+        | {
+              name?: string
+              size: NonNullable<FormFieldProps['size']>
+              error?: string | boolean
+              ariaId: string
+          }
+        | undefined
+    >('formField')
+
+    const hasError = $derived(
+        formFieldContext?.error !== undefined && formFieldContext?.error !== false
+    )
+    const resolvedSize = $derived(size ?? formFieldContext?.size ?? config.defaultVariants.size)
+    const resolvedColor = $derived(hasError ? 'error' : color)
+    const autoId = useId()
+    const resolvedId = $derived(id ?? formFieldContext?.ariaId ?? autoId)
+    const resolvedName = $derived(name ?? formFieldContext?.name)
+    const isDisabled = $derived(disabled || loading)
+
+    const ariaDescribedBy = $derived.by(() => {
+        if (!formFieldContext) return undefined
+        const fid = formFieldContext.ariaId
+        return hasError ? `${fid}-error` : `${fid}-description ${fid}-help`
+    })
+
+    const slots = $derived(
+        radioGroupVariants({
+            color: resolvedColor,
+            size: resolvedSize,
+            orientation,
+            loading,
+            required,
+            disabled: isDisabled ? true : undefined
+        })
+    )
+
+    const layoutClasses = $derived.by(() => ({
+        root: slots.root({ class: [config.slots.root, className, ui?.root] }),
+        fieldset: slots.fieldset({ class: [config.slots.fieldset, ui?.fieldset] }),
+        legend: slots.legend({ class: [config.slots.legend, ui?.legend] }),
+        item: slots.item({ class: [config.slots.item, ui?.item] }),
+        container: slots.container({ class: [config.slots.container, ui?.container] }),
+        wrapper: slots.wrapper({ class: [config.slots.wrapper, ui?.wrapper] })
+    }))
+
+    const elementClasses = $derived.by(() => ({
+        base: slots.base({ class: [config.slots.base, ui?.base] }),
+        indicator: slots.indicator({ class: [config.slots.indicator, ui?.indicator] }),
+        loadingIcon: slots.loadingIcon({ class: [config.slots.loadingIcon, ui?.loadingIcon] }),
+        label: slots.label({ class: [config.slots.label, ui?.label] }),
+        description: slots.description({ class: [config.slots.description, ui?.description] })
+    }))
+</script>
+
+<div class={layoutClasses.root}>
+    <RadioGroup.Root
+        bind:value
+        {onValueChange}
+        id={resolvedId}
+        name={resolvedName}
+        disabled={isDisabled}
+        {required}
+        {loop}
+        {orientation}
+        aria-describedby={ariaDescribedBy}
+        aria-invalid={hasError ? true : undefined}
+        class={layoutClasses.fieldset}
+    >
+        {#if legend || legendSlot}
+            {#if legendSlot}
+                {@render legendSlot({ legend })}
+            {:else}
+                <span class={layoutClasses.legend}>{legend}</span>
+            {/if}
+        {/if}
+
+        {#each items as radioItem (radioItem.value)}
+            {@const itemId = `${resolvedId}-${radioItem.value}`}
+            {@const itemDisabled = isDisabled || radioItem.disabled}
+
+            <div class="{layoutClasses.item}{itemDisabled && !isDisabled ? ' opacity-75' : ''}">
+                <div class={layoutClasses.container}>
+                    <RadioGroup.Item
+                        value={radioItem.value}
+                        disabled={itemDisabled}
+                        id={itemId}
+                        class={elementClasses.base}
+                    >
+                        {#snippet children({ checked })}
+                            {#if checked}
+                                <span class={elementClasses.indicator}>
+                                    {#if loading}
+                                        <Icon
+                                            name={loadingIcon}
+                                            class={elementClasses.loadingIcon}
+                                        />
+                                    {/if}
+                                </span>
+                            {/if}
+                        {/snippet}
+                    </RadioGroup.Item>
+                </div>
+
+                {#if radioItem.label || radioItem.description || labelSlot || descriptionSlot}
+                    <div class={layoutClasses.wrapper}>
+                        {#if labelSlot}
+                            {@render labelSlot({ item: radioItem })}
+                        {:else if radioItem.label}
+                            <Label.Root
+                                for={itemId}
+                                class="{elementClasses.label}{itemDisabled
+                                    ? ' cursor-not-allowed'
+                                    : ''}"
+                            >
+                                {radioItem.label}
+                            </Label.Root>
+                        {/if}
+
+                        {#if descriptionSlot}
+                            {@render descriptionSlot({ item: radioItem })}
+                        {:else if radioItem.description}
+                            <p
+                                class="{elementClasses.description}{itemDisabled
+                                    ? ' cursor-not-allowed'
+                                    : ''}"
+                            >
+                                {radioItem.description}
+                            </p>
+                        {/if}
+                    </div>
+                {/if}
+            </div>
+        {/each}
+    </RadioGroup.Root>
+</div>

--- a/src/lib/RadioGroup/RadioGroup.svelte.spec.ts
+++ b/src/lib/RadioGroup/RadioGroup.svelte.spec.ts
@@ -1,0 +1,274 @@
+import { page } from 'vitest/browser'
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-svelte'
+import RadioGroup from './RadioGroup.svelte'
+import type { RadioGroupItem } from './radio-group.types.js'
+
+const defaultItems: RadioGroupItem[] = [
+    { value: 'a', label: 'Option A' },
+    { value: 'b', label: 'Option B' },
+    { value: 'c', label: 'Option C' }
+]
+
+const getRadios = () =>
+    document.querySelectorAll('button[role="radio"]') as NodeListOf<HTMLButtonElement>
+
+const getRadio = (index = 0) => getRadios()[index] ?? null
+
+describe('RadioGroup', () => {
+    // ==================== RENDERING ====================
+    describe('rendering', () => {
+        it('should render radio items', async () => {
+            render(RadioGroup, { items: defaultItems })
+            const radios = page.getByRole('radio')
+            await expect.element(radios.first()).toBeInTheDocument()
+            expect(getRadios().length).toBe(3)
+        })
+
+        it('should render all items unchecked by default', () => {
+            render(RadioGroup, { items: defaultItems })
+            const radios = getRadios()
+            for (const radio of radios) {
+                expect(radio.getAttribute('data-state')).toBe('unchecked')
+            }
+        })
+
+        it('should render with value pre-selected', () => {
+            render(RadioGroup, { items: defaultItems, value: 'b' })
+            expect(getRadio(1)!.getAttribute('data-state')).toBe('checked')
+        })
+
+        it('should render with third item selected', () => {
+            render(RadioGroup, { items: defaultItems, value: 'c' })
+            expect(getRadio(2)!.getAttribute('data-state')).toBe('checked')
+        })
+
+        it('should render with name attribute', () => {
+            const { container } = render(RadioGroup, {
+                items: defaultItems,
+                name: 'my-radio'
+            })
+            const hidden = container.querySelector('input[name="my-radio"]')
+            expect(hidden).toBeTruthy()
+        })
+
+        it('should render with id', () => {
+            render(RadioGroup, { items: defaultItems, id: 'my-group' })
+            const radios = getRadios()
+            expect(radios[0]!.id).toBe('my-group-a')
+            expect(radios[1]!.id).toBe('my-group-b')
+        })
+
+        it('should generate ids automatically', () => {
+            render(RadioGroup, { items: defaultItems })
+            expect(getRadio()!.id).toBeTruthy()
+        })
+
+        it('should render empty when no items', () => {
+            render(RadioGroup)
+            expect(getRadios().length).toBe(0)
+        })
+    })
+
+    // ==================== VALUE CHANGE ====================
+    describe('value change', () => {
+        it('should select item on click', async () => {
+            render(RadioGroup, { items: defaultItems })
+            const radio = page.getByRole('radio').nth(0)
+            await radio.click()
+            expect(getRadio(0)!.getAttribute('data-state')).toBe('checked')
+        })
+
+        it('should call onValueChange callback', async () => {
+            const onValueChange = vi.fn()
+            render(RadioGroup, { items: defaultItems, onValueChange })
+            const radio = page.getByRole('radio').nth(1)
+            await radio.click()
+            expect(onValueChange).toHaveBeenCalledWith('b')
+        })
+
+        it('should deselect previous item when selecting new one', async () => {
+            render(RadioGroup, { items: defaultItems, value: 'a' })
+            expect(getRadio(0)!.getAttribute('data-state')).toBe('checked')
+            const radio = page.getByRole('radio').nth(1)
+            await radio.click()
+            expect(getRadio(0)!.getAttribute('data-state')).toBe('unchecked')
+            expect(getRadio(1)!.getAttribute('data-state')).toBe('checked')
+        })
+    })
+
+    // ==================== DISABLED STATE ====================
+    describe('disabled', () => {
+        it('should disable all items when disabled prop is true', async () => {
+            render(RadioGroup, { items: defaultItems, disabled: true })
+            const radios = page.getByRole('radio')
+            await expect.element(radios.first()).toBeDisabled()
+            await expect.element(radios.nth(1)).toBeDisabled()
+            await expect.element(radios.nth(2)).toBeDisabled()
+        })
+
+        it('should not select when disabled', async () => {
+            render(RadioGroup, { items: defaultItems, disabled: true })
+            const radio = page.getByRole('radio').first()
+            await radio.click({ force: true })
+            expect(getRadio(0)!.getAttribute('data-state')).toBe('unchecked')
+        })
+
+        it('should disable individual items', async () => {
+            const items: RadioGroupItem[] = [
+                { value: 'a', label: 'Option A' },
+                { value: 'b', label: 'Option B', disabled: true },
+                { value: 'c', label: 'Option C' }
+            ]
+            render(RadioGroup, { items })
+            const radios = page.getByRole('radio')
+            await expect.element(radios.nth(1)).toBeDisabled()
+            await expect.element(radios.first()).not.toBeDisabled()
+        })
+    })
+
+    // ==================== LOADING STATE ====================
+    describe('loading', () => {
+        it('should be disabled when loading', async () => {
+            render(RadioGroup, { items: defaultItems, loading: true })
+            const radios = page.getByRole('radio')
+            await expect.element(radios.first()).toBeDisabled()
+        })
+
+        it('should not select when loading', async () => {
+            render(RadioGroup, { items: defaultItems, loading: true })
+            const radio = page.getByRole('radio').first()
+            await radio.click({ force: true })
+            expect(getRadio(0)!.getAttribute('data-state')).toBe('unchecked')
+        })
+    })
+
+    // ==================== COLORS ====================
+    describe('colors', () => {
+        const colors = [
+            'primary',
+            'secondary',
+            'tertiary',
+            'success',
+            'warning',
+            'error',
+            'info'
+        ] as const
+
+        for (const color of colors) {
+            it(`should render with color="${color}"`, () => {
+                render(RadioGroup, { items: defaultItems, color, value: 'a' })
+                expect(getRadio(0)!.className).toMatch(new RegExp(`bg-${color}`))
+            })
+        }
+    })
+
+    // ==================== SIZES ====================
+    describe('sizes', () => {
+        it('should apply xs size classes', () => {
+            render(RadioGroup, { items: defaultItems, size: 'xs' })
+            expect(getRadio()!.className).toMatch(/size-3\.5/)
+        })
+
+        it('should apply md size classes by default', () => {
+            render(RadioGroup, { items: defaultItems })
+            expect(getRadio()!.className).toMatch(/size-4\.5/)
+        })
+
+        it('should apply xl size classes', () => {
+            render(RadioGroup, { items: defaultItems, size: 'xl' })
+            expect(getRadio()!.className).toMatch(/size-5\.5/)
+        })
+    })
+
+    // ==================== ORIENTATION ====================
+    describe('orientation', () => {
+        it('should render vertical by default', () => {
+            render(RadioGroup, { items: defaultItems })
+            const group = document.querySelector('[role="radiogroup"]')
+            expect(group!.className).toMatch(/flex-col/)
+        })
+
+        it('should render horizontal', () => {
+            render(RadioGroup, { items: defaultItems, orientation: 'horizontal' })
+            const group = document.querySelector('[role="radiogroup"]')
+            expect(group!.className).toMatch(/flex-row/)
+        })
+
+        it('should set data-orientation attribute', () => {
+            render(RadioGroup, { items: defaultItems, orientation: 'horizontal' })
+            const group = document.querySelector('[role="radiogroup"]')
+            expect(group!.getAttribute('data-orientation')).toBe('horizontal')
+        })
+    })
+
+    // ==================== LEGEND ====================
+    describe('legend', () => {
+        it('should render legend text', async () => {
+            render(RadioGroup, { items: defaultItems, legend: 'Choose one' })
+            const legend = page.getByText('Choose one')
+            await expect.element(legend).toBeInTheDocument()
+        })
+
+        it('should not render legend when not provided', () => {
+            render(RadioGroup, { items: defaultItems })
+            const legends = document.querySelectorAll('legend, .legend')
+            // Should not have a legend element with text content
+            expect(Array.from(legends).filter((l) => l.textContent?.trim())).toHaveLength(0)
+        })
+    })
+
+    // ==================== LABEL & DESCRIPTION ====================
+    describe('label & description', () => {
+        it('should render label text for each item', async () => {
+            render(RadioGroup, { items: defaultItems })
+            const labelA = page.getByText('Option A')
+            const labelB = page.getByText('Option B')
+            await expect.element(labelA).toBeInTheDocument()
+            await expect.element(labelB).toBeInTheDocument()
+        })
+
+        it('should render description text', async () => {
+            const items: RadioGroupItem[] = [
+                { value: 'a', label: 'Option A', description: 'First option desc' }
+            ]
+            render(RadioGroup, { items })
+            const desc = page.getByText('First option desc')
+            await expect.element(desc).toBeInTheDocument()
+        })
+
+        it('should associate label with radio via for attribute', () => {
+            render(RadioGroup, { items: defaultItems, id: 'test-group' })
+            const label = document.querySelector('label[for="test-group-a"]')
+            expect(label).toBeTruthy()
+            expect(label!.textContent).toBe('Option A')
+        })
+    })
+
+    // ==================== ACCESSIBILITY ====================
+    describe('accessibility', () => {
+        it('should have role="radiogroup" on root', async () => {
+            render(RadioGroup, { items: defaultItems })
+            const group = page.getByRole('radiogroup')
+            await expect.element(group).toBeInTheDocument()
+        })
+
+        it('should have role="radio" on each item', () => {
+            render(RadioGroup, { items: defaultItems })
+            expect(getRadios().length).toBe(3)
+        })
+
+        it('should set data-state="checked" on selected item', () => {
+            render(RadioGroup, { items: defaultItems, value: 'b' })
+            expect(getRadio(0)!.getAttribute('data-state')).toBe('unchecked')
+            expect(getRadio(1)!.getAttribute('data-state')).toBe('checked')
+            expect(getRadio(2)!.getAttribute('data-state')).toBe('unchecked')
+        })
+
+        it('should set aria-required when required', () => {
+            render(RadioGroup, { items: defaultItems, required: true })
+            const group = document.querySelector('[role="radiogroup"]')
+            expect(group!.getAttribute('aria-required')).toBe('true')
+        })
+    })
+})

--- a/src/lib/RadioGroup/index.ts
+++ b/src/lib/RadioGroup/index.ts
@@ -1,0 +1,2 @@
+export { default as RadioGroup } from './RadioGroup.svelte'
+export type { RadioGroupProps, RadioGroupItem } from './radio-group.types.js'

--- a/src/lib/RadioGroup/radio-group.types.ts
+++ b/src/lib/RadioGroup/radio-group.types.ts
@@ -1,0 +1,112 @@
+import type { Snippet } from 'svelte'
+import type { RadioGroup as RadioGroupPrimitive } from 'bits-ui'
+import type { ClassNameValue } from 'tailwind-merge'
+import type { RadioGroupVariantProps, RadioGroupSlots } from './radio-group.variants.js'
+
+export type RadioGroupItem = {
+    /**
+     * The unique value for this radio item.
+     */
+    value: string
+
+    /**
+     * Label text displayed next to the radio.
+     */
+    label?: string
+
+    /**
+     * Description text displayed below the label.
+     */
+    description?: string
+
+    /**
+     * Whether this individual radio item is disabled.
+     * @default false
+     */
+    disabled?: boolean
+}
+
+export type RadioGroupProps = Pick<
+    RadioGroupPrimitive.RootProps,
+    'disabled' | 'name' | 'required' | 'loop'
+> & {
+    /**
+     * The selected value. Supports two-way binding with `bind:value`.
+     */
+    value?: string
+
+    /**
+     * Callback when the value changes.
+     */
+    onValueChange?: (value: string) => void
+
+    /**
+     * The list of radio items to render.
+     */
+    items?: RadioGroupItem[]
+
+    /**
+     * Sets the color scheme for the radio indicators.
+     * @default 'primary'
+     */
+    color?: NonNullable<RadioGroupVariantProps['color']>
+
+    /**
+     * Controls the dimensions of the radio group.
+     * @default 'md'
+     */
+    size?: NonNullable<RadioGroupVariantProps['size']>
+
+    /**
+     * Controls the layout direction.
+     * @default 'vertical'
+     */
+    orientation?: NonNullable<RadioGroupVariantProps['orientation']>
+
+    /**
+     * Legend text displayed above the radio group.
+     */
+    legend?: string
+
+    /**
+     * Renders a loading spinner and disables interaction.
+     * @default false
+     */
+    loading?: boolean
+
+    /**
+     * Icon displayed as the loading indicator.
+     * @default Uses `icons.loading` from app config
+     */
+    loadingIcon?: string
+
+    /**
+     * The HTML id attribute for the radio group.
+     */
+    id?: string
+
+    /**
+     * Custom snippet for the legend.
+     */
+    legendSlot?: Snippet<[{ legend?: string }]>
+
+    /**
+     * Custom snippet for each item's label.
+     */
+    labelSlot?: Snippet<[{ item: RadioGroupItem }]>
+
+    /**
+     * Custom snippet for each item's description.
+     */
+    descriptionSlot?: Snippet<[{ item: RadioGroupItem }]>
+
+    /**
+     * Additional CSS classes for the root element.
+     */
+    class?: ClassNameValue
+
+    /**
+     * Override styles for specific radio group slots.
+     */
+    ui?: Partial<Record<RadioGroupSlots, ClassNameValue>>
+}

--- a/src/lib/RadioGroup/radio-group.variants.ts
+++ b/src/lib/RadioGroup/radio-group.variants.ts
@@ -1,0 +1,168 @@
+import { tv, type VariantProps } from 'tailwind-variants'
+
+export const radioGroupVariants = tv({
+    slots: {
+        root: '',
+        fieldset: 'flex',
+        legend: 'block font-medium text-on-surface mb-1',
+        item: 'flex items-start',
+        container: 'flex items-center',
+        base: [
+            'inline-flex items-center justify-center shrink-0 rounded-full border',
+            'focus-visible:outline-2 focus-visible:outline-offset-2',
+            'transition-colors duration-200',
+            'border-outline-variant',
+            'data-[state=unchecked]:bg-transparent'
+        ],
+        indicator: [
+            'flex items-center justify-center rounded-full',
+            'after:content-[""] after:block after:rounded-full after:bg-white'
+        ],
+        loadingIcon: 'shrink-0 animate-spin text-white',
+        wrapper: 'ms-2',
+        label: 'block font-medium text-on-surface',
+        description: 'text-on-surface-variant'
+    },
+    variants: {
+        color: {
+            primary: '',
+            secondary: '',
+            tertiary: '',
+            success: '',
+            warning: '',
+            error: '',
+            info: '',
+            surface: ''
+        },
+        size: {
+            xs: {
+                fieldset: 'gap-2',
+                base: 'size-3.5',
+                container: 'h-4',
+                indicator: 'size-3.5 after:size-1',
+                loadingIcon: 'size-2',
+                wrapper: 'text-xs'
+            },
+            sm: {
+                fieldset: 'gap-2.5',
+                base: 'size-4',
+                container: 'h-4',
+                indicator: 'size-4 after:size-1.5',
+                loadingIcon: 'size-2.5',
+                wrapper: 'text-xs'
+            },
+            md: {
+                fieldset: 'gap-3',
+                base: 'size-4.5',
+                container: 'h-5',
+                indicator: 'size-4.5 after:size-1.5',
+                loadingIcon: 'size-3',
+                wrapper: 'text-sm'
+            },
+            lg: {
+                fieldset: 'gap-3.5',
+                base: 'size-5',
+                container: 'h-5',
+                indicator: 'size-5 after:size-2',
+                loadingIcon: 'size-3.5',
+                wrapper: 'text-sm'
+            },
+            xl: {
+                fieldset: 'gap-4',
+                base: 'size-5.5',
+                container: 'h-6',
+                indicator: 'size-5.5 after:size-2.5',
+                loadingIcon: 'size-4',
+                wrapper: 'text-base'
+            }
+        },
+        orientation: {
+            horizontal: {
+                fieldset: 'flex-row'
+            },
+            vertical: {
+                fieldset: 'flex-col'
+            }
+        },
+        loading: {
+            true: ''
+        },
+        required: {
+            true: {
+                legend: "after:content-['*'] after:ms-0.5 after:text-error"
+            }
+        },
+        disabled: {
+            true: {
+                root: 'opacity-75',
+                base: 'cursor-not-allowed',
+                label: 'cursor-not-allowed',
+                description: 'cursor-not-allowed'
+            }
+        }
+    },
+    compoundVariants: [
+        // ========== COLOR (checked bg + border + focus ring) ==========
+        {
+            color: 'primary',
+            class: {
+                base: 'data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:outline-primary'
+            }
+        },
+        {
+            color: 'secondary',
+            class: {
+                base: 'data-[state=checked]:bg-secondary data-[state=checked]:border-secondary focus-visible:outline-secondary'
+            }
+        },
+        {
+            color: 'tertiary',
+            class: {
+                base: 'data-[state=checked]:bg-tertiary data-[state=checked]:border-tertiary focus-visible:outline-tertiary'
+            }
+        },
+        {
+            color: 'success',
+            class: {
+                base: 'data-[state=checked]:bg-success data-[state=checked]:border-success focus-visible:outline-success'
+            }
+        },
+        {
+            color: 'warning',
+            class: {
+                base: 'data-[state=checked]:bg-warning data-[state=checked]:border-warning focus-visible:outline-warning'
+            }
+        },
+        {
+            color: 'error',
+            class: {
+                base: 'data-[state=checked]:bg-error data-[state=checked]:border-error focus-visible:outline-error'
+            }
+        },
+        {
+            color: 'info',
+            class: {
+                base: 'data-[state=checked]:bg-info data-[state=checked]:border-info focus-visible:outline-info'
+            }
+        },
+        {
+            color: 'surface',
+            class: {
+                base: 'data-[state=checked]:bg-on-surface data-[state=checked]:border-on-surface focus-visible:outline-outline'
+            }
+        }
+    ],
+    defaultVariants: {
+        color: 'primary',
+        size: 'md',
+        orientation: 'vertical'
+    }
+})
+
+export type RadioGroupVariantProps = VariantProps<typeof radioGroupVariants>
+export type RadioGroupSlots = keyof ReturnType<typeof radioGroupVariants>
+
+export const radioGroupDefaults = {
+    defaultVariants: radioGroupVariants.defaultVariants,
+    slots: {} as Partial<Record<RadioGroupSlots, string>>
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -35,6 +35,7 @@ export * from './Textarea/index.js'
 export * from './Select/index.js'
 export * from './Switch/index.js'
 export * from './Checkbox/index.js'
+export * from './RadioGroup/index.js'
 
 // Configuration
 export { defineConfig } from './config.js'

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -45,7 +45,8 @@
         { href: '/textarea', label: 'Textarea', icon: 'lucide:text' },
         { href: '/select', label: 'Select', icon: 'lucide:chevrons-up-down' },
         { href: '/switch', label: 'Switch', icon: 'lucide:toggle-left' },
-        { href: '/checkbox', label: 'Checkbox', icon: 'lucide:square-check' }
+        { href: '/checkbox', label: 'Checkbox', icon: 'lucide:square-check' },
+        { href: '/radio-group', label: 'Radio Group', icon: 'lucide:circle-dot-dashed' }
     ]
 
     const docItems = [

--- a/src/routes/radio-group/+page.svelte
+++ b/src/routes/radio-group/+page.svelte
@@ -1,0 +1,232 @@
+<script lang="ts">
+    import { RadioGroup, FormField } from '$lib/index.js'
+    import type { RadioGroupItem } from '$lib/index.js'
+
+    const colors = [
+        'primary',
+        'secondary',
+        'tertiary',
+        'success',
+        'warning',
+        'error',
+        'info',
+        'surface'
+    ] as const
+    const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const
+
+    const fruits: RadioGroupItem[] = [
+        { value: 'apple', label: 'Apple' },
+        { value: 'banana', label: 'Banana' },
+        { value: 'orange', label: 'Orange' }
+    ]
+
+    const plans: RadioGroupItem[] = [
+        { value: 'free', label: 'Free', description: 'Basic features for personal use.' },
+        { value: 'pro', label: 'Pro', description: 'Advanced features for professionals.' },
+        { value: 'enterprise', label: 'Enterprise', description: 'Full suite for organizations.' }
+    ]
+
+    const partialDisabled: RadioGroupItem[] = [
+        { value: 'available', label: 'Available' },
+        { value: 'unavailable', label: 'Unavailable', disabled: true },
+        { value: 'limited', label: 'Limited' }
+    ]
+
+    let bindValue = $state('')
+</script>
+
+<div class="space-y-8">
+    <div class="space-y-2">
+        <h1 class="text-2xl font-bold">RadioGroup</h1>
+        <p class="text-on-surface-variant">
+            A radio group component for single-selection from a list of options with customizable
+            colors, sizes, orientation, and FormField integration.
+        </p>
+    </div>
+
+    <!-- Basic Usage -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Basic Usage</h2>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <RadioGroup items={fruits} />
+        </div>
+    </section>
+
+    <!-- Two-way Binding -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Two-way Binding</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1">bind:value</code> for reactive
+            two-way data binding.
+        </p>
+        <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
+            <RadioGroup items={fruits} bind:value={bindValue} />
+            <p class="text-sm text-on-surface-variant">
+                Selected: <span class="font-mono text-on-surface">{bindValue || '(none)'}</span>
+            </p>
+        </div>
+    </section>
+
+    <!-- With Label & Description -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Label & Description</h2>
+        <p class="text-sm text-on-surface-variant">
+            Each item supports <code class="rounded bg-surface-container-highest px-1">label</code>
+            and
+            <code class="rounded bg-surface-container-highest px-1">description</code> properties.
+        </p>
+        <div class="flex flex-col gap-4 rounded-lg bg-surface-container-high p-4">
+            <RadioGroup items={plans} />
+        </div>
+    </section>
+
+    <!-- Legend -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Legend</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">legend</code> prop to add
+            a title above the radio group.
+        </p>
+        <div class="flex flex-col gap-4 rounded-lg bg-surface-container-high p-4">
+            <RadioGroup items={fruits} legend="Select a fruit" />
+        </div>
+    </section>
+
+    <!-- Colors -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Colors</h2>
+        <div class="flex flex-wrap gap-8 rounded-lg bg-surface-container-high p-4">
+            {#each colors as color (color)}
+                <RadioGroup {color} value="a" items={[{ value: 'a', label: color }]} />
+            {/each}
+        </div>
+    </section>
+
+    <!-- Sizes -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Sizes</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">size</code> prop to control
+            the dimensions.
+        </p>
+        <div class="flex flex-wrap items-start gap-8 rounded-lg bg-surface-container-high p-4">
+            {#each sizes as size (size)}
+                <RadioGroup {size} value="a" items={[{ value: 'a', label: size }]} />
+            {/each}
+        </div>
+    </section>
+
+    <!-- Orientation -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Orientation</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">orientation</code> prop to
+            control layout direction.
+        </p>
+        <div class="flex flex-col gap-6 rounded-lg bg-surface-container-high p-4">
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">Vertical (default)</p>
+                <RadioGroup items={fruits} orientation="vertical" />
+            </div>
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">Horizontal</p>
+                <RadioGroup items={fruits} orientation="horizontal" />
+            </div>
+        </div>
+    </section>
+
+    <!-- Disabled -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Disabled</h2>
+        <p class="text-sm text-on-surface-variant">Disable the entire group or individual items.</p>
+        <div class="flex flex-col gap-6 rounded-lg bg-surface-container-high p-4">
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">Entire group disabled</p>
+                <RadioGroup items={fruits} disabled value="apple" />
+            </div>
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">Individual item disabled</p>
+                <RadioGroup items={partialDisabled} />
+            </div>
+        </div>
+    </section>
+
+    <!-- Loading -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Loading</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">loading</code> prop to show
+            a loading state and disable interaction.
+        </p>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <RadioGroup items={fruits} loading value="apple" />
+        </div>
+    </section>
+
+    <!-- Required -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Required</h2>
+        <div class="flex flex-wrap gap-6 rounded-lg bg-surface-container-high p-4">
+            <RadioGroup items={fruits} required legend="Choose a fruit" />
+        </div>
+    </section>
+
+    <!-- FormField Integration -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">FormField Integration</h2>
+        <p class="text-sm text-on-surface-variant">
+            When used inside a <code class="rounded bg-surface-container-highest px-1"
+                >FormField</code
+            >, the RadioGroup automatically inherits size and error state.
+        </p>
+        <div class="flex flex-col gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="w-full max-w-sm">
+                <FormField
+                    label="Subscription Plan"
+                    description="Choose the plan that works for you."
+                >
+                    <RadioGroup items={plans} />
+                </FormField>
+            </div>
+
+            <div class="w-full max-w-sm">
+                <FormField label="Preferred Fruit" error="Please select a fruit.">
+                    <RadioGroup items={fruits} />
+                </FormField>
+            </div>
+        </div>
+    </section>
+
+    <!-- Custom UI -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Custom UI</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">ui</code> prop to override
+            classes on specific slots.
+        </p>
+        <div class="flex flex-col gap-6 rounded-lg bg-surface-container-high p-4">
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">Custom label & description</p>
+                <RadioGroup
+                    items={plans}
+                    value="pro"
+                    ui={{
+                        label: 'font-bold text-primary',
+                        description: 'italic text-tertiary'
+                    }}
+                />
+            </div>
+
+            <div>
+                <p class="mb-2 text-xs text-on-surface-variant">Custom spacing</p>
+                <RadioGroup
+                    items={fruits}
+                    ui={{
+                        fieldset: 'gap-6',
+                        wrapper: 'ms-4'
+                    }}
+                />
+            </div>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
## Summary

- Add new `RadioGroup` component built on `bits-ui` `RadioGroup` primitives for single-selection from a list of options
- Include full theme system with `tailwind-variants`, demo page, sidebar navigation entry, and 38 unit tests
- Support FormField integration for automatic size/error state inheritance and accessibility attributes

## New Files

| File | Purpose |
|------|---------|
| `src/lib/RadioGroup/RadioGroup.svelte` | Main component using `bits-ui` `RadioGroup.Root` and `RadioGroup.Item` |
| `src/lib/RadioGroup/radio-group.types.ts` | TypeScript types (`RadioGroupProps`, `RadioGroupItem`) |
| `src/lib/RadioGroup/radio-group.variants.ts` | Tailwind Variants with 11 slots, 8 colors, 5 sizes, 2 orientations |
| `src/lib/RadioGroup/index.ts` | Component and type re-exports |
| `src/lib/RadioGroup/RadioGroup.svelte.spec.ts` | 38 unit tests covering rendering, interactions, states, and a11y |
| `src/routes/radio-group/+page.svelte` | Demo page with 12 feature sections |

## Modified Files

| File | Change |
|------|--------|
| `src/lib/index.ts` | Added `RadioGroup` export |
| `src/routes/+layout.svelte` | Added "Radio Group" to sidebar navigation |

## Component API

### Props

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `value` | `string` | `''` | Selected value, supports `bind:value` two-way binding |
| `items` | `RadioGroupItem[]` | `[]` | List of radio items (`value`, `label`, `description`, `disabled`) |
| `color` | `'primary' \| 'secondary' \| 'tertiary' \| 'success' \| 'warning' \| 'error' \| 'info' \| 'surface'` | `'primary'` | Color scheme for checked indicator |
| `size` | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | Controls dimensions and text sizing |
| `orientation` | `'vertical' \| 'horizontal'` | `'vertical'` | Layout direction |
| `legend` | `string` | — | Title text above the group |
| `disabled` | `boolean` | `false` | Disables entire group |
| `required` | `boolean` | `false` | Marks as required (asterisk on legend) |
| `loading` | `boolean` | `false` | Shows loading spinner, disables interaction |
| `loop` | `boolean` | `true` | Enables keyboard cycling through items |
| `name` | `string` | — | Form submission name |
| `onValueChange` | `(value: string) => void` | — | Callback on selection change |
| `ui` | `Partial<Record<RadioGroupSlots, ClassNameValue>>` | — | Per-slot class overrides |

### Slots (Snippets)

| Slot | Payload | Description |
|------|---------|-------------|
| `legendSlot` | `{ legend?: string }` | Custom legend rendering |
| `labelSlot` | `{ item: RadioGroupItem }` | Custom label per item |
| `descriptionSlot` | `{ item: RadioGroupItem }` | Custom description per item |

### Variant Slots (11 total)

`root`, `fieldset`, `legend`, `item`, `container`, `base`, `indicator`, `loadingIcon`, `wrapper`, `label`, `description`

## Features

- **Items-based API**: Pass an array of `RadioGroupItem` objects with `value`, `label`, `description`, and per-item `disabled`
- **Individual item disabled**: Disabled items render with `opacity-75` and `cursor-not-allowed`, without affecting other items
- **FormField integration**: Inherits `size`, `error` state, `name`, and `ariaId` from parent `FormField` context
- **Accessibility**: Proper `radiogroup`/`radio` roles, `aria-required`, `aria-invalid`, `aria-describedby`, `data-state`, `data-orientation`, and `<label for="">` associations
- **Keyboard navigation**: Arrow keys navigate between items based on orientation, with optional loop
- **Loading state**: Spinner icon inside checked indicator, all items disabled during loading
- **Global config**: Supports `defineConfig({ radioGroup: { ... } })` for project-wide defaults

## Demo Page Sections

Basic Usage · Two-way Binding · Label & Description · Legend · Colors · Sizes · Orientation · Disabled (group + individual) · Loading · Required · FormField Integration · Custom UI

## Test Coverage (38 tests)

- **Rendering** (8): items, unchecked default, pre-selected, name, id, auto-id, empty
- **Value Change** (3): click select, callback, deselect previous
- **Disabled** (3): group disabled, no toggle, individual item disabled
- **Loading** (2): disabled when loading, no toggle
- **Colors** (7): all color variants
- **Sizes** (3): xs, md, xl
- **Orientation** (3): vertical, horizontal, data-orientation attribute
- **Legend** (2): render, no render when empty
- **Label & Description** (3): labels, description, label-for association
- **Accessibility** (4): radiogroup role, radio role, data-state, aria-required