### PR TITLE
feat: add ThemeModeButton component

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,13 @@ pnpm add sv5ui
 
 ### General
 
-| Component                    | Description                                                                |
-| :--------------------------- | :------------------------------------------------------------------------- |
-| [**Button**](src/lib/Button) | Versatile button with 6 variants, loading state, icons, and avatar support |
-| [**Link**](src/lib/Link)     | Smart anchor with automatic active-state detection based on current route  |
-| [**Icon**](src/lib/Icon)     | Iconify wrapper — render any of 200,000+ icons by name                     |
-| [**Kbd**](src/lib/Kbd)       | Keyboard shortcut display with OS-aware symbol mapping                     |
+| Component                                      | Description                                                                        |
+| :--------------------------------------------- | :--------------------------------------------------------------------------------- |
+| [**Button**](src/lib/Button)                   | Versatile button with 6 variants, loading state, icons, and avatar support         |
+| [**Link**](src/lib/Link)                       | Smart anchor with automatic active-state detection based on current route          |
+| [**Icon**](src/lib/Icon)                       | Iconify wrapper — render any of 200,000+ icons by name                             |
+| [**Kbd**](src/lib/Kbd)                         | Keyboard shortcut display with OS-aware symbol mapping                             |
+| [**ThemeModeButton**](src/lib/ThemeModeButton) | Light/dark mode toggle button with customizable icons and mode-watcher integration |
 
 ### Layout
 

