### PR TITLE
chore: bump version to 1.1.2 and remove VERSION export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sv5ui",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "A modern Svelte 5 UI component library with Tailwind CSS",
     "author": "ndlabdev",
     "license": "MIT",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -41,4 +41,3 @@ export * from './ThemeModeButton/index.js'
 // Configuration
 export { defineConfig } from './config.js'
 export type { UIConfig } from './config.js'
-

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -42,6 +42,3 @@ export * from './ThemeModeButton/index.js'
 export { defineConfig } from './config.js'
 export type { UIConfig } from './config.js'
 
-// Version
-declare const __SV5UI_VERSION__: string
-export const VERSION = __SV5UI_VERSION__

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,16 +2,8 @@ import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'vitest/config'
 import { playwright } from '@vitest/browser-playwright'
 import { sveltekit } from '@sveltejs/kit/vite'
-import { readFileSync } from 'node:fs'
-
-const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
-
 export default defineConfig({
     plugins: [tailwindcss(), sveltekit()],
-
-    define: {
-        __SV5UI_VERSION__: JSON.stringify(pkg.version)
-    },
 
     test: {
         expect: { requireAssertions: true },


### PR DESCRIPTION
## Summary
- Bump version from 1.1.1 to 1.1.2
- Remove `VERSION` export and Vite `define` config (không hoạt động với `svelte-package`)

## Changes
- **package.json**: Bump version to 1.1.2
- **src/lib/index.ts**: Remove VERSION export
- **vite.config.ts**: Remove `define` and `readFileSync` import
