### PR TITLE
chore: bump version to 1.1.3 and add Svelte 5 syntax skill

### DIFF
--- a/.agents/skills/trevors-dot-claude-svelte5/SKILL.md
+++ b/.agents/skills/trevors-dot-claude-svelte5/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: svelte5
+description: Svelte 5 syntax reference. Use when writing ANY Svelte component. Svelte 5 uses runes ($state, $derived, $effect, $props) instead of Svelte 4 patterns. Training data is heavily Svelte 4—this skill prevents outdated syntax.
+---
+
+# Svelte 5 Syntax
+
+Always use Svelte 5 runes. Never use Svelte 4 patterns.
+
+## Svelte 4 → Svelte 5
+
+| Svelte 4 ❌                    | Svelte 5 ✅                                            |
+| ------------------------------ | ------------------------------------------------------ |
+| `export let foo`               | `let { foo } = $props()`                               |
+| `export let foo = 'default'`   | `let { foo = 'default' } = $props()`                   |
+| `$: doubled = x * 2`           | `let doubled = $derived(x * 2)`                        |
+| `$: { sideEffect() }`          | `$effect(() => { sideEffect() })`                      |
+| `on:click={handler}`           | `onclick={handler}`                                    |
+| `on:input={handler}`           | `oninput={handler}`                                    |
+| `on:click\|preventDefault={h}` | `onclick={e => { e.preventDefault(); h(e) }}`          |
+| `<slot />`                     | `{@render children()}`                                 |
+| `<slot name="x" />`            | `{@render x?.()}`                                      |
+| `$$props`                      | Use `$props()` with rest: `let { ...rest } = $props()` |
+| `$$restProps`                  | `let { known, ...rest } = $props()`                    |
+| `createEventDispatcher()`      | Pass callback props: `let { onchange } = $props()`     |
+
+## Stores → Runes
+
+| Svelte 4 ❌                               | Svelte 5 ✅             |
+| ----------------------------------------- | ----------------------- |
+| `import { writable } from 'svelte/store'` | Remove import           |
+| `const count = writable(0)`               | `let count = $state(0)` |
+| `$count` (auto-subscribe)                 | `count` (direct access) |
+| `count.set(1)`                            | `count = 1`             |
+| `count.update(n => n + 1)`                | `count += 1`            |
+
+## Quick Reference
+
+```svelte
+<script>
+  // Props (with defaults and rest)
+  let { required, optional = 'default', ...rest } = $props();
+
+  // Two-way bindable prop
+  let { value = $bindable() } = $props();
+
+  // Reactive state
+  let count = $state(0);
+  let items = $state([]);      // arrays are deeply reactive
+  let user = $state({ name: '' }); // objects too
+
+  // Derived values
+  let doubled = $derived(count * 2);
+  let complex = $derived.by(() => {
+    // multi-line logic here
+    return expensiveCalc(count);
+  });
+
+  // Side effects
+  $effect(() => {
+    console.log(count);
+    return () => cleanup(); // optional cleanup
+  });
+</script>
+
+<!-- Events: native names, no colon -->
+<button onclick={() => count++}>Click</button>
+<input oninput={e => value = e.target.value} />
+
+<!-- Render snippets (replaces slots) -->
+{@render children?.()}
+```
+
+## Snippets (Replace Slots)
+
+```svelte
+<!-- Parent passes snippets -->
+<Dialog>
+  {#snippet header()}
+    <h1>Title</h1>
+  {/snippet}
+
+  {#snippet footer(close)}
+    <button onclick={close}>Done</button>
+  {/snippet}
+</Dialog>
+
+<!-- Child renders them -->
+<script>
+  let { header, footer, children } = $props();
+</script>
+{@render header?.()}
+{@render children?.()}
+{@render footer?.(() => open = false)}
+```
+
+## References
+
+Load these when needed:
+
+- **[references/typescript.md](references/typescript.md)** — Typing props, state, derived, snippets, events, context
+- **[references/patterns.md](references/patterns.md)** — Context API, controlled inputs, forwarding props, async data, debouncing
+- **[references/gotchas.md](references/gotchas.md)** — Reactivity edge cases, effect pitfalls, binding quirks

--- a/.agents/skills/trevors-dot-claude-svelte5/SKILL.md
+++ b/.agents/skills/trevors-dot-claude-svelte5/SKILL.md
@@ -38,34 +38,34 @@ Always use Svelte 5 runes. Never use Svelte 4 patterns.
 
 ```svelte
 <script>
-  // Props (with defaults and rest)
-  let { required, optional = 'default', ...rest } = $props();
+    // Props (with defaults and rest)
+    let { required, optional = 'default', ...rest } = $props()
 
-  // Two-way bindable prop
-  let { value = $bindable() } = $props();
+    // Two-way bindable prop
+    let { value = $bindable() } = $props()
 
-  // Reactive state
-  let count = $state(0);
-  let items = $state([]);      // arrays are deeply reactive
-  let user = $state({ name: '' }); // objects too
+    // Reactive state
+    let count = $state(0)
+    let items = $state([]) // arrays are deeply reactive
+    let user = $state({ name: '' }) // objects too
 
-  // Derived values
-  let doubled = $derived(count * 2);
-  let complex = $derived.by(() => {
-    // multi-line logic here
-    return expensiveCalc(count);
-  });
+    // Derived values
+    let doubled = $derived(count * 2)
+    let complex = $derived.by(() => {
+        // multi-line logic here
+        return expensiveCalc(count)
+    })
 
-  // Side effects
-  $effect(() => {
-    console.log(count);
-    return () => cleanup(); // optional cleanup
-  });
+    // Side effects
+    $effect(() => {
+        console.log(count)
+        return () => cleanup() // optional cleanup
+    })
 </script>
 
 <!-- Events: native names, no colon -->
 <button onclick={() => count++}>Click</button>
-<input oninput={e => value = e.target.value} />
+<input oninput={(e) => (value = e.target.value)} />
 
 <!-- Render snippets (replaces slots) -->
 {@render children?.()}
@@ -74,24 +74,24 @@ Always use Svelte 5 runes. Never use Svelte 4 patterns.
 ## Snippets (Replace Slots)
 
 ```svelte