--- a/src/lib/ThemeModeButton/ThemeModeButton.svelte
+++ b/src/lib/ThemeModeButton/ThemeModeButton.svelte
@@ -1,0 +1,73 @@
+<script lang="ts" module>
+    import type { ThemeModeButtonProps } from './theme-mode-button.types.js'
+
+    export type Props = ThemeModeButtonProps
+</script>
+
+<script lang="ts">
+    import { toggleMode, mode } from 'mode-watcher'
+    import {
+        themeModeButtonVariants,
+        themeModeButtonDefaults
+    } from './theme-mode-button.variants.js'
+    import { getComponentConfig, iconsDefaults } from '../config.js'
+    import Button from '../Button/Button.svelte'
+
+    const config = getComponentConfig('themeModeButton', themeModeButtonDefaults)
+    const icons = getComponentConfig('icons', iconsDefaults)
+
+    let {
+        ui,
+        color = config.defaultVariants.color ?? 'surface',
+        variant = config.defaultVariants.variant ?? 'ghost',
+        size,
+        lightIcon = icons.light,
+        darkIcon = icons.dark,
+        loading = false,
+        disabled = false,
+        square = true,
+        block = false,
+        children,
+        class: className,
+        ...restProps
+    }: Props = $props()
+
+    const isDark = $derived(mode.current === 'dark')
+
+    const slots = $derived(themeModeButtonVariants())
+
+    const iconName = $derived(isDark ? lightIcon : darkIcon)
+</script>
+
+{#if children}
+    <Button
+        {color}
+        {variant}
+        {size}
+        {loading}
+        {disabled}
+        {square}
+        {block}
+        class={slots.base({ class: [config.slots.base, className, ui?.base] })}
+        aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+        onclick={toggleMode}
+        {...restProps}
+    >
+        {@render children({ isDark })}
+    </Button>
+{:else}
+    <Button
+        {color}
+        {variant}
+        {size}
+        {loading}
+        {disabled}
+        {square}
+        {block}
+        icon={iconName}
+        class={slots.base({ class: [config.slots.base, className, ui?.base] })}
+        aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+        onclick={toggleMode}
+        {...restProps}
+    />
+{/if}

--- a/src/lib/ThemeModeButton/ThemeModeButton.svelte.spec.ts
+++ b/src/lib/ThemeModeButton/ThemeModeButton.svelte.spec.ts
@@ -1,0 +1,265 @@
+import { page } from 'vitest/browser'
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-svelte'
+import ThemeModeButton from './ThemeModeButton.svelte'
+
+describe('ThemeModeButton', () => {
+    // ==================== RENDERING ====================
+
+    describe('rendering', () => {
+        it('should render a button element', async () => {
+            render(ThemeModeButton)
+            const btn = page.getByRole('button')
+            await expect.element(btn).toBeInTheDocument()
+        })
+
+        it('should render with aria-label for switching mode', async () => {
+            render(ThemeModeButton)
+            const btn = page.getByRole('button')
+            const ariaLabel = btn.element().getAttribute('aria-label')
+            expect(ariaLabel).toMatch(/Switch to (light|dark) mode/)
+        })
+
+        it('should render an icon inside the button', async () => {
+            render(ThemeModeButton)
+            const btn = page.getByRole('button')
+            await expect.element(btn).toBeInTheDocument()
+            await vi.waitFor(() => {
+                const svg = document.querySelector('button svg')
+                expect(svg).not.toBeNull()
+            })
+        })
+    })
+
+    // ==================== DEFAULT PROPS ====================
+
+    describe('default props', () => {
+        it('should apply ghost variant by default', async () => {
+            render(ThemeModeButton)
+            const btn = page.getByRole('button')
+            await expect.element(btn).toHaveClass(/text-on-surface-variant/)
+        })
+
+        it('should be square by default', async () => {
+            render(ThemeModeButton)
+            const btn = page.getByRole('button')
+            await expect.element(btn).not.toHaveTextContent(/\w+/)
+        })
+    })
+
+    // ==================== VARIANTS ====================
+
+    describe('variants', () => {
+        const variants = ['solid', 'outline', 'soft', 'subtle', 'ghost', 'link'] as const
+
+        for (const variant of variants) {
+            it(`should render with variant="${variant}"`, async () => {
+                render(ThemeModeButton, { variant })
+                const btn = page.getByRole('button')
+                await expect.element(btn).toBeInTheDocument()
+            })
+        }
+
+        it('should apply solid variant classes', async () => {
+            render(ThemeModeButton, { variant: 'solid', color: 'primary' })
+            const btn = page.getByRole('button')
+            await expect.element(btn).toHaveClass(/bg-primary/)
+        })
+
+        it('should apply outline variant classes', async () => {
+            render(ThemeModeButton, { variant: 'outline', color: 'primary' })
+            const btn = page.getByRole('button')
+            await expect.element(btn).toHaveClass(/ring-primary/)
+        })
+
+        it('should apply ghost variant classes', async () => {
+            render(ThemeModeButton, { variant: 'ghost', color: 'primary' })
+            const btn = page.getByRole('button')
+            await expect.element(btn).toHaveClass(/text-primary/)
+        })
+    })
+
+    // ==================== COLORS ====================
+
+    describe('colors', () => {
+        const colors = [
+            'primary',
+            'secondary',
+            'tertiary',
+            'success',
+            'warning',
+            'error',
+            'info'
+        ] as const
+
+        for (const color of colors) {
+            it(`should render with color="${color}"`, async () => {
+                render(ThemeModeButton, { variant: 'solid', color })
+                const btn = page.getByRole('button')
+                await expect.element(btn).toHaveClass(new RegExp(`bg-${color}`))
+            })
+        }
+
+        it('should apply surface color with ghost variant', async () => {
+            render(ThemeModeButton, { variant: 'ghost', color: 'surface' })
+            const btn = page.getByRole('button')
+            await expect.element(btn).toHaveClass(/text-on-surface-variant/)
+        })
+    })
+
+    // ==================== SIZES ====================
+
+    describe('sizes', () => {
+        it('should apply xs size classes', async () => {
+            render(ThemeModeButton, { size: 'xs' })
+            const btn = page.getByRole('button')
+            await expect.element(btn).toHaveClass(/text-xs/)
+        })
+
+        it('should apply sm size classes', async () => {
+            render(ThemeModeButton, { size: 'sm' })
+            const btn = page.getByRole('button')
+            await expect.element(btn).toHaveClass(/text-xs/)
+        })
+
+        it('should apply md size classes by default', async () => {
+            render(ThemeModeButton)
+            const btn = page.getByRole('button')
+            await expect.element(btn).toHaveClass(/text-sm/)
+        })
+
+        it('should apply lg size classes', async () => {
+            render(ThemeModeButton, { size: 'lg' })
+            const btn = page.getByRole('button')
+            await expect.element(btn).toHaveClass(/text-sm/)
+        })
+
+        it('should apply xl size classes', async () => {
+            render(ThemeModeButton, { size: 'xl' })
+            const btn = page.getByRole('button')
+            await expect.element(btn).toHaveClass(/text-base/)
+        })
+    })
+
+    // ==================== DISABLED STATE ====================
+
+    describe('disabled', () => {
+        it('should be disabled when disabled prop is true', async () => {
+            render(ThemeModeButton, { disabled: true })
+            const btn = page.getByRole('button')
+            await expect.element(btn).toBeDisabled()
+        })
+
+        it('should not be disabled by default', async () => {
+            render(ThemeModeButton)
+            const btn = page.getByRole('button')
+            await expect.element(btn).toBeEnabled()
+        })
+
+        it('should not fire click when disabled', async () => {
+            const onclick = vi.fn()
+            render(ThemeModeButton, { disabled: true, onclick })
+            const btn = page.getByRole('button')
+            await btn.click({ force: true })
+            expect(onclick).not.toHaveBeenCalled()
+        })
+    })
+
+    // ==================== LOADING STATE ====================
+
+    describe('loading', () => {
+        it('should be disabled when loading', async () => {
+            render(ThemeModeButton, { loading: true })
+            const btn = page.getByRole('button')
+            await expect.element(btn).toBeDisabled()
+        })
+
+        it('should not fire click when loading', async () => {
+            const onclick = vi.fn()
+            render(ThemeModeButton, { loading: true, onclick })
+            const btn = page.getByRole('button')
+            await btn.click({ force: true })
+            expect(onclick).not.toHaveBeenCalled()
+        })
+    })
+
+    // ==================== BLOCK ====================
+
+    describe('block', () => {
+        it('should apply full width when block is true', async () => {
+            render(ThemeModeButton, { block: true, square: false })
+            const btn = page.getByRole('button')
+            await expect.element(btn).toHaveClass(/w-full/)
+        })
+
+        it('should not apply full width by default', async () => {
+            render(ThemeModeButton)
+            const btn = page.getByRole('button')
+            await expect.element(btn).not.toHaveClass(/w-full/)
+        })
+    })
+
+    // ==================== EVENTS ====================
+
+    describe('events', () => {
+        it('should handle click events', async () => {
+            const onclick = vi.fn()
+            render(ThemeModeButton, { onclick })
+            const btn = page.getByRole('button')
+            await btn.click()
+            expect(onclick).toHaveBeenCalledOnce()
+        })
+    })
+
+    // ==================== CUSTOM CLASS & UI ====================
+
+    describe('custom class & ui', () => {
+        it('should apply custom class', async () => {
+            render(ThemeModeButton, { class: 'my-custom-class' })
+            const btn = page.getByRole('button')
+            await expect.element(btn).toHaveClass(/my-custom-class/)
+        })
+
+        it('should apply rounded-full class', async () => {
+            render(ThemeModeButton, { class: 'rounded-full' })
+            const btn = page.getByRole('button')
+            await expect.element(btn).toHaveClass(/rounded-full/)
+        })
+    })
+
+    // ==================== COMBINED PROPS ====================
+
+    describe('combined props', () => {
+        it('should render with multiple props combined', async () => {
+            render(ThemeModeButton, {
+                variant: 'outline',
+                color: 'error',
+                size: 'lg'
+            })
+            const btn = page.getByRole('button')
+            await expect.element(btn).toBeInTheDocument()
+            await expect.element(btn).toHaveClass(/ring-error/)
+        })
+
+        it('should render disabled with custom variant and color', async () => {
+            render(ThemeModeButton, {
+                variant: 'solid',
+                color: 'primary',
+                disabled: true
+            })
+            const btn = page.getByRole('button')
+            await expect.element(btn).toBeDisabled()
+            await expect.element(btn).toHaveClass(/bg-primary/)
+        })
+
+        it('should render with size and custom class', async () => {
+            render(ThemeModeButton, {
+                size: 'xl',
+                class: 'shadow-lg'
+            })
+            const btn = page.getByRole('button')
+            await expect.element(btn).toHaveClass(/text-base/)
+            await expect.element(btn).toHaveClass(/shadow-lg/)
+        })
+    })
+})

--- a/src/lib/ThemeModeButton/index.ts
+++ b/src/lib/ThemeModeButton/index.ts
@@ -1,0 +1,2 @@
+export { default as ThemeModeButton } from './ThemeModeButton.svelte'
+export type { ThemeModeButtonProps } from './theme-mode-button.types.js'

--- a/src/lib/ThemeModeButton/theme-mode-button.types.ts
+++ b/src/lib/ThemeModeButton/theme-mode-button.types.ts
@@ -1,0 +1,73 @@
+import type { Snippet } from 'svelte'
+import type { HTMLButtonAttributes } from 'svelte/elements'
+import type { ClassNameValue } from 'tailwind-merge'
+import type { ButtonVariantProps } from '../Button/button.variants.js'
+import type { ThemeModeButtonSlots } from './theme-mode-button.variants.js'
+
+export type ThemeModeButtonProps = Omit<HTMLButtonAttributes, 'children'> & {
+    /**
+     * Controls the visual style of the button.
+     * @default 'ghost'
+     */
+    variant?: NonNullable<ButtonVariantProps['variant']>
+
+    /**
+     * Sets the color scheme applied to the button.
+     * @default 'surface'
+     */
+    color?: NonNullable<ButtonVariantProps['color']>
+
+    /**
+     * Controls the dimensions and text size of the button.
+     * @default 'md'
+     */
+    size?: NonNullable<ButtonVariantProps['size']>
+
+    /**
+     * Icon displayed when light mode is active.
+     * Supports any valid Iconify icon name.
+     * @default 'lucide:sun'
+     */
+    lightIcon?: string
+
+    /**
+     * Icon displayed when dark mode is active.
+     * Supports any valid Iconify icon name.
+     * @default 'lucide:moon'
+     */
+    darkIcon?: string
+
+    /**
+     * Renders a loading spinner and disables interaction.
+     * @default false
+     */
+    loading?: boolean
+
+    /**
+     * Forces equal width and height, ideal for icon-only buttons.
+     * @default true
+     */
+    square?: boolean
+
+    /**
+     * Stretches the button to fill the full width of its container.
+     * @default false
+     */
+    block?: boolean
+
+    /**
+     * Custom content rendered inside the button.
+     * When provided, replaces the default icon rendering.
+     */
+    children?: Snippet<[{ isDark: boolean }]>
+
+    /**
+     * Additional CSS classes for the root element.
+     */
+    class?: ClassNameValue
+
+    /**
+     * Override styles for specific slots.
+     */
+    ui?: Partial<Record<ThemeModeButtonSlots, ClassNameValue>>
+}

--- a/src/lib/ThemeModeButton/theme-mode-button.variants.ts
+++ b/src/lib/ThemeModeButton/theme-mode-button.variants.ts
@@ -1,0 +1,23 @@
+import { tv, type VariantProps } from 'tailwind-variants'
+import type { ButtonVariantProps } from '../Button/button.variants.js'
+
+export const themeModeButtonVariants = tv({
+    slots: {
+        base: '',
+        icon: 'shrink-0'
+    },
+    variants: {},
+    defaultVariants: {}
+})
+
+export type ThemeModeButtonVariantProps = VariantProps<typeof themeModeButtonVariants>
+export type ThemeModeButtonSlots = keyof ReturnType<typeof themeModeButtonVariants>
+
+export const themeModeButtonDefaults = {
+    defaultVariants: {
+        ...themeModeButtonVariants.defaultVariants,
+        color: 'surface' as NonNullable<ButtonVariantProps['color']>,
+        variant: 'ghost' as NonNullable<ButtonVariantProps['variant']>
+    },
+    slots: {} as Partial<Record<ThemeModeButtonSlots, string>>
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -29,7 +29,9 @@ export const iconsDefaults = {
     chevronDown: 'lucide:chevron-down',
     chevronRight: 'lucide:chevron-right',
     close: 'lucide:x',
-    check: 'lucide:check'
+    check: 'lucide:check',
+    light: 'lucide:sun',
+    dark: 'lucide:moon'
 }
 
 // ==================== TYPES ====================

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -36,6 +36,7 @@ export * from './Select/index.js'
 export * from './Switch/index.js'
 export * from './Checkbox/index.js'
 export * from './RadioGroup/index.js'
+export * from './ThemeModeButton/index.js'
 
 // Configuration
 export { defineConfig } from './config.js'

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -46,7 +46,8 @@
         { href: '/select', label: 'Select', icon: 'lucide:chevrons-up-down' },
         { href: '/switch', label: 'Switch', icon: 'lucide:toggle-left' },
         { href: '/checkbox', label: 'Checkbox', icon: 'lucide:square-check' },
-        { href: '/radio-group', label: 'Radio Group', icon: 'lucide:circle-dot-dashed' }
+        { href: '/radio-group', label: 'Radio Group', icon: 'lucide:circle-dot-dashed' },
+        { href: '/theme-mode-button', label: 'Theme Toggle', icon: 'lucide:sun-moon' }
     ]
 
     const docItems = [

--- a/src/routes/theme-mode-button/+page.svelte
+++ b/src/routes/theme-mode-button/+page.svelte
@@ -1,0 +1,197 @@
+<script lang="ts">
+    import { ThemeModeButton } from '$lib/index.js'
+    import { mode } from 'mode-watcher'
+
+    const variants = ['solid', 'outline', 'soft', 'subtle', 'ghost', 'link'] as const
+    const colors = [
+        'primary',
+        'secondary',
+        'tertiary',
+        'success',
+        'warning',
+        'error',
+        'info',
+        'surface'
+    ] as const
+    const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const
+</script>
+
+<div class="space-y-8">
+    <div class="space-y-2">
+        <h1 class="text-2xl font-bold">ThemeModeButton</h1>
+        <p class="text-on-surface-variant">
+            A button to switch between light and dark mode. Built on top of the Button component and
+            mode-watcher.
+        </p>
+    </div>
+
+    <!-- Basic Usage -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Basic Usage</h2>
+        <div class="flex flex-wrap items-center gap-4 rounded-lg bg-surface-container-high p-4">
+            <ThemeModeButton />
+            <span class="text-sm text-on-surface-variant capitalize">
+                Current mode: {mode.current}
+            </span>
+        </div>
+    </section>
+
+    <!-- Variants -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Variants</h2>
+        <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
+            {#each variants as variant (variant)}
+                <div class="flex flex-col items-center gap-2">
+                    <ThemeModeButton {variant} color="primary" />
+                    <span class="text-xs text-on-surface-variant capitalize">{variant}</span>
+                </div>
+            {/each}
+        </div>
+    </section>
+
+    <!-- Colors -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Colors</h2>
+        <div class="overflow-x-auto">
+            <table class="w-full">
+                <thead>
+                    <tr class="border-b border-outline-variant">
+                        <th class="px-2 py-3 text-left text-sm font-medium text-on-surface-variant"
+                            >Variant</th
+                        >
+                        {#each colors as color (color)}
+                            <th
+                                class="px-2 py-3 text-center text-sm font-medium text-on-surface-variant capitalize"
+                                >{color}</th
+                            >
+                        {/each}
+                    </tr>
+                </thead>
+                <tbody>
+                    {#each variants as variant (variant)}
+                        <tr class="border-b border-outline-variant/50">
+                            <td
+                                class="px-2 py-3 text-sm font-medium text-on-surface-variant capitalize"
+                                >{variant}</td
+                            >
+                            {#each colors as color (color)}
+                                <td class="px-2 py-3 text-center">
+                                    <ThemeModeButton {variant} {color} />
+                                </td>
+                            {/each}
+                        </tr>
+                    {/each}
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <!-- Sizes -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Sizes</h2>
+        <div class="flex flex-wrap items-end gap-3 rounded-lg bg-surface-container-high p-4">
+            {#each sizes as size (size)}
+                <div class="flex flex-col items-center gap-2">
+                    <ThemeModeButton {size} />
+                    <span class="text-xs text-on-surface-variant">{size}</span>
+                </div>
+            {/each}
+        </div>
+    </section>
+
+    <!-- Custom Icons -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Custom Icons</h2>
+        <p class="text-sm text-on-surface-variant">
+            Override the default light/dark icons using the
+            <code class="rounded bg-surface-container-highest px-1">lightIcon</code> and
+            <code class="rounded bg-surface-container-highest px-1">darkIcon</code> props.
+        </p>
+        <div class="flex flex-wrap items-center gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="flex flex-col items-center gap-2">
+                <ThemeModeButton lightIcon="lucide:sun-medium" darkIcon="lucide:moon-star" />
+                <span class="text-xs text-on-surface-variant">sun-medium / moon-star</span>
+            </div>
+            <div class="flex flex-col items-center gap-2">
+                <ThemeModeButton lightIcon="lucide:sun-dim" darkIcon="lucide:cloud-moon" />
+                <span class="text-xs text-on-surface-variant">sun-dim / cloud-moon</span>
+            </div>
+            <div class="flex flex-col items-center gap-2">
+                <ThemeModeButton lightIcon="lucide:sunrise" darkIcon="lucide:sunset" />
+                <span class="text-xs text-on-surface-variant">sunrise / sunset</span>
+            </div>
+        </div>
+    </section>
+
+    <!-- Non-square (with label via children) -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Custom Content (Children Snippet)</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">children</code> snippet
+            with
+            <code class="rounded bg-surface-container-highest px-1">{'{ isDark }'}</code> to render custom
+            content.
+        </p>
+        <div class="flex flex-wrap items-center gap-4 rounded-lg bg-surface-container-high p-4">
+            <ThemeModeButton square={false} variant="outline" color="secondary">
+                {#snippet children({ isDark })}
+                    {isDark ? 'Light Mode' : 'Dark Mode'}
+                {/snippet}
+            </ThemeModeButton>
+
+            <ThemeModeButton square={false} variant="soft" color="primary">
+                {#snippet children({ isDark })}
+                    <span class="flex items-center gap-2">
+                        {#if isDark}
+                            ☀️ Switch to Light
+                        {:else}
+                            🌙 Switch to Dark
+                        {/if}
+                    </span>
+                {/snippet}
+            </ThemeModeButton>
+        </div>
+    </section>
+
+    <!-- Disabled & Loading -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Disabled & Loading</h2>
+        <div class="flex flex-wrap items-center gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="flex flex-col items-center gap-2">
+                <ThemeModeButton disabled />
+                <span class="text-xs text-on-surface-variant">Disabled</span>
+            </div>
+            <div class="flex flex-col items-center gap-2">
+                <ThemeModeButton loading />
+                <span class="text-xs text-on-surface-variant">Loading</span>
+            </div>
+        </div>
+    </section>
+
+    <!-- UI Overrides -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">UI Prop (Class Overrides)</h2>
+        <div class="flex flex-wrap items-center gap-4 rounded-lg bg-surface-container-high p-4">
+            <div class="flex flex-col items-center gap-2">
+                <ThemeModeButton class="rounded-full" variant="outline" color="primary" />
+                <span class="text-xs text-on-surface-variant">Pill shape</span>
+            </div>
+            <div class="flex flex-col items-center gap-2">
+                <ThemeModeButton
+                    variant="solid"
+                    color="tertiary"
+                    class="shadow-lg shadow-tertiary/30"
+                />
+                <span class="text-xs text-on-surface-variant">With shadow</span>
+            </div>
+            <div class="flex flex-col items-center gap-2">
+                <ThemeModeButton
+                    variant="solid"
+                    color="primary"
+                    class="bg-linear-to-r from-primary to-tertiary hover:from-primary/90 hover:to-tertiary/90"
+                />
+                <span class="text-xs text-on-surface-variant">Gradient</span>
+            </div>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
## Summary
- Add `ThemeModeButton` component that toggles between light and dark mode using `mode-watcher`, built on top of the existing `Button` component
- Support all Button variants (`solid`, `outline`, `soft`, `subtle`, `ghost`, `link`), colors, and sizes with `ghost`/`surface` as defaults
- Add customizable `lightIcon`/`darkIcon` props and global icon config (`icons.light`, `icons.dark`) in `config.ts`
- Add `children` snippet with `{ isDark }` context for fully custom content rendering
- Add demo page at `/theme-mode-button` with examples for variants, colors, sizes, custom icons, custom content, disabled/loading, and UI overrides
- Add 40 browser-based test cases covering rendering, variants, colors, sizes, states, events, and combined props

## Test plan
- [x] `svelte-check` passes with 0 errors
- [x] 40/40 tests pass (`npx vitest run --project client src/lib/ThemeModeButton/`)
- [ ] Verify light/dark mode toggle works in browser
- [ ] Verify demo page renders correctly at `/theme-mode-button`
- [ ] Verify sidebar navigation link appears
