### PR TITLE
fix: embed TooltipProvider inside Tooltip component

### DIFF
--- a/src/lib/Tooltip/Tooltip.svelte
+++ b/src/lib/Tooltip/Tooltip.svelte
@@ -118,30 +118,32 @@
     </Tooltip.Content>
 {/snippet}
 
-<Tooltip.Root
-    bind:open
-    {onOpenChange}
-    {delayDuration}
-    {disableHoverableContent}
-    {disableCloseOnTriggerClick}
-    {ignoreNonKeyboardFocus}
-    disabled={disabled || !hasContent}
->
-    {#if children}
-        <Tooltip.Trigger>
-            {#snippet child({ props })}
-                <span {...props} class={className as string}>
-                    {@render children({ open })}
-                </span>
-            {/snippet}
-        </Tooltip.Trigger>
-    {/if}
+<Tooltip.Provider {delayDuration} {disableHoverableContent}>
+    <Tooltip.Root
+        bind:open
+        {onOpenChange}
+        {delayDuration}
+        {disableHoverableContent}
+        {disableCloseOnTriggerClick}
+        {ignoreNonKeyboardFocus}
+        disabled={disabled || !hasContent}
+    >
+        {#if children}
+            <Tooltip.Trigger>
+                {#snippet child({ props })}
+                    <span {...props} class={className as string}>
+                        {@render children({ open })}
+                    </span>
+                {/snippet}
+            </Tooltip.Trigger>
+        {/if}
 
-    {#if portal}
-        <Tooltip.Portal>
+        {#if portal}
+            <Tooltip.Portal>
+                {@render tooltipContentEl()}
+            </Tooltip.Portal>
+        {:else}
             {@render tooltipContentEl()}
-        </Tooltip.Portal>
-    {:else}
-        {@render tooltipContentEl()}
-    {/if}
-</Tooltip.Root>
+        {/if}
+    </Tooltip.Root>
+</Tooltip.Provider>

--- a/src/lib/Tooltip/TooltipTestWrapper.svelte
+++ b/src/lib/Tooltip/TooltipTestWrapper.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
-    import { Tooltip as BitsTooltip } from 'bits-ui'
     import Tooltip from './Tooltip.svelte'
     import type { TooltipProps } from './tooltip.types.js'
 
     let props: TooltipProps = $props()
 </script>
 
-<BitsTooltip.Provider delayDuration={0}>
-    <Tooltip {...props} />
-</BitsTooltip.Provider>
+<Tooltip {...props} />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -61,106 +61,106 @@
 <ModeWatcher />
 
 <div class="min-h-screen bg-surface text-on-surface">
-        <!-- Header -->
-        <header
-            class="sticky top-0 z-50 border-b border-outline-variant bg-surface-container px-4 py-3 lg:px-6"
-        >
-            <div class="flex items-center justify-between">
-                <div class="flex items-center gap-3">
-                    <button
-                        class="rounded-md p-1.5 text-on-surface-variant hover:bg-surface-container-high lg:hidden"
-                        onclick={() => (sidebarOpen = !sidebarOpen)}
-                    >
-                        <Icon name="lucide:menu" size="20" />
-                    </button>
-                    <Link href="/" raw class="text-xl font-bold text-primary">SV5UI</Link>
-                    <span class="hidden text-sm text-on-surface-variant sm:inline"
-                        >Svelte 5 UI Components</span
-                    >
-                </div>
-                <div class="flex items-center gap-3">
-                    <span class="hidden text-sm text-on-surface-variant capitalize sm:inline">
-                        {mode.current}
-                    </span>
-                    <Button
-                        variant="ghost"
-                        color="secondary"
-                        icon={mode.current === 'dark' ? 'lucide:sun' : 'lucide:moon'}
-                        onclick={toggleMode}
-                        square
-                        size="sm"
-                    />
-                </div>
-            </div>
-        </header>
-
-        <div class="flex">
-            <!-- Sidebar Overlay (mobile) -->
-            {#if sidebarOpen}
+    <!-- Header -->
+    <header
+        class="sticky top-0 z-50 border-b border-outline-variant bg-surface-container px-4 py-3 lg:px-6"
+    >
+        <div class="flex items-center justify-between">
+            <div class="flex items-center gap-3">
                 <button
-                    class="fixed inset-0 z-30 bg-black/50 lg:hidden"
-                    onclick={() => (sidebarOpen = false)}
-                    aria-label="Close sidebar"
-                ></button>
-            {/if}
-
-            <!-- Sidebar -->
-            <aside
-                class="fixed top-14.25 left-0 z-40 h-[calc(100vh-57px)] w-64 shrink-0 overflow-y-auto border-r border-outline-variant bg-surface-container transition-transform duration-200 lg:sticky lg:translate-x-0 {sidebarOpen
-                    ? 'translate-x-0'
-                    : '-translate-x-full'}"
-            >
-                <nav class="p-4">
-                    <p
-                        class="mb-2 px-3 text-xs font-semibold tracking-wider text-on-surface-variant uppercase"
-                    >
-                        Components
-                    </p>
-                    <div class="flex flex-col gap-0.5">
-                        {#each navItems as item (item.href)}
-                            <Link
-                                href={item.href}
-                                raw
-                                exact={item.exact}
-                                activeClass="bg-primary-container text-on-primary-container font-medium"
-                                inactiveClass="text-on-surface-variant hover:bg-surface-container-highest"
-                                class="flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors"
-                                onclick={() => (sidebarOpen = false)}
-                            >
-                                <Icon name={item.icon} size="18" />
-                                {item.label}
-                            </Link>
-                        {/each}
-                    </div>
-
-                    <p
-                        class="mt-6 mb-2 px-3 text-xs font-semibold tracking-wider text-on-surface-variant uppercase"
-                    >
-                        Guides
-                    </p>
-                    <div class="flex flex-col gap-0.5">
-                        {#each docItems as item (item.href)}
-                            <Link
-                                href={item.href}
-                                raw
-                                activeClass="bg-primary-container text-on-primary-container font-medium"
-                                inactiveClass="text-on-surface-variant hover:bg-surface-container-highest"
-                                class="flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors"
-                                onclick={() => (sidebarOpen = false)}
-                            >
-                                <Icon name={item.icon} size="18" />
-                                {item.label}
-                            </Link>
-                        {/each}
-                    </div>
-                </nav>
-            </aside>
-
-            <!-- Main Content -->
-            <main class="min-h-[calc(100vh-57px)] flex-1 p-6 lg:p-8">
-                <div class="mx-auto max-w-5xl">
-                    {@render children()}
-                </div>
-            </main>
+                    class="rounded-md p-1.5 text-on-surface-variant hover:bg-surface-container-high lg:hidden"
+                    onclick={() => (sidebarOpen = !sidebarOpen)}
+                >
+                    <Icon name="lucide:menu" size="20" />
+                </button>
+                <Link href="/" raw class="text-xl font-bold text-primary">SV5UI</Link>
+                <span class="hidden text-sm text-on-surface-variant sm:inline"
+                    >Svelte 5 UI Components</span
+                >
+            </div>
+            <div class="flex items-center gap-3">
+                <span class="hidden text-sm text-on-surface-variant capitalize sm:inline">
+                    {mode.current}
+                </span>
+                <Button
+                    variant="ghost"
+                    color="secondary"
+                    icon={mode.current === 'dark' ? 'lucide:sun' : 'lucide:moon'}
+                    onclick={toggleMode}
+                    square
+                    size="sm"
+                />
+            </div>
         </div>
+    </header>
+
+    <div class="flex">
+        <!-- Sidebar Overlay (mobile) -->
+        {#if sidebarOpen}
+            <button
+                class="fixed inset-0 z-30 bg-black/50 lg:hidden"
+                onclick={() => (sidebarOpen = false)}
+                aria-label="Close sidebar"
+            ></button>
+        {/if}
+
+        <!-- Sidebar -->
+        <aside
+            class="fixed top-14.25 left-0 z-40 h-[calc(100vh-57px)] w-64 shrink-0 overflow-y-auto border-r border-outline-variant bg-surface-container transition-transform duration-200 lg:sticky lg:translate-x-0 {sidebarOpen
+                ? 'translate-x-0'
+                : '-translate-x-full'}"
+        >
+            <nav class="p-4">
+                <p
+                    class="mb-2 px-3 text-xs font-semibold tracking-wider text-on-surface-variant uppercase"
+                >
+                    Components
+                </p>
+                <div class="flex flex-col gap-0.5">
+                    {#each navItems as item (item.href)}
+                        <Link
+                            href={item.href}
+                            raw
+                            exact={item.exact}
+                            activeClass="bg-primary-container text-on-primary-container font-medium"
+                            inactiveClass="text-on-surface-variant hover:bg-surface-container-highest"
+                            class="flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors"
+                            onclick={() => (sidebarOpen = false)}
+                        >
+                            <Icon name={item.icon} size="18" />
+                            {item.label}
+                        </Link>
+                    {/each}
+                </div>
+
+                <p
+                    class="mt-6 mb-2 px-3 text-xs font-semibold tracking-wider text-on-surface-variant uppercase"
+                >
+                    Guides
+                </p>
+                <div class="flex flex-col gap-0.5">
+                    {#each docItems as item (item.href)}
+                        <Link
+                            href={item.href}
+                            raw
+                            activeClass="bg-primary-container text-on-primary-container font-medium"
+                            inactiveClass="text-on-surface-variant hover:bg-surface-container-highest"
+                            class="flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors"
+                            onclick={() => (sidebarOpen = false)}
+                        >
+                            <Icon name={item.icon} size="18" />
+                            {item.label}
+                        </Link>
+                    {/each}
+                </div>
+            </nav>
+        </aside>
+
+        <!-- Main Content -->
+        <main class="min-h-[calc(100vh-57px)] flex-1 p-6 lg:p-8">
+            <div class="mx-auto max-w-5xl">
+                {@render children()}
+            </div>
+        </main>
+    </div>
 </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import { ModeWatcher } from 'mode-watcher'
     import { toggleMode, mode } from 'mode-watcher'
-    import { Tooltip } from 'bits-ui'
     import { Button, Icon, Link } from '$lib/index.js'
     import './layout.css'
     import '../sv5ui.config.js'
@@ -61,8 +60,7 @@
 
 <ModeWatcher />
 
-<Tooltip.Provider delayDuration={200}>
-    <div class="min-h-screen bg-surface text-on-surface">
+<div class="min-h-screen bg-surface text-on-surface">
         <!-- Header -->
         <header
             class="sticky top-0 z-50 border-b border-outline-variant bg-surface-container px-4 py-3 lg:px-6"
@@ -165,5 +163,4 @@
                 </div>
             </main>
         </div>
-    </div>
-</Tooltip.Provider>
+</div>


### PR DESCRIPTION
## Summary
- Embed `TooltipProvider` directly inside the `Tooltip` component so users no longer need to import and wrap it manually from `bits-ui`

## Why
Currently, users must import `TooltipProvider` from `bits-ui` and wrap their layout before using `<Tooltip>`. This is a poor DX — the component should work out of the box.

## Changes
- **Tooltip.svelte**: Wrap tooltip content with `TooltipProvider` internally

## Usage
Before (broken DX):
```svelte
<script>
  import { TooltipProvider } from 'bits-ui';
  import { Tooltip } from 'sv5ui';
</script>

<TooltipProvider>
  <Tooltip content="Hello">Hover me</Tooltip>
</TooltipProvider>
