### PR TITLE
feat: export VERSION constant from package

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -41,3 +41,7 @@ export * from './ThemeModeButton/index.js'
 // Configuration
 export { defineConfig } from './config.js'
 export type { UIConfig } from './config.js'
+
+// Version
+declare const __SV5UI_VERSION__: string
+export const VERSION = __SV5UI_VERSION__

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,9 +2,16 @@ import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'vitest/config'
 import { playwright } from '@vitest/browser-playwright'
 import { sveltekit } from '@sveltejs/kit/vite'
+import { readFileSync } from 'node:fs'
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
 export default defineConfig({
     plugins: [tailwindcss(), sveltekit()],
+
+    define: {
+        __SV5UI_VERSION__: JSON.stringify(pkg.version)
+    },
 
     test: {
         expect: { requireAssertions: true },


### PR DESCRIPTION
## Summary
- Export `VERSION` constant that dynamically reads from `package.json` at build time via Vite `define`
- No need to manually update version in multiple places

## Changes
- **vite.config.ts**: Add `define` with `__SV5UI_VERSION__` injected from `package.json`
- **src/lib/index.ts**: Export `VERSION` constant

## Usage
```ts
import { VERSION } from 'sv5ui';
