### PR TITLE
Fix/mode watcher peer dependency

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Publish to npm
+
+on:
+    push:
+        tags:
+            - 'v*.*.*'
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            id-token: write
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: pnpm/action-setup@v4
+              with:
+                  version: latest
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: pnpm
+                  registry-url: 'https://registry.npmjs.org'
+
+            - run: pnpm install --frozen-lockfile
+
+            - name: Build package
+              run: pnpm exec svelte-kit sync && pnpm exec svelte-package
+
+            - name: Publish to npm
+              run: npm publish --access public
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sv5ui",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "A modern Svelte 5 UI component library with Tailwind CSS",
     "author": "ndlabdev",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sv5ui",
-    "version": "0.0.1",
+    "version": "1.0.0",
     "description": "A modern Svelte 5 UI component library with Tailwind CSS",
     "author": "ndlabdev",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sv5ui",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "A modern Svelte 5 UI component library with Tailwind CSS",
     "author": "ndlabdev",
     "license": "MIT",
@@ -48,6 +48,7 @@
         }
     },
     "peerDependencies": {
+        "mode-watcher": "^1.0.0",
         "svelte": "^5.0.0",
         "tailwindcss": "^4.0.0"
     },
@@ -65,7 +66,6 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-svelte": "^3.13.1",
         "globals": "^16.5.0",
-        "mode-watcher": "^1.1.0",
         "playwright": "^1.57.0",
         "prettier": "^3.7.4",
         "prettier-plugin-svelte": "^3.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       bits-ui:
         specifier: ^2.15.4
         version: 2.15.4(@internationalized/date@3.11.0)(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.2)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.48.2)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.48.2)
+      mode-watcher:
+        specifier: ^1.0.0
+        version: 1.1.0(svelte@5.48.2)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -66,9 +69,6 @@ importers:
       globals:
         specifier: ^16.5.0
         version: 16.5.0
-      mode-watcher:
-        specifier: ^1.1.0
-        version: 1.1.0(svelte@5.48.2)
       playwright:
         specifier: ^1.57.0
         version: 1.58.0


### PR DESCRIPTION
## Summary
- Move `mode-watcher` from `devDependencies` to `peerDependencies` to fix missing dependency error when users install `sv5ui`
- Add GitHub Actions workflow to auto-publish to npm when a git tag (`v*.*.*`) is pushed
- Bump version to 1.1.1

## Why
Users installing `sv5ui` via `pnpm i sv5ui` encountered an error because `mode-watcher` was only listed in `devDependencies`. Since `ThemeModeButton` component imports `mode-watcher` at runtime, it must be declared as a `peerDependency`.

## Changes
- **package.json**: Move `mode-watcher` from `devDependencies` → `peerDependencies`
- **.github/workflows/publish.yml**: New workflow that automatically builds and publishes to npm when a version tag is pushed

## Test plan
- [x] Verify `pnpm i sv5ui` no longer throws `mode-watcher` error
- [x] Verify publish workflow triggers correctly on tag push