-<!-- Parent passes snippets -->
-<Dialog>
-  {#snippet header()}
-    <h1>Title</h1>
-  {/snippet}
-
-  {#snippet footer(close)}
-    <button onclick={close}>Done</button>
-  {/snippet}
-</Dialog>
-
 <!-- Child renders them -->
 <script>
-  let { header, footer, children } = $props();
+    let { header, footer, children } = $props()
 </script>
+
+<!-- Parent passes snippets -->
+<Dialog>
+    {#snippet header()}
+        <h1>Title</h1>
+    {/snippet}
+
+    {#snippet footer(close)}
+        <button onclick={close}>Done</button>
+    {/snippet}
+</Dialog>
 {@render header?.()}
 {@render children?.()}
-{@render footer?.(() => open = false)}
+{@render footer?.(() => (open = false))}
 ```
 
 ## References

--- a/.agents/skills/trevors-dot-claude-svelte5/gotchas.md
+++ b/.agents/skills/trevors-dot-claude-svelte5/gotchas.md
@@ -1,0 +1,250 @@
+# Svelte 5 Gotchas
+
+## Reactivity
+
+### Object/Array Mutation
+
+```svelte
+<script>
+  let items = $state(['a', 'b']);
+
+  // ✅ These all work (deep reactivity)
+  items.push('c');
+  items[0] = 'x';
+  items.splice(1, 1);
+
+  // ✅ Reassignment also works
+  items = [...items, 'c'];
+</script>
+```
+
+### Primitives Must Be Reassigned
+
+```svelte
+<script>
+  let count = $state(0);
+
+  // ✅ Correct
+  count = count + 1;
+  count++;
+
+  // ❌ This does nothing (no mutation possible)
+  // Primitives have no methods to mutate
+</script>
+```
+
+### Derived Cannot Be Assigned
+
+```svelte
+<script>
+  let count = $state(0);
+  let doubled = $derived(count * 2);
+
+  // ❌ Error: doubled is readonly
+  doubled = 10;
+
+  // ✅ Change the source instead
+  count = 5;  // doubled becomes 10
+</script>
+```
+
+## Props
+
+### Props Are Readonly by Default
+
+```svelte
+<script>
+  let { count } = $props();
+
+  // ❌ Error: cannot assign to prop
+  count = 5;
+
+  // ✅ Use $bindable for two-way binding
+  let { count = $bindable(0) } = $props();
+  count = 5;  // Now works
+</script>
+```
+
+### Destructuring Loses Reactivity
+
+```svelte
+<script>
+  let { user } = $props();
+
+  // ❌ Not reactive - name is a static copy
+  let { name } = user;
+
+  // ✅ Access directly for reactivity
+  // In template: {user.name}
+
+  // ✅ Or use $derived
+  let name = $derived(user.name);
+</script>
+```
+
+## Effects
+
+### $effect Runs After Mount
+
+```svelte
+<script>
+  let el;
+
+  // ❌ el is undefined on first run
+  $effect(() => {
+    console.log(el.offsetHeight);  // Error!
+  });
+
+  // ✅ Guard against undefined
+  $effect(() => {
+    if (!el) return;
+    console.log(el.offsetHeight);
+  });
+</script>
+
+<div bind:this={el}>Content</div>
+```
+
+### $effect Tracks Dependencies Automatically
+
+```svelte
+<script>
+  let count = $state(0);
+  let other = $state(0);
+
+  // Runs when `count` changes (it's read inside)
+  $effect(() => {
+    console.log(count);
+  });
+
+  // ❌ Won't track `other` - not read inside
+  $effect(() => {
+    console.log(count);
+    // `other` not tracked because not accessed
+  });
+
+  // ✅ Access dependencies you want to track
+  $effect(() => {
+    console.log(count, other);
+  });
+</script>
+```
+
+### Avoid Infinite Loops
+
+```svelte
+<script>
+  let count = $state(0);
+
+  // ❌ Infinite loop: reads and writes same state
+  $effect(() => {
+    count = count + 1;
+  });
+
+  // ✅ Use untrack for writes that shouldn't re-trigger
+  import { untrack } from 'svelte';
+  $effect(() => {
+    const current = count;
+    untrack(() => {
+      someOtherState = current;
+    });
+  });
+</script>
+```
+
+## Events
+
+### No Event Modifiers
+
+```svelte
+<!-- ❌ Svelte 4 modifiers don't exist -->
+<button on:click|preventDefault|stopPropagation={handler}>
+
+<!-- ✅ Handle in the function -->
+<button onclick={e => {
+  e.preventDefault();
+  e.stopPropagation();
+  handler(e);
+}}>
+```
+
+### Event Types Changed
+
+```svelte
+<!-- ❌ on:click -->
+<button on:click={handler}>
+
+<!-- ✅ onclick (lowercase, no colon) -->
+<button onclick={handler}>
+
+<!-- Same for all events -->
+<input oninput={handler} />
+<form onsubmit={handler}>
+<div onmouseenter={handler}>
+```
+
+## Snippets
+
+### Children is a Snippet, Not Slot
+
+```svelte
+<script>
+  let { children } = $props();
+</script>
+
+<!-- ❌ Old slot syntax -->
+<slot />
+
+<!-- ✅ Render the children snippet -->
+{@render children?.()}
+```
+
+### Snippets Can Take Parameters
+
+```svelte
+<!-- Parent -->
+<List {items}>
+  {#snippet item(data, index)}
+    <span>{index}: {data.name}</span>
+  {/snippet}
+</List>
+
+<!-- List.svelte -->
+<script>
+  let { items, item } = $props();
+</script>
+
+{#each items as data, index}
+  {@render item(data, index)}
+{/each}
+```
+
+## Bindings
+
+### bind:this Still Works
+
+```svelte
+<script>
+  let canvas;
+
+  $effect(() => {
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+  });
+</script>
+
+<canvas bind:this={canvas}></canvas>
+```
+
+### bind:value Works with $bindable
+
+```svelte
+<!-- Child needs $bindable for parent to bind -->
+<script>
+  let { value = $bindable('') } = $props();
+</script>
+<input bind:value />
+
+<!-- Parent can then bind -->
+<Child bind:value={name} />
+```

--- a/.agents/skills/trevors-dot-claude-svelte5/gotchas.md
+++ b/.agents/skills/trevors-dot-claude-svelte5/gotchas.md
@@ -6,15 +6,15 @@
 
 ```svelte
 <script>
-  let items = $state(['a', 'b']);
+    let items = $state(['a', 'b'])
 
-  // ✅ These all work (deep reactivity)
-  items.push('c');
-  items[0] = 'x';
-  items.splice(1, 1);
+    // ✅ These all work (deep reactivity)
+    items.push('c')
+    items[0] = 'x'
+    items.splice(1, 1)
 
-  // ✅ Reassignment also works
-  items = [...items, 'c'];
+    // ✅ Reassignment also works
+    items = [...items, 'c']
 </script>
 ```
 
@@ -22,14 +22,14 @@
 
 ```svelte
 <script>
-  let count = $state(0);
+    let count = $state(0)
 
-  // ✅ Correct
-  count = count + 1;
-  count++;
+    // ✅ Correct
+    count = count + 1
+    count++
 
-  // ❌ This does nothing (no mutation possible)
-  // Primitives have no methods to mutate
+    // ❌ This does nothing (no mutation possible)
+    // Primitives have no methods to mutate
 </script>
 ```
 
@@ -37,14 +37,14 @@
 
 ```svelte
 <script>
-  let count = $state(0);
-  let doubled = $derived(count * 2);
+    let count = $state(0)
+    let doubled = $derived(count * 2)
 
-  // ❌ Error: doubled is readonly
-  doubled = 10;
+    // ❌ Error: doubled is readonly
+    doubled = 10
 
-  // ✅ Change the source instead
-  count = 5;  // doubled becomes 10
+    // ✅ Change the source instead
+    count = 5 // doubled becomes 10
 </script>
 ```
 
@@ -54,14 +54,14 @@
 
 ```svelte
 <script>
-  let { count } = $props();
+    let { count } = $props()
 
-  // ❌ Error: cannot assign to prop
-  count = 5;
+    // ❌ Error: cannot assign to prop
+    count = 5
 
-  // ✅ Use $bindable for two-way binding
-  let { count = $bindable(0) } = $props();
-  count = 5;  // Now works
+    // ✅ Use $bindable for two-way binding
+    let { count = $bindable(0) } = $props()
+    count = 5 // Now works
 </script>
 ```
 
@@ -69,16 +69,16 @@
 
 ```svelte
 <script>
-  let { user } = $props();
+    let { user } = $props()
 
-  // ❌ Not reactive - name is a static copy
-  let { name } = user;
+    // ❌ Not reactive - name is a static copy
+    let { name } = user
 
-  // ✅ Access directly for reactivity
-  // In template: {user.name}
+    // ✅ Access directly for reactivity
+    // In template: {user.name}
 
-  // ✅ Or use $derived
-  let name = $derived(user.name);
+    // ✅ Or use $derived
+    let name = $derived(user.name)
 </script>
 ```
 
@@ -88,18 +88,18 @@
 
 ```svelte
 <script>
-  let el;
+    let el
 
-  // ❌ el is undefined on first run
-  $effect(() => {
-    console.log(el.offsetHeight);  // Error!
-  });
+    // ❌ el is undefined on first run
+    $effect(() => {
+        console.log(el.offsetHeight) // Error!
+    })
 
-  // ✅ Guard against undefined
-  $effect(() => {
-    if (!el) return;
-    console.log(el.offsetHeight);
-  });
+    // ✅ Guard against undefined
+    $effect(() => {
+        if (!el) return
+        console.log(el.offsetHeight)
+    })
 </script>
 
 <div bind:this={el}>Content</div>
@@ -109,24 +109,24 @@
 
 ```svelte
 <script>
-  let count = $state(0);
-  let other = $state(0);
+    let count = $state(0)
+    let other = $state(0)
 
-  // Runs when `count` changes (it's read inside)
-  $effect(() => {
-    console.log(count);
-  });
+    // Runs when `count` changes (it's read inside)
+    $effect(() => {
+        console.log(count)
+    })
 
-  // ❌ Won't track `other` - not read inside
-  $effect(() => {
-    console.log(count);
-    // `other` not tracked because not accessed
-  });
+    // ❌ Won't track `other` - not read inside
+    $effect(() => {
+        console.log(count)
+        // `other` not tracked because not accessed
+    })
 
-  // ✅ Access dependencies you want to track
-  $effect(() => {
-    console.log(count, other);
-  });
+    // ✅ Access dependencies you want to track
+    $effect(() => {
+        console.log(count, other)
+    })
 </script>
 ```
 
@@ -134,21 +134,21 @@
 
 ```svelte
 <script>
-  let count = $state(0);
+    let count = $state(0)
 
-  // ❌ Infinite loop: reads and writes same state
-  $effect(() => {
-    count = count + 1;
-  });
+    // ❌ Infinite loop: reads and writes same state
+    $effect(() => {
+        count = count + 1
+    })
 
-  // ✅ Use untrack for writes that shouldn't re-trigger
-  import { untrack } from 'svelte';
-  $effect(() => {
-    const current = count;
-    untrack(() => {
-      someOtherState = current;
-    });
-  });
+    // ✅ Use untrack for writes that shouldn't re-trigger
+    import { untrack } from 'svelte'
+    $effect(() => {
+        const current = count
+        untrack(() => {
+            someOtherState = current
+        })
+    })
 </script>
 ```
 
@@ -189,7 +189,7 @@
 
 ```svelte
 <script>
-  let { children } = $props();
+    let { children } = $props()
 </script>
 
 <!-- ❌ Old slot syntax -->
@@ -202,20 +202,20 @@
 ### Snippets Can Take Parameters
 
 ```svelte
-<!-- Parent -->
-<List {items}>
-  {#snippet item(data, index)}
-    <span>{index}: {data.name}</span>
-  {/snippet}
-</List>
-
 <!-- List.svelte -->
 <script>
-  let { items, item } = $props();
+    let { items, item } = $props()
 </script>
 
+<!-- Parent -->
+<List {items}>
+    {#snippet item(data, index)}
+        <span>{index}: {data.name}</span>
+    {/snippet}
+</List>
+
 {#each items as data, index}
-  {@render item(data, index)}
+    {@render item(data, index)}
 {/each}
 ```
 
@@ -225,12 +225,12 @@
 
 ```svelte
 <script>
-  let canvas;
+    let canvas
 
-  $effect(() => {
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d');
-  });
+    $effect(() => {
+        if (!canvas) return
+        const ctx = canvas.getContext('2d')
+    })
 </script>
 
 <canvas bind:this={canvas}></canvas>
@@ -241,8 +241,9 @@
 ```svelte
 <!-- Child needs $bindable for parent to bind -->
 <script>
-  let { value = $bindable('') } = $props();
+    let { value = $bindable('') } = $props()
 </script>
+
 <input bind:value />
 
 <!-- Parent can then bind -->

--- a/.agents/skills/trevors-dot-claude-svelte5/patterns.md
+++ b/.agents/skills/trevors-dot-claude-svelte5/patterns.md
@@ -1,0 +1,211 @@
+# Svelte 5 Component Patterns
+
+## Forwarding Props and Events
+
+```svelte
+<!-- Button.svelte -->
+<script>
+  let { children, variant = 'default', ...rest } = $props();
+</script>
+
+<button class="btn btn-{variant}" {...rest}>
+  {@render children()}
+</button>
+```
+
+## Controlled Input
+
+```svelte
+<!-- TextInput.svelte -->
+<script>
+  let { value = $bindable(''), oninput, ...rest } = $props();
+</script>
+
+<input
+  bind:value
+  oninput={e => {
+    oninput?.(e);
+  }}
+  {...rest}
+/>
+
+<!-- Usage -->
+<TextInput bind:value={name} />
+```
+
+## Context API
+
+```svelte
+<!-- Provider.svelte -->
+<script>
+  import { setContext } from 'svelte';
+
+  let { children } = $props();
+  let count = $state(0);
+
+  setContext('counter', {
+    get count() { return count },  // getter for reactive access
+    increment: () => count++
+  });
+</script>
+
+{@render children()}
+
+<!-- Consumer.svelte -->
+<script>
+  import { getContext } from 'svelte';
+  const { count, increment } = getContext('counter');
+</script>
+
+<button onclick={increment}>{count}</button>
+```
+
+## Reactive Context (Alternative)
+
+```svelte
+<!-- Provider.svelte -->
+<script>
+  import { setContext } from 'svelte';
+
+  let { children } = $props();
+  let state = $state({ count: 0, user: null });
+
+  setContext('app', state);  // pass the $state object directly
+</script>
+
+<!-- Consumer.svelte -->
+<script>
+  import { getContext } from 'svelte';
+  const state = getContext('app');
+</script>
+
+<!-- Reactive because state is a $state proxy -->
+<p>{state.count}</p>
+```
+
+## Component with Actions
+
+```svelte
+<script>
+  let { children, onmount } = $props();
+  let element;
+
+  $effect(() => {
+    if (element && onmount) {
+      return onmount(element);  // return cleanup function
+    }
+  });
+</script>
+
+<div bind:this={element}>
+  {@render children()}
+</div>
+```
+
+## Conditional Rendering with Snippets
+
+```svelte
+<!-- Modal.svelte -->
+<script>
+  let { open, onclose, title, children, footer } = $props();
+</script>
+
+{#if open}
+  <div class="modal-backdrop" onclick={onclose}>
+    <div class="modal" onclick={e => e.stopPropagation()}>
+      <header>
+        {#if typeof title === 'string'}
+          <h2>{title}</h2>
+        {:else}
+          {@render title?.()}
+        {/if}
+      </header>
+      <main>{@render children()}</main>
+      {#if footer}
+        <footer>{@render footer()}</footer>
+      {/if}
+    </div>
+  </div>
+{/if}
+```
+
+## List with Selection
+
+```svelte
+<script>
+  let { items, selected = $bindable(null), onselect } = $props();
+
+  function select(item) {
+    selected = item;
+    onselect?.(item);
+  }
+</script>
+
+<ul>
+  {#each items as item (item.id)}
+    <li>
+      <button
+        class:selected={selected === item}
+        onclick={() => select(item)}
+      >
+        {item.name}
+      </button>
+    </li>
+  {/each}
+</ul>
+```
+
+## Async Data Loading
+
+```svelte
+<script>
+  let { load } = $props();
+
+  let data = $state(null);
+  let error = $state(null);
+  let loading = $state(true);
+
+  $effect(() => {
+    loading = true;
+    error = null;
+
+    load()
+      .then(result => data = result)
+      .catch(e => error = e)
+      .finally(() => loading = false);
+  });
+</script>
+
+{#if loading}
+  <p>Loading...</p>
+{:else if error}
+  <p>Error: {error.message}</p>
+{:else}
+  <slot {data} />
+{/if}
+```
+
+## Debounced Input
+
+```svelte
+<script>
+  let { value = $bindable(''), delay = 300, onchange } = $props();
+  let internal = $state(value);
+  let timeout;
+
+  $effect(() => {
+    internal = value;  // sync from parent
+  });
+
+  function handleInput(e) {
+    internal = e.target.value;
+    clearTimeout(timeout);
+    timeout = setTimeout(() => {
+      value = internal;
+      onchange?.(internal);
+    }, delay);
+  }
+</script>
+
+<input value={internal} oninput={handleInput} />
+```

--- a/.agents/skills/trevors-dot-claude-svelte5/patterns.md
+++ b/.agents/skills/trevors-dot-claude-svelte5/patterns.md
@@ -5,11 +5,11 @@
 ```svelte
 <!-- Button.svelte -->
 <script>
-  let { children, variant = 'default', ...rest } = $props();
+    let { children, variant = 'default', ...rest } = $props()
 </script>
 
 <button class="btn btn-{variant}" {...rest}>
-  {@render children()}
+    {@render children()}
 </button>
 ```
 
@@ -18,15 +18,15 @@
 ```svelte
 <!-- TextInput.svelte -->
 <script>
-  let { value = $bindable(''), oninput, ...rest } = $props();
+    let { value = $bindable(''), oninput, ...rest } = $props()
 </script>
 
 <input
-  bind:value
-  oninput={e => {
-    oninput?.(e);
-  }}
-  {...rest}
+    bind:value
+    oninput={(e) => {
+        oninput?.(e)
+    }}
+    {...rest}
 />
 
 <!-- Usage -->
@@ -87,18 +87,18 @@
 
 ```svelte
 <script>
-  let { children, onmount } = $props();
-  let element;
+    let { children, onmount } = $props()
+    let element
 
-  $effect(() => {
-    if (element && onmount) {
-      return onmount(element);  // return cleanup function
-    }
-  });
+    $effect(() => {
+        if (element && onmount) {
+            return onmount(element) // return cleanup function
+        }
+    })
 </script>
 
 <div bind:this={element}>
-  {@render children()}
+    {@render children()}
 </div>
 ```
 
@@ -107,25 +107,25 @@
 ```svelte
 <!-- Modal.svelte -->
 <script>
-  let { open, onclose, title, children, footer } = $props();
+    let { open, onclose, title, children, footer } = $props()
 </script>
 
 {#if open}
-  <div class="modal-backdrop" onclick={onclose}>
-    <div class="modal" onclick={e => e.stopPropagation()}>
-      <header>
-        {#if typeof title === 'string'}
-          <h2>{title}</h2>
-        {:else}
-          {@render title?.()}
-        {/if}
-      </header>
-      <main>{@render children()}</main>
-      {#if footer}
-        <footer>{@render footer()}</footer>
-      {/if}
+    <div class="modal-backdrop" onclick={onclose}>
+        <div class="modal" onclick={(e) => e.stopPropagation()}>
+            <header>
+                {#if typeof title === 'string'}
+                    <h2>{title}</h2>
+                {:else}
+                    {@render title?.()}
+                {/if}
+            </header>
+            <main>{@render children()}</main>
+            {#if footer}
+                <footer>{@render footer()}</footer>
+            {/if}
+        </div>
     </div>
-  </div>
 {/if}
 ```
 
@@ -133,25 +133,22 @@
 
 ```svelte
 <script>
-  let { items, selected = $bindable(null), onselect } = $props();
+    let { items, selected = $bindable(null), onselect } = $props()
 
-  function select(item) {
-    selected = item;
-    onselect?.(item);
-  }
+    function select(item) {
+        selected = item
+        onselect?.(item)
+    }
 </script>
 
 <ul>
-  {#each items as item (item.id)}
-    <li>
-      <button
-        class:selected={selected === item}
-        onclick={() => select(item)}
-      >
-        {item.name}
-      </button>
-    </li>
-  {/each}
+    {#each items as item (item.id)}
+        <li>
+            <button class:selected={selected === item} onclick={() => select(item)}>
+                {item.name}
+            </button>
+        </li>
+    {/each}
 </ul>
 ```
 
@@ -159,29 +156,29 @@
 
 ```svelte
 <script>
-  let { load } = $props();
+    let { load } = $props()
 
-  let data = $state(null);
-  let error = $state(null);
-  let loading = $state(true);
+    let data = $state(null)
+    let error = $state(null)
+    let loading = $state(true)
 
-  $effect(() => {
-    loading = true;
-    error = null;
+    $effect(() => {
+        loading = true
+        error = null
 
-    load()
-      .then(result => data = result)
-      .catch(e => error = e)
-      .finally(() => loading = false);
-  });
+        load()
+            .then((result) => (data = result))
+            .catch((e) => (error = e))
+            .finally(() => (loading = false))
+    })
 </script>
 
 {#if loading}
-  <p>Loading...</p>
+    <p>Loading...</p>
 {:else if error}
-  <p>Error: {error.message}</p>
+    <p>Error: {error.message}</p>
 {:else}
-  <slot {data} />
+    <slot {data} />
 {/if}
 ```
 
@@ -189,22 +186,22 @@
 
 ```svelte
 <script>
-  let { value = $bindable(''), delay = 300, onchange } = $props();
-  let internal = $state(value);
-  let timeout;
+    let { value = $bindable(''), delay = 300, onchange } = $props()
+    let internal = $state(value)
+    let timeout
 
-  $effect(() => {
-    internal = value;  // sync from parent
-  });
+    $effect(() => {
+        internal = value // sync from parent
+    })
 
-  function handleInput(e) {
-    internal = e.target.value;
-    clearTimeout(timeout);
-    timeout = setTimeout(() => {
-      value = internal;
-      onchange?.(internal);
-    }, delay);
-  }
+    function handleInput(e) {
+        internal = e.target.value
+        clearTimeout(timeout)
+        timeout = setTimeout(() => {
+            value = internal
+            onchange?.(internal)
+        }, delay)
+    }
 </script>
 
 <input value={internal} oninput={handleInput} />

--- a/.agents/skills/trevors-dot-claude-svelte5/typescript.md
+++ b/.agents/skills/trevors-dot-claude-svelte5/typescript.md
@@ -1,0 +1,147 @@
+# Svelte 5 TypeScript Patterns
+
+## Typing Props
+
+```svelte
+<script lang="ts">
+  // Inline types
+  let { name, count = 0 }: { name: string; count?: number } = $props();
+
+  // Interface (preferred for complex props)
+  interface Props {
+    name: string;
+    items: string[];
+    onselect?: (item: string) => void;
+  }
+  let { name, items, onselect }: Props = $props();
+
+  // With rest props
+  interface Props {
+    variant: 'primary' | 'secondary';
+  }
+  let { variant, ...rest }: Props & Record<string, unknown> = $props();
+
+  // Generic components
+  interface Props<T> {
+    items: T[];
+    selected?: T;
+    onselect?: (item: T) => void;
+  }
+  let { items, selected, onselect }: Props<T> = $props();
+</script>
+```
+
+## Typing State
+
+```svelte
+<script lang="ts">
+  // Primitives (inferred)
+  let count = $state(0);
+
+  // Explicit when needed
+  let user = $state<User | null>(null);
+  let items = $state<string[]>([]);
+
+  // Complex objects
+  interface FormState {
+    name: string;
+    email: string;
+    errors: Record<string, string>;
+  }
+  let form = $state<FormState>({ name: '', email: '', errors: {} });
+</script>
+```
+
+## Typing Derived
+
+```svelte
+<script lang="ts">
+  let count = $state(0);
+
+  // Usually inferred
+  let doubled = $derived(count * 2);
+
+  // Explicit when needed
+  let result = $derived<string | null>(count > 0 ? String(count) : null);
+
+  // Complex derived
+  let computed = $derived.by((): ComputedResult => {
+    return { value: count, formatted: `Count: ${count}` };
+  });
+</script>
+```
+
+## Typing Bindable Props
+
+```svelte
+<script lang="ts">
+  // Simple bindable
+  let { value = $bindable('') }: { value: string } = $props();
+
+  // Optional bindable
+  let { checked = $bindable<boolean>() }: { checked?: boolean } = $props();
+</script>
+```
+
+## Typing Snippets
+
+```svelte
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    children: Snippet;
+    header?: Snippet;
+    row?: Snippet<[item: Item, index: number]>;  // snippet with params
+  }
+  let { children, header, row }: Props = $props();
+</script>
+
+{@render header?.()}
+{#each items as item, i}
+  {@render row?.(item, i)}
+{/each}
+{@render children()}
+```
+
+## Typing Event Handlers
+
+```svelte
+<script lang="ts">
+  // Native events
+  function handleClick(e: MouseEvent) { }
+  function handleInput(e: Event & { currentTarget: HTMLInputElement }) {
+    const value = e.currentTarget.value;
+  }
+
+  // Callback props
+  interface Props {
+    onclick?: (e: MouseEvent) => void;
+    onchange?: (value: string) => void;
+  }
+</script>
+
+<button onclick={handleClick}>Click</button>
+<input oninput={e => handleInput(e)} />
+```
+
+## Typing Context
+
+```svelte
+<script lang="ts" context="module">
+  export interface MyContext {
+    count: number;
+    increment: () => void;
+  }
+</script>
+
+<script lang="ts">
+  import { setContext, getContext } from 'svelte';
+
+  // Setting
+  setContext<MyContext>('key', { count: 0, increment: () => {} });
+
+  // Getting
+  const ctx = getContext<MyContext>('key');
+</script>
+```

--- a/.agents/skills/trevors-dot-claude-svelte5/typescript.md
+++ b/.agents/skills/trevors-dot-claude-svelte5/typescript.md
@@ -4,30 +4,30 @@
 
 ```svelte
 <script lang="ts">
-  // Inline types
-  let { name, count = 0 }: { name: string; count?: number } = $props();
+    // Inline types
+    let { name, count = 0 }: { name: string; count?: number } = $props()
 
-  // Interface (preferred for complex props)
-  interface Props {
-    name: string;
-    items: string[];
-    onselect?: (item: string) => void;
-  }
-  let { name, items, onselect }: Props = $props();
+    // Interface (preferred for complex props)
+    interface Props {
+        name: string
+        items: string[]
+        onselect?: (item: string) => void
+    }
+    let { name, items, onselect }: Props = $props()
 
-  // With rest props
-  interface Props {
-    variant: 'primary' | 'secondary';
-  }
-  let { variant, ...rest }: Props & Record<string, unknown> = $props();
+    // With rest props
+    interface Props {
+        variant: 'primary' | 'secondary'
+    }
+    let { variant, ...rest }: Props & Record<string, unknown> = $props()
 
-  // Generic components
-  interface Props<T> {
-    items: T[];
-    selected?: T;
-    onselect?: (item: T) => void;
-  }
-  let { items, selected, onselect }: Props<T> = $props();
+    // Generic components
+    interface Props<T> {
+        items: T[]
+        selected?: T
+        onselect?: (item: T) => void
+    }
+    let { items, selected, onselect }: Props<T> = $props()
 </script>
 ```
 
@@ -35,20 +35,20 @@
 
 ```svelte
 <script lang="ts">
-  // Primitives (inferred)
-  let count = $state(0);
+    // Primitives (inferred)
+    let count = $state(0)
 
-  // Explicit when needed
-  let user = $state<User | null>(null);
-  let items = $state<string[]>([]);
+    // Explicit when needed
+    let user = $state<User | null>(null)
+    let items = $state<string[]>([])
 
-  // Complex objects
-  interface FormState {
-    name: string;
-    email: string;
-    errors: Record<string, string>;
-  }
-  let form = $state<FormState>({ name: '', email: '', errors: {} });
+    // Complex objects
+    interface FormState {
+        name: string
+        email: string
+        errors: Record<string, string>
+    }
+    let form = $state<FormState>({ name: '', email: '', errors: {} })
 </script>
 ```
 
@@ -56,18 +56,18 @@
 
 ```svelte
 <script lang="ts">
-  let count = $state(0);
+    let count = $state(0)
 
-  // Usually inferred
-  let doubled = $derived(count * 2);
+    // Usually inferred
+    let doubled = $derived(count * 2)
 
-  // Explicit when needed
-  let result = $derived<string | null>(count > 0 ? String(count) : null);
+    // Explicit when needed
+    let result = $derived<string | null>(count > 0 ? String(count) : null)
 
-  // Complex derived
-  let computed = $derived.by((): ComputedResult => {
-    return { value: count, formatted: `Count: ${count}` };
-  });
+    // Complex derived
+    let computed = $derived.by((): ComputedResult => {
+        return { value: count, formatted: `Count: ${count}` }
+    })
 </script>
 ```
 
@@ -75,11 +75,11 @@
 
 ```svelte
 <script lang="ts">
-  // Simple bindable
-  let { value = $bindable('') }: { value: string } = $props();
+    // Simple bindable
+    let { value = $bindable('') }: { value: string } = $props()
 
-  // Optional bindable
-  let { checked = $bindable<boolean>() }: { checked?: boolean } = $props();
+    // Optional bindable
+    let { checked = $bindable<boolean>() }: { checked?: boolean } = $props()
 </script>
 ```
 
@@ -87,19 +87,19 @@
 
 ```svelte
 <script lang="ts">
-  import type { Snippet } from 'svelte';
+    import type { Snippet } from 'svelte'
 
-  interface Props {
-    children: Snippet;
-    header?: Snippet;
-    row?: Snippet<[item: Item, index: number]>;  // snippet with params
-  }
-  let { children, header, row }: Props = $props();
+    interface Props {
+        children: Snippet
+        header?: Snippet
+        row?: Snippet<[item: Item, index: number]> // snippet with params
+    }
+    let { children, header, row }: Props = $props()
 </script>
 
 {@render header?.()}
 {#each items as item, i}
-  {@render row?.(item, i)}
+    {@render row?.(item, i)}
 {/each}
 {@render children()}
 ```
@@ -108,40 +108,40 @@
 
 ```svelte
 <script lang="ts">
-  // Native events
-  function handleClick(e: MouseEvent) { }
-  function handleInput(e: Event & { currentTarget: HTMLInputElement }) {
-    const value = e.currentTarget.value;
-  }
+    // Native events
+    function handleClick(e: MouseEvent) {}
+    function handleInput(e: Event & { currentTarget: HTMLInputElement }) {
+        const value = e.currentTarget.value
+    }
 
-  // Callback props
-  interface Props {
-    onclick?: (e: MouseEvent) => void;
-    onchange?: (value: string) => void;
-  }
+    // Callback props
+    interface Props {
+        onclick?: (e: MouseEvent) => void
+        onchange?: (value: string) => void
+    }
 </script>
 
 <button onclick={handleClick}>Click</button>
-<input oninput={e => handleInput(e)} />
+<input oninput={(e) => handleInput(e)} />
 ```
 
 ## Typing Context
 
 ```svelte
 <script lang="ts" context="module">
-  export interface MyContext {
-    count: number;
-    increment: () => void;
-  }
+    export interface MyContext {
+        count: number
+        increment: () => void
+    }
 </script>
 
 <script lang="ts">
-  import { setContext, getContext } from 'svelte';
+    import { setContext, getContext } from 'svelte'
 
-  // Setting
-  setContext<MyContext>('key', { count: 0, increment: () => {} });
+    // Setting
+    setContext<MyContext>('key', { count: 0, increment: () => {} })
 
-  // Getting
-  const ctx = getContext<MyContext>('key');
+    // Getting
+    const ctx = getContext<MyContext>('key')
 </script>
 ```

--- a/README.md
+++ b/README.md
@@ -10,9 +10,15 @@
 </p>
 
 <p align="center">
+  <a href="https://sv5ui.vercel.app/docs"><strong>Documentation</strong></a> · <a href="https://sv5ui.vercel.app"><strong>Live Demo</strong></a>
+</p>
+
+<p align="center">
   <a href="https://www.npmjs.com/package/sv5ui"><img src="https://img.shields.io/npm/v/sv5ui.svg?style=flat-square&colorA=18181b&colorB=ff3e00" alt="npm version" /></a>
   <a href="https://github.com/ndlabdev/sv5ui/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/sv5ui.svg?style=flat-square&colorA=18181b&colorB=ff3e00" alt="license" /></a>
   <a href="https://www.npmjs.com/package/sv5ui"><img src="https://img.shields.io/npm/dm/sv5ui.svg?style=flat-square&colorA=18181b&colorB=ff3e00" alt="downloads" /></a>
+  <a href="https://svelte.dev"><img src="https://img.shields.io/badge/svelte-5-ff3e00?style=flat-square&logo=svelte&logoColor=white" alt="Svelte 5" /></a>
+  <a href="https://www.typescriptlang.org"><img src="https://img.shields.io/badge/types-TypeScript-blue?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript" /></a>
 </p>
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sv5ui",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "A modern Svelte 5 UI component library with Tailwind CSS",
     "author": "ndlabdev",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "type": "git",
         "url": "git+https://github.com/ndlabdev/sv5ui.git"
     },
-    "homepage": "https://github.com/ndlabdev/sv5ui#readme",
+    "homepage": "https://sv5ui.vercel.app",
     "bugs": {
         "url": "https://github.com/ndlabdev/sv5ui/issues"
     },


### PR DESCRIPTION
## Summary

### 1. Bump version to `1.1.3`
- Updated `version` in `package.json` from `1.1.2` → `1.1.3`

### 2. Add Svelte 5 syntax skill
- Installed **trevors-dot-claude-svelte5** skill from LobeHub Skills Marketplace
- Added `.agents/skills/trevors-dot-claude-svelte5/` directory with 4 files:
  - `SKILL.md` — Svelte 5 runes reference (props, state, derived, effect, snippets)
  - `typescript.md` — Typing props, state, derived, snippets, events, context
  - `patterns.md` — Context API, controlled inputs, forwarding props, async data
  - `gotchas.md` — Reactivity edge cases, effect pitfalls, binding quirks

### 3. Improve README
- Added **Documentation** (`sv5ui.vercel.app/docs`) and **Live Demo** (`sv5ui.vercel.app`) links
- Added **Svelte 5** and **TypeScript** badges

### 4. Update homepage URL
- Changed `homepage` in `package.json` from GitHub readme → `https://sv5ui.vercel.app`
