### PR TITLE
refactor: redesign Link & Button components

### DIFF
--- a/src/lib/Button/Button.svelte
+++ b/src/lib/Button/Button.svelte
@@ -5,13 +5,13 @@
 </script>
 
 <script lang="ts">
-    import { Button } from 'bits-ui'
     import { buttonVariants, buttonDefaults } from './button.variants.js'
     import { getComponentConfig, iconsDefaults } from '../config.js'
     import { getContext } from 'svelte'
     import { fieldGroupVariant } from '../FieldGroup/field-group.variants.js'
     import Icon from '../Icon/Icon.svelte'
     import Avatar from '../Avatar/Avatar.svelte'
+    import Link from '../Link/Link.svelte'
     import type { AvatarSize } from '../Avatar/avatar.types.js'
     import type { FieldGroupVariantProps } from '../FieldGroup/field-group.variants.js'
 
@@ -26,6 +26,7 @@
         size,
         label,
         loading = false,
+        loadingAuto = false,
         loadingIcon = icons.loading,
         disabled = false,
         block = false,
@@ -35,10 +36,20 @@
         trailingIcon,
         trailing = false,
         avatar,
+        href,
+        type,
+        external,
+        active,
+        exact = false,
+        activeColor,
+        activeVariant,
+        activeClass,
+        inactiveClass,
         leadingSlot,
         trailingSlot,
         children,
         class: className,
+        onclick,
         ...restProps
     }: Props = $props()
 
@@ -57,27 +68,34 @@
             : undefined
     )
 
+    let autoLoading = $state(false)
+    let pendingPromise: Promise<unknown> | null = null
+    const isLoading = $derived(loading || autoLoading)
+
     const isIconOnly = $derived(square || (!label && !children))
-    const isLeading = $derived((!!icon && !trailing) || (loading && !trailing) || !!leadingIcon)
-    const isTrailing = $derived((!!icon && trailing) || (loading && trailing) || !!trailingIcon)
+    const isLeading = $derived((!!icon && !trailing) || (isLoading && !trailing) || !!leadingIcon)
+    const isTrailing = $derived((!!icon && trailing) || (isLoading && trailing) || !!trailingIcon)
 
     const leadingIconName = $derived(
-        loading && isLeading
+        isLoading && isLeading
             ? loadingIcon
             : leadingIcon || (isLeading && !trailing ? icon : undefined)
     )
     const trailingIconName = $derived(
-        loading && isTrailing ? loadingIcon : trailingIcon || (trailing ? icon : undefined)
+        isLoading && isTrailing ? loadingIcon : trailingIcon || (trailing ? icon : undefined)
     )
+
+    const resolvedColor = $derived(active && activeColor ? activeColor : color)
+    const resolvedVariant = $derived(active && activeVariant ? activeVariant : variant)
 
     const classes = $derived.by(() => {
         const slots = buttonVariants({
-            variant,
-            color,
+            variant: resolvedVariant,
+            color: resolvedColor,
             size: resolvedSize,
             block,
             square: isIconOnly,
-            loading,
+            loading: isLoading,
             leading: isLeading,
             trailing: isTrailing
         })
@@ -94,9 +112,48 @@
             leadingAvatarSize: slots.leadingAvatarSize() as AvatarSize
         }
     })
+
+    function handleClick(e: MouseEvent) {
+        if (disabled || isLoading) {
+            e.preventDefault()
+            e.stopPropagation()
+            return
+        }
+
+        if (typeof onclick === 'function') {
+            const result = (onclick as (e: MouseEvent) => unknown)(e)
+
+            if (loadingAuto && result instanceof Promise) {
+                autoLoading = true
+                pendingPromise = result
+                result.then(
+                    () => {
+                        if (pendingPromise === result) autoLoading = false
+                    },
+                    () => {
+                        if (pendingPromise === result) autoLoading = false
+                    }
+                )
+            }
+        }
+    }
 </script>
 
-<Button.Root bind:ref class={classes.base} disabled={disabled || loading} {...restProps}>
+<Link
+    {...restProps}
+    bind:ref
+    {href}
+    {type}
+    {external}
+    {active}
+    {exact}
+    {activeClass}
+    {inactiveClass}
+    raw
+    disabled={disabled || isLoading}
+    class={classes.base}
+    onclick={handleClick}
+>
     {#if leadingSlot}
         {@render leadingSlot()}
     {:else if isLeading && leadingIconName}
@@ -118,4 +175,4 @@
     {:else if isTrailing && trailingIconName}
         <Icon name={trailingIconName} class={classes.trailingIcon} />
     {/if}
-</Button.Root>
+</Link>

--- a/src/lib/Button/Button.svelte.spec.ts
+++ b/src/lib/Button/Button.svelte.spec.ts
@@ -339,6 +339,113 @@ describe('Button', () => {
         })
     })
 
+    // ==================== LINK RENDERING ====================
+
+    describe('link rendering', () => {
+        it('should render as anchor when href is provided', async () => {
+            render(Button, { label: 'Go', href: '/about' })
+            const link = page.getByRole('link', { name: 'Go' })
+            await expect.element(link).toBeInTheDocument()
+            await expect.element(link).toHaveAttribute('href', '/about')
+        })
+
+        it('should render as button when no href', async () => {
+            render(Button, { label: 'Click' })
+            const btn = page.getByRole('button', { name: 'Click' })
+            await expect.element(btn).toBeInTheDocument()
+        })
+
+        it('should add external attributes for external links', async () => {
+            render(Button, { label: 'External', href: 'https://example.com' })
+            const link = page.getByRole('link', { name: 'External' })
+            await expect.element(link).toHaveAttribute('target', '_blank')
+            await expect.element(link).toHaveAttribute('rel', 'noopener noreferrer')
+        })
+
+        it('should render with type="submit" when no href', async () => {
+            render(Button, { label: 'Submit', type: 'submit' })
+            const btn = page.getByRole('button', { name: 'Submit' })
+            await expect.element(btn).toHaveAttribute('type', 'submit')
+        })
+
+        it('should disable anchor link when disabled', async () => {
+            render(Button, { label: 'Disabled Link', href: '/about', disabled: true })
+            const link = page.getByRole('link', { name: 'Disabled Link' })
+            await expect.element(link).toHaveAttribute('aria-disabled', 'true')
+            await expect.element(link).not.toHaveAttribute('href')
+        })
+    })
+
+    // ==================== LOADING AUTO ====================
+
+    describe('loadingAuto', () => {
+        it('should show loading state while onclick Promise is pending', async () => {
+            let resolvePromise: () => void
+            const onclick = vi.fn(
+                () =>
+                    new Promise<void>((resolve) => {
+                        resolvePromise = resolve
+                    })
+            )
+            render(Button, { label: 'Auto', loadingAuto: true, onclick })
+            const btn = page.getByRole('button', { name: 'Auto' })
+            await btn.click()
+            expect(onclick).toHaveBeenCalledOnce()
+            // After click, button should be disabled (loading)
+            await expect.element(btn).toBeDisabled()
+            // Resolve the promise
+            resolvePromise!()
+            // After resolve, button should be enabled again
+            await expect.element(btn).toBeEnabled()
+        })
+
+        it('should not auto-load when loadingAuto is false', async () => {
+            const onclick = vi.fn(() => new Promise<void>(() => {}))
+            render(Button, { label: 'No Auto', onclick })
+            const btn = page.getByRole('button', { name: 'No Auto' })
+            await btn.click()
+            await expect.element(btn).toBeEnabled()
+        })
+    })
+
+    // ==================== ACTIVE COLOR/VARIANT ====================
+
+    describe('active color and variant', () => {
+        it('should apply activeColor when active', async () => {
+            render(Button, {
+                label: 'Active',
+                active: true,
+                color: 'primary',
+                activeColor: 'error'
+            })
+            const btn = page.getByRole('button', { name: 'Active' })
+            await expect.element(btn).toHaveClass(/bg-error/)
+        })
+
+        it('should apply activeVariant when active', async () => {
+            render(Button, {
+                label: 'Active',
+                active: true,
+                variant: 'solid',
+                activeVariant: 'outline'
+            })
+            const btn = page.getByRole('button', { name: 'Active' })
+            await expect.element(btn).toHaveClass(/ring-primary/)
+        })
+
+        it('should use default color/variant when not active', async () => {
+            render(Button, {
+                label: 'Inactive',
+                active: false,
+                color: 'primary',
+                activeColor: 'error'
+            })
+            const btn = page.getByRole('button', { name: 'Inactive' })
+            await expect.element(btn).toHaveClass(/bg-primary/)
+            await expect.element(btn).not.toHaveClass(/bg-error/)
+        })
+    })
+
     // ==================== COMBINED PROPS ====================
 
     describe('combined props', () => {
@@ -365,6 +472,18 @@ describe('Button', () => {
             const btn = page.getByRole('button', { name: 'Saving' })
             await expect.element(btn).toBeDisabled()
             await expect.element(btn).toHaveTextContent('Saving')
+        })
+
+        it('should render as link with variant and color', async () => {
+            render(Button, {
+                label: 'Link Button',
+                href: '/dashboard',
+                variant: 'outline',
+                color: 'success'
+            })
+            const link = page.getByRole('link', { name: 'Link Button' })
+            await expect.element(link).toHaveAttribute('href', '/dashboard')
+            await expect.element(link).toHaveClass(/ring-success/)
         })
     })
 })

--- a/src/lib/Button/button.types.ts
+++ b/src/lib/Button/button.types.ts
@@ -1,10 +1,15 @@
 import type { Snippet } from 'svelte'
-import type { Button } from 'bits-ui'
+import type { HTMLAttributes } from 'svelte/elements'
 import type { ClassNameValue } from 'tailwind-merge'
 import type { ButtonVariantProps, ButtonSlots } from './button.variants.js'
 import type { AvatarProps } from '../Avatar/avatar.types.js'
 
-export type ButtonProps = Button.RootProps & {
+export type ButtonProps = Omit<HTMLAttributes<HTMLElement>, 'class' | 'color'> & {
+    /**
+     * Bindable reference to the root DOM element.
+     */
+    ref?: HTMLElement | null
+
     /**
      * Controls the visual style of the button.
      * @default 'solid'
@@ -36,11 +41,23 @@ export type ButtonProps = Button.RootProps & {
     loading?: boolean
 
     /**
+     * Automatically shows loading state while the onclick handler's Promise is pending.
+     * @default false
+     */
+    loadingAuto?: boolean
+
+    /**
      * Icon displayed as the loading indicator.
      * Supports any valid Iconify icon name.
      * @default Uses `icons.loading` from app config
      */
     loadingIcon?: string
+
+    /**
+     * Disables the button and prevents interaction.
+     * @default false
+     */
+    disabled?: boolean
 
     /**
      * Stretches the button to fill the full width of its container.
@@ -85,6 +102,60 @@ export type ButtonProps = Button.RootProps & {
      */
     avatar?: AvatarProps
 
+    // ==================== LINK PROPS ====================
+
+    /**
+     * The destination URL. When provided, renders as an anchor element.
+     */
+    href?: string
+
+    /**
+     * The button type attribute. Only applies when rendering as `<button>`.
+     * @default 'button'
+     */
+    type?: 'button' | 'submit' | 'reset'
+
+    /**
+     * Treats the link as external, adding `rel="noopener noreferrer"` and `target="_blank"`.
+     * Auto-detected from the `href` when omitted.
+     */
+    external?: boolean
+
+    /**
+     * Overrides the auto-detected active state.
+     */
+    active?: boolean
+
+    /**
+     * Requires an exact pathname match for active state detection.
+     * @default false
+     */
+    exact?: boolean
+
+    /**
+     * Color scheme applied when the button is active.
+     * Falls back to the `color` prop when omitted.
+     */
+    activeColor?: NonNullable<ButtonVariantProps['color']>
+
+    /**
+     * Visual style applied when the button is active.
+     * Falls back to the `variant` prop when omitted.
+     */
+    activeVariant?: NonNullable<ButtonVariantProps['variant']>
+
+    /**
+     * Additional CSS class applied when the button link is active.
+     */
+    activeClass?: string
+
+    /**
+     * Additional CSS class applied when the button link is inactive.
+     */
+    inactiveClass?: string
+
+    // ==================== SLOTS & STYLING ====================
+
     /**
      * Custom content rendered before the label.
      * Takes precedence over `avatar` and `leadingIcon`.
@@ -96,6 +167,11 @@ export type ButtonProps = Button.RootProps & {
      * Takes precedence over `trailingIcon`.
      */
     trailingSlot?: Snippet
+
+    /**
+     * Custom content for the button label area.
+     */
+    children?: Snippet
 
     /**
      * Additional CSS classes for the root element.

--- a/src/lib/Link/Link.svelte
+++ b/src/lib/Link/Link.svelte
@@ -28,11 +28,15 @@
         if (mode === false) return true
         if (mode === 'partial') {
             for (const [key, value] of linkQuery) {
-                if (currentQuery.get(key) !== value) return false
+                if (!currentQuery.getAll(key).includes(value)) return false
             }
             return true
         }
-        return linkQuery.toString() === currentQuery.toString()
+
+        // Exact: check size first (O(1) bail-out), then compare sorted strings
+        if (linkQuery.size !== currentQuery.size) return false
+        const sorted = (p: URLSearchParams) => new URLSearchParams([...p].sort()).toString()
+        return sorted(linkQuery) === sorted(currentQuery)
     }
 
     function isPathnameMatch(linkPath: string, currentPath: string, exactMatch: boolean): boolean {
@@ -54,7 +58,7 @@
 
     let {
         href,
-        color = config.defaultVariants.color,
+        type,
         active,
         exact = false,
         exactQuery = false,
@@ -69,25 +73,36 @@
         ui,
         target,
         rel,
+        onclick,
         ...restProps
     }: Props = $props()
 
+    const isLink = $derived(!!href)
+
     const isExternal = $derived(
-        external ??
-            (href.startsWith('http://') || href.startsWith('https://') || href.startsWith('//'))
+        isLink &&
+            (external ??
+                (href!.startsWith('http://') ||
+                    href!.startsWith('https://') ||
+                    href!.startsWith('//')))
     )
 
-    const resolvedTarget = $derived(target ?? (isExternal ? '_blank' : undefined))
+    const resolvedTarget = $derived(
+        isLink ? (target ?? (isExternal ? '_blank' : undefined)) : undefined
+    )
 
     const resolvedRel = $derived(
-        rel ?? (isExternal || resolvedTarget === '_blank' ? 'noopener noreferrer' : undefined)
+        isLink
+            ? (rel ??
+                  (isExternal || resolvedTarget === '_blank' ? 'noopener noreferrer' : undefined))
+            : undefined
     )
 
     const isActive = $derived.by(() => {
         if (active !== undefined) return active
-        if (!page.url || isExternal) return false
+        if (!isLink || !page.url || isExternal) return false
 
-        const link = parseUrl(href, page.url)
+        const link = parseUrl(href!, page.url)
 
         if (exactHash && link.hash !== page.url.hash) return false
         if (!isQueryMatch(link.query, page.url.searchParams, exactQuery)) return false
@@ -99,24 +114,51 @@
         const stateClass = isActive ? activeClass : inactiveClass
         if (raw) return [className, stateClass].filter(Boolean).join(' ')
 
-        const slots = linkVariants({ color, active: isActive, disabled, raw })
+        const slots = linkVariants({ active: isActive, disabled, raw })
         return slots.base({ class: [config.slots.base, stateClass, className, ui?.base] })
     })
 
     const ariaCurrent = $derived(isActive && exact ? ('page' as const) : undefined)
+
+    function handleClick(e: MouseEvent) {
+        if (disabled) {
+            e.preventDefault()
+            e.stopPropagation()
+            return
+        }
+
+        if (typeof onclick === 'function') {
+            ;(onclick as (e: MouseEvent) => void)(e)
+        }
+    }
 </script>
 
-<!-- eslint-disable svelte/no-navigation-without-resolve -->
-<a
-    href={disabled ? undefined : href}
-    class={baseClass}
-    target={resolvedTarget}
-    rel={resolvedRel}
-    aria-disabled={disabled ? 'true' : undefined}
-    aria-current={ariaCurrent}
-    tabindex={disabled ? -1 : undefined}
-    {...restProps}
->
-    <!-- eslint-enable svelte/no-navigation-without-resolve -->
-    {@render children?.()}
-</a>
+{#if isLink}
+    <!-- eslint-disable svelte/no-navigation-without-resolve -->
+    <a
+        href={disabled ? undefined : href}
+        class={baseClass}
+        target={resolvedTarget}
+        rel={resolvedRel}
+        role={disabled ? 'link' : undefined}
+        aria-disabled={disabled ? 'true' : undefined}
+        aria-current={ariaCurrent}
+        tabindex={disabled ? -1 : undefined}
+        onclick={handleClick}
+        {...restProps}
+    >
+        <!-- eslint-enable svelte/no-navigation-without-resolve -->
+        {@render children?.()}
+    </a>
+{:else}
+    <button
+        type={type ?? 'button'}
+        class={baseClass}
+        {disabled}
+        aria-current={ariaCurrent}
+        onclick={handleClick}
+        {...restProps}
+    >
+        {@render children?.()}
+    </button>
+{/if}

--- a/src/lib/Link/Link.svelte
+++ b/src/lib/Link/Link.svelte
@@ -28,11 +28,15 @@
         if (mode === false) return true
         if (mode === 'partial') {
             for (const [key, value] of linkQuery) {
-                if (currentQuery.get(key) !== value) return false
+                if (!currentQuery.getAll(key).includes(value)) return false
             }
             return true
         }
-        return linkQuery.toString() === currentQuery.toString()
+
+        // Exact: check size first (O(1) bail-out), then compare sorted strings
+        if (linkQuery.size !== currentQuery.size) return false
+        const sorted = (p: URLSearchParams) => new URLSearchParams([...p].sort()).toString()
+        return sorted(linkQuery) === sorted(currentQuery)
     }
 
     function isPathnameMatch(linkPath: string, currentPath: string, exactMatch: boolean): boolean {
@@ -53,8 +57,9 @@
     const config = getComponentConfig('link', linkDefaults)
 
     let {
+        ref = $bindable(null),
         href,
-        color = config.defaultVariants.color,
+        type,
         active,
         exact = false,
         exactQuery = false,
@@ -69,25 +74,36 @@
         ui,
         target,
         rel,
+        onclick,
         ...restProps
     }: Props = $props()
 
+    const isLink = $derived(!!href)
+
     const isExternal = $derived(
-        external ??
-            (href.startsWith('http://') || href.startsWith('https://') || href.startsWith('//'))
+        isLink &&
+            (external ??
+                (href!.startsWith('http://') ||
+                    href!.startsWith('https://') ||
+                    href!.startsWith('//')))
     )
 
-    const resolvedTarget = $derived(target ?? (isExternal ? '_blank' : undefined))
+    const resolvedTarget = $derived(
+        isLink ? (target ?? (isExternal ? '_blank' : undefined)) : undefined
+    )
 
     const resolvedRel = $derived(
-        rel ?? (isExternal || resolvedTarget === '_blank' ? 'noopener noreferrer' : undefined)
+        isLink
+            ? (rel ??
+                  (isExternal || resolvedTarget === '_blank' ? 'noopener noreferrer' : undefined))
+            : undefined
     )
 
     const isActive = $derived.by(() => {
         if (active !== undefined) return active
-        if (!page.url || isExternal) return false
+        if (!isLink || !page.url || isExternal) return false
 
-        const link = parseUrl(href, page.url)
+        const link = parseUrl(href!, page.url)
 
         if (exactHash && link.hash !== page.url.hash) return false
         if (!isQueryMatch(link.query, page.url.searchParams, exactQuery)) return false
@@ -99,24 +115,53 @@
         const stateClass = isActive ? activeClass : inactiveClass
         if (raw) return [className, stateClass].filter(Boolean).join(' ')
 
-        const slots = linkVariants({ color, active: isActive, disabled, raw })
+        const slots = linkVariants({ active: isActive, disabled, raw })
         return slots.base({ class: [config.slots.base, stateClass, className, ui?.base] })
     })
 
     const ariaCurrent = $derived(isActive && exact ? ('page' as const) : undefined)
+
+    function handleClick(e: MouseEvent) {
+        if (disabled) {
+            e.preventDefault()
+            e.stopPropagation()
+            return
+        }
+
+        if (typeof onclick === 'function') {
+            ;(onclick as (e: MouseEvent) => void)(e)
+        }
+    }
 </script>
 
-<!-- eslint-disable svelte/no-navigation-without-resolve -->
-<a
-    href={disabled ? undefined : href}
-    class={baseClass}
-    target={resolvedTarget}
-    rel={resolvedRel}
-    aria-disabled={disabled ? 'true' : undefined}
-    aria-current={ariaCurrent}
-    tabindex={disabled ? -1 : undefined}
-    {...restProps}
->
-    <!-- eslint-enable svelte/no-navigation-without-resolve -->
-    {@render children?.()}
-</a>
+{#if isLink}
+    <!-- eslint-disable svelte/no-navigation-without-resolve -->
+    <a
+        bind:this={ref}
+        href={disabled ? undefined : href}
+        class={baseClass}
+        target={resolvedTarget}
+        rel={resolvedRel}
+        role={disabled ? 'link' : undefined}
+        aria-disabled={disabled ? 'true' : undefined}
+        aria-current={ariaCurrent}
+        tabindex={disabled ? -1 : undefined}
+        onclick={handleClick}
+        {...restProps}
+    >
+        <!-- eslint-enable svelte/no-navigation-without-resolve -->
+        {@render children?.()}
+    </a>
+{:else}
+    <button
+        bind:this={ref}
+        type={type ?? 'button'}
+        class={baseClass}
+        {disabled}
+        aria-current={ariaCurrent}
+        onclick={handleClick}
+        {...restProps}
+    >
+        {@render children?.()}
+    </button>
+{/if}

--- a/src/lib/Link/Link.svelte.spec.ts
+++ b/src/lib/Link/Link.svelte.spec.ts
@@ -7,22 +7,38 @@ describe('Link', () => {
     // ==================== RENDERING ====================
 
     describe('rendering', () => {
-        it('should render an anchor element', async () => {
+        it('should render an anchor element when href is provided', async () => {
             const { container } = render(Link, { href: '/', active: false })
             const el = container.querySelector('a')
             expect(el).not.toBeNull()
         })
 
-        it('should render as <a> tag', async () => {
+        it('should render as <a> tag when href is provided', async () => {
             const { container } = render(Link, { href: '/', active: false })
             expect(container.firstElementChild!.tagName).toBe('A')
+        })
+
+        it('should render as <button> tag when no href is provided', async () => {
+            const { container } = render(Link, { active: false })
+            expect(container.firstElementChild!.tagName).toBe('BUTTON')
+        })
+
+        it('should render button with type="button" by default', async () => {
+            const { container } = render(Link, { active: false })
+            const el = page.elementLocator(container.firstElementChild!)
+            await expect.element(el).toHaveAttribute('type', 'button')
+        })
+
+        it('should render button with custom type', async () => {
+            const { container } = render(Link, { type: 'submit', active: false })
+            const el = page.elementLocator(container.firstElementChild!)
+            await expect.element(el).toHaveAttribute('type', 'submit')
         })
 
         it('should apply base classes', async () => {
             const { container } = render(Link, { href: '/', active: false })
             const el = page.elementLocator(container.firstElementChild!)
-            await expect.element(el).toHaveClass(/inline-flex/)
-            await expect.element(el).toHaveClass(/items-center/)
+            await expect.element(el).toHaveClass(/focus-visible:outline-primary/)
         })
     })
 
@@ -42,55 +58,25 @@ describe('Link', () => {
         })
     })
 
-    // ==================== COLORS ====================
-
-    describe('colors', () => {
-        const colors = [
-            'primary',
-            'secondary',
-            'tertiary',
-            'success',
-            'warning',
-            'error',
-            'info'
-        ] as const
-
-        for (const color of colors) {
-            it(`should apply ${color} color when active`, async () => {
-                const { container } = render(Link, { href: '/', color, active: true })
-                const el = page.elementLocator(container.firstElementChild!)
-                await expect.element(el).toHaveClass(new RegExp(`text-${color}`))
-            })
-        }
-
-        for (const color of colors) {
-            it(`should apply ${color}/80 color when inactive`, async () => {
-                const { container } = render(Link, { href: '/', color, active: false })
-                const el = page.elementLocator(container.firstElementChild!)
-                await expect.element(el).toHaveClass(new RegExp(`text-${color}\\/80`))
-            })
-        }
-
-        it('should default to primary color', async () => {
-            const { container } = render(Link, { href: '/', active: true })
-            const el = page.elementLocator(container.firstElementChild!)
-            await expect.element(el).toHaveClass(/text-primary/)
-        })
-    })
-
     // ==================== ACTIVE STATE ====================
 
     describe('active state', () => {
         it('should apply active styles when active=true', async () => {
-            const { container } = render(Link, { href: '/', active: true, color: 'primary' })
+            const { container } = render(Link, { href: '/', active: true })
             const el = page.elementLocator(container.firstElementChild!)
             await expect.element(el).toHaveClass(/text-primary/)
         })
 
         it('should apply inactive styles when active=false', async () => {
-            const { container } = render(Link, { href: '/', active: false, color: 'primary' })
+            const { container } = render(Link, { href: '/', active: false })
             const el = page.elementLocator(container.firstElementChild!)
-            await expect.element(el).toHaveClass(/text-primary\/80/)
+            await expect.element(el).toHaveClass(/text-on-surface-variant/)
+        })
+
+        it('should apply active styles on button when active=true', async () => {
+            const { container } = render(Link, { active: true })
+            const el = page.elementLocator(container.firstElementChild!)
+            await expect.element(el).toHaveClass(/text-primary/)
         })
 
         it('should apply activeClass when active', async () => {
@@ -137,16 +123,29 @@ describe('Link', () => {
     // ==================== DISABLED ====================
 
     describe('disabled', () => {
-        it('should set aria-disabled="true" when disabled', async () => {
+        it('should set aria-disabled="true" when disabled (link)', async () => {
             const { container } = render(Link, { href: '/', disabled: true, active: false })
             const el = page.elementLocator(container.firstElementChild!)
             await expect.element(el).toHaveAttribute('aria-disabled', 'true')
         })
 
-        it('should set tabindex="-1" when disabled', async () => {
+        it('should set role="link" on disabled anchor', async () => {
+            const { container } = render(Link, { href: '/', disabled: true, active: false })
+            const el = page.elementLocator(container.firstElementChild!)
+            await expect.element(el).toHaveAttribute('role', 'link')
+        })
+
+        it('should set tabindex="-1" when disabled (link)', async () => {
             const { container } = render(Link, { href: '/', disabled: true, active: false })
             const el = page.elementLocator(container.firstElementChild!)
             await expect.element(el).toHaveAttribute('tabindex', '-1')
+        })
+
+        it('should use native disabled attribute on button', async () => {
+            const { container } = render(Link, { disabled: true, active: false })
+            const el = container.firstElementChild! as HTMLButtonElement
+            expect(el.tagName).toBe('BUTTON')
+            expect(el.disabled).toBe(true)
         })
 
         it('should apply disabled styling classes', async () => {
@@ -233,8 +232,8 @@ describe('Link', () => {
         it('should strip default variant classes in raw mode', async () => {
             const { container } = render(Link, { href: '/', raw: true, active: false })
             const el = container.firstElementChild!
-            expect(el.className).not.toMatch(/inline-flex/)
             expect(el.className).not.toMatch(/text-primary/)
+            expect(el.className).not.toMatch(/text-on-surface-variant/)
         })
 
         it('should still apply custom class in raw mode', async () => {
@@ -327,13 +326,12 @@ describe('Link', () => {
         it('should render active link with custom classes', async () => {
             const { container } = render(Link, {
                 href: '/',
-                color: 'success',
                 active: true,
                 activeClass: 'font-semibold',
                 class: 'underline'
             })
             const el = page.elementLocator(container.firstElementChild!)
-            await expect.element(el).toHaveClass(/text-success/)
+            await expect.element(el).toHaveClass(/text-primary/)
             await expect.element(el).toHaveClass(/font-semibold/)
             await expect.element(el).toHaveClass(/underline/)
         })
@@ -350,6 +348,19 @@ describe('Link', () => {
             // href should be removed when disabled
             const anchor = container.firstElementChild!
             expect(anchor.hasAttribute('href')).toBe(false)
+        })
+
+        it('should render button with active state and custom class', async () => {
+            const { container } = render(Link, {
+                active: true,
+                activeClass: 'font-bold',
+                class: 'px-4'
+            })
+            const el = page.elementLocator(container.firstElementChild!)
+            expect(container.firstElementChild!.tagName).toBe('BUTTON')
+            await expect.element(el).toHaveClass(/text-primary/)
+            await expect.element(el).toHaveClass(/font-bold/)
+            await expect.element(el).toHaveClass(/px-4/)
         })
     })
 })

--- a/src/lib/Link/link.types.ts
+++ b/src/lib/Link/link.types.ts
@@ -1,18 +1,19 @@
-import type { HTMLAnchorAttributes } from 'svelte/elements'
-import type { LinkVariantProps, LinkSlots } from './link.variants.js'
+import type { Snippet } from 'svelte'
+import type { HTMLAttributes } from 'svelte/elements'
+import type { LinkSlots } from './link.variants.js'
 import type { ClassNameValue } from 'tailwind-merge'
 
-export type LinkProps = Omit<HTMLAnchorAttributes, 'class' | 'href'> & {
+export type LinkProps = Omit<HTMLAttributes<HTMLElement>, 'class'> & {
     /**
-     * The destination URL for the anchor element.
+     * Bindable reference to the root DOM element.
      */
-    href: string
+    ref?: HTMLElement | null
 
     /**
-     * Sets the color scheme applied to the link.
-     * @default 'primary'
+     * The destination URL for the anchor element.
+     * When omitted, renders as a `<button>` element.
      */
-    color?: NonNullable<LinkVariantProps['color']>
+    href?: string
 
     /**
      * Overrides the auto-detected active state.
@@ -70,6 +71,22 @@ export type LinkProps = Omit<HTMLAnchorAttributes, 'class' | 'href'> & {
     external?: boolean
 
     /**
+     * The button type attribute. Only applies when rendering as `<button>`.
+     * @default 'button'
+     */
+    type?: 'button' | 'submit' | 'reset'
+
+    /**
+     * The link target attribute. Only applies when rendering as `<a>`.
+     */
+    target?: string
+
+    /**
+     * The link rel attribute. Only applies when rendering as `<a>`.
+     */
+    rel?: string
+
+    /**
      * Additional CSS classes for the root element.
      */
     class?: ClassNameValue
@@ -78,4 +95,9 @@ export type LinkProps = Omit<HTMLAnchorAttributes, 'class' | 'href'> & {
      * Override styles for specific link slots.
      */
     ui?: Partial<Record<LinkSlots, ClassNameValue>>
+
+    /**
+     * Content rendered inside the link.
+     */
+    children?: Snippet
 }

--- a/src/lib/Link/link.types.ts
+++ b/src/lib/Link/link.types.ts
@@ -1,18 +1,17 @@
-import type { HTMLAnchorAttributes } from 'svelte/elements'
-import type { LinkVariantProps, LinkSlots } from './link.variants.js'
+import type { Snippet } from 'svelte'
+import type { HTMLAnchorAttributes, HTMLButtonAttributes } from 'svelte/elements'
+import type { LinkSlots } from './link.variants.js'
 import type { ClassNameValue } from 'tailwind-merge'
 
-export type LinkProps = Omit<HTMLAnchorAttributes, 'class' | 'href'> & {
+export type LinkProps = Omit<
+    HTMLAnchorAttributes & HTMLButtonAttributes,
+    'class' | 'href' | 'type' | 'disabled'
+> & {
     /**
      * The destination URL for the anchor element.
+     * When omitted, renders as a `<button>` element.
      */
-    href: string
-
-    /**
-     * Sets the color scheme applied to the link.
-     * @default 'primary'
-     */
-    color?: NonNullable<LinkVariantProps['color']>
+    href?: string
 
     /**
      * Overrides the auto-detected active state.
@@ -70,6 +69,12 @@ export type LinkProps = Omit<HTMLAnchorAttributes, 'class' | 'href'> & {
     external?: boolean
 
     /**
+     * The button type attribute. Only applies when rendering as `<button>`.
+     * @default 'button'
+     */
+    type?: 'button' | 'submit' | 'reset'
+
+    /**
      * Additional CSS classes for the root element.
      */
     class?: ClassNameValue
@@ -78,4 +83,9 @@ export type LinkProps = Omit<HTMLAnchorAttributes, 'class' | 'href'> & {
      * Override styles for specific link slots.
      */
     ui?: Partial<Record<LinkSlots, ClassNameValue>>
+
+    /**
+     * Content rendered inside the link.
+     */
+    children?: Snippet
 }

--- a/src/lib/Link/link.variants.ts
+++ b/src/lib/Link/link.variants.ts
@@ -2,25 +2,16 @@ import { tv, type VariantProps } from 'tailwind-variants'
 
 export const linkVariants = tv({
     slots: {
-        base: [
-            'inline-flex items-center',
-            'transition-colors duration-200',
-            'focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary'
-        ]
+        base: 'focus-visible:outline-primary'
     },
     variants: {
-        color: {
-            primary: '',
-            secondary: '',
-            tertiary: '',
-            success: '',
-            warning: '',
-            error: '',
-            info: ''
-        },
         active: {
-            true: '',
-            false: ''
+            true: {
+                base: 'text-primary'
+            },
+            false: {
+                base: 'text-on-surface-variant'
+            }
         },
         disabled: {
             true: {
@@ -34,113 +25,14 @@ export const linkVariants = tv({
         }
     },
     compoundVariants: [
-        // ========== PRIMARY ==========
         {
-            color: 'primary',
-            active: true,
-            raw: false,
-            class: { base: 'text-primary' }
-        },
-        {
-            color: 'primary',
             active: false,
             disabled: false,
             raw: false,
-            class: { base: 'text-primary/80 hover:text-primary' }
-        },
-
-        // ========== SECONDARY ==========
-        {
-            color: 'secondary',
-            active: true,
-            raw: false,
-            class: { base: 'text-secondary' }
-        },
-        {
-            color: 'secondary',
-            active: false,
-            disabled: false,
-            raw: false,
-            class: { base: 'text-secondary/80 hover:text-secondary' }
-        },
-
-        // ========== TERTIARY ==========
-        {
-            color: 'tertiary',
-            active: true,
-            raw: false,
-            class: { base: 'text-tertiary' }
-        },
-        {
-            color: 'tertiary',
-            active: false,
-            disabled: false,
-            raw: false,
-            class: { base: 'text-tertiary/80 hover:text-tertiary' }
-        },
-
-        // ========== SUCCESS ==========
-        {
-            color: 'success',
-            active: true,
-            raw: false,
-            class: { base: 'text-success' }
-        },
-        {
-            color: 'success',
-            active: false,
-            disabled: false,
-            raw: false,
-            class: { base: 'text-success/80 hover:text-success' }
-        },
-
-        // ========== WARNING ==========
-        {
-            color: 'warning',
-            active: true,
-            raw: false,
-            class: { base: 'text-warning' }
-        },
-        {
-            color: 'warning',
-            active: false,
-            disabled: false,
-            raw: false,
-            class: { base: 'text-warning/80 hover:text-warning' }
-        },
-
-        // ========== ERROR ==========
-        {
-            color: 'error',
-            active: true,
-            raw: false,
-            class: { base: 'text-error' }
-        },
-        {
-            color: 'error',
-            active: false,
-            disabled: false,
-            raw: false,
-            class: { base: 'text-error/80 hover:text-error' }
-        },
-
-        // ========== INFO ==========
-        {
-            color: 'info',
-            active: true,
-            raw: false,
-            class: { base: 'text-info' }
-        },
-        {
-            color: 'info',
-            active: false,
-            disabled: false,
-            raw: false,
-            class: { base: 'text-info/80 hover:text-info' }
+            class: { base: 'hover:text-on-surface transition-colors' }
         }
     ],
     defaultVariants: {
-        color: 'primary',
         active: false,
         disabled: false,
         raw: false

--- a/src/lib/ThemeModeButton/theme-mode-button.types.ts
+++ b/src/lib/ThemeModeButton/theme-mode-button.types.ts
@@ -1,10 +1,10 @@
 import type { Snippet } from 'svelte'
-import type { HTMLButtonAttributes } from 'svelte/elements'
+import type { HTMLAttributes } from 'svelte/elements'
 import type { ClassNameValue } from 'tailwind-merge'
 import type { ButtonVariantProps } from '../Button/button.variants.js'
 import type { ThemeModeButtonSlots } from './theme-mode-button.variants.js'
 
-export type ThemeModeButtonProps = Omit<HTMLButtonAttributes, 'children'> & {
+export type ThemeModeButtonProps = Omit<HTMLAttributes<HTMLElement>, 'class' | 'children'> & {
     /**
      * Controls the visual style of the button.
      * @default 'ghost'
@@ -42,6 +42,12 @@ export type ThemeModeButtonProps = Omit<HTMLButtonAttributes, 'children'> & {
      * @default false
      */
     loading?: boolean
+
+    /**
+     * Disables the button and prevents interaction.
+     * @default false
+     */
+    disabled?: boolean
 
     /**
      * Forces equal width and height, ideal for icon-only buttons.

--- a/src/routes/button/+page.svelte
+++ b/src/routes/button/+page.svelte
@@ -19,14 +19,57 @@
     <div class="space-y-2">
         <h1 class="text-2xl font-bold">Button</h1>
         <p class="text-on-surface-variant">
-            Versatile button component with multiple variants, colors, sizes, icons, and loading
-            states.
+            Use the Button component to trigger actions or navigate with
+            <code class="rounded bg-surface-container-highest px-1">href</code>. Supports multiple
+            variants, colors, sizes, icons, avatars, and loading states.
         </p>
     </div>
 
-    <!-- Variants x Colors Matrix -->
+    <!-- Usage -->
     <section class="space-y-3">
-        <h2 class="text-lg font-semibold">Variants & Colors</h2>
+        <h2 class="text-lg font-semibold">Usage</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">label</code> prop or the default
+            slot to set the button text.
+        </p>
+        <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
+            <Button label="Button" />
+        </div>
+    </section>
+
+    <!-- Variant -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Variant</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">variant</code> prop to
+            change the visual style. Defaults to
+            <code class="rounded bg-surface-container-highest px-1">solid</code>.
+        </p>
+        <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
+            {#each variants as variant (variant)}
+                <Button {variant} label={variant[0].toUpperCase() + variant.slice(1)} />
+            {/each}
+        </div>
+    </section>
+
+    <!-- Color -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Color</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">color</code> prop to
+            change the color scheme. Defaults to
+            <code class="rounded bg-surface-container-highest px-1">primary</code>.
+        </p>
+        <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
+            {#each colors as color (color)}
+                <Button {color} label={color[0].toUpperCase() + color.slice(1)} />
+            {/each}
+        </div>
+    </section>
+
+    <!-- Variant x Color Matrix -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Variant & Color Matrix</h2>
         <div class="overflow-x-auto">
             <table class="w-full">
                 <thead>
@@ -61,21 +104,47 @@
         </div>
     </section>
 
-    <!-- Sizes -->
+    <!-- Size -->
     <section class="space-y-3">
-        <h2 class="text-lg font-semibold">Sizes</h2>
+        <h2 class="text-lg font-semibold">Size</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">size</code> prop to
+            change the dimensions. Defaults to
+            <code class="rounded bg-surface-container-highest px-1">md</code>.
+        </p>
         <div class="flex flex-wrap items-end gap-3 rounded-lg bg-surface-container-high p-4">
             {#each sizes as size (size)}
-                <Button variant="solid" color="primary" {size} label={size.toUpperCase()} />
+                <Button {size} label={size.toUpperCase()} />
             {/each}
         </div>
     </section>
 
-    <!-- With Icons -->
+    <!-- Icon -->
     <section class="space-y-3">
-        <h2 class="text-lg font-semibold">With Icons</h2>
+        <h2 class="text-lg font-semibold">Icon</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">icon</code> prop to
+            display an icon in the button. By default the icon is placed on the leading side. Use
+            the
+            <code class="rounded bg-surface-container-highest px-1">trailing</code> prop to move it to
+            the trailing side.
+        </p>
         <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
-            <Button variant="solid" color="primary" leadingIcon="lucide:plus" label="Add Item" />
+            <Button icon="lucide:rocket" label="Launch" />
+            <Button icon="lucide:arrow-right" trailing label="Next" />
+        </div>
+    </section>
+
+    <!-- Leading & Trailing Icon -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Leading & Trailing Icon</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1">leadingIcon</code> and
+            <code class="rounded bg-surface-container-highest px-1">trailingIcon</code> to display icons
+            on both sides simultaneously.
+        </p>
+        <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
+            <Button leadingIcon="lucide:plus" label="Add Item" />
             <Button
                 variant="outline"
                 color="secondary"
@@ -89,16 +158,22 @@
                 trailingIcon="lucide:chevron-down"
                 label="Confirm"
             />
-            <Button variant="ghost" color="error" leadingIcon="lucide:trash-2" label="Delete" />
         </div>
     </section>
 
-    <!-- Icon Only (Square) -->
+    <!-- Square (Icon Only) -->
     <section class="space-y-3">
-        <h2 class="text-lg font-semibold">Icon Only (Square)</h2>
+        <h2 class="text-lg font-semibold">Square</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">square</code> prop to
+            force equal width and height — ideal for icon-only buttons. When only
+            <code class="rounded bg-surface-container-highest px-1">icon</code> is provided without
+            <code class="rounded bg-surface-container-highest px-1">label</code>, the button is
+            automatically treated as icon-only.
+        </p>
         <div class="flex flex-wrap items-end gap-3 rounded-lg bg-surface-container-high p-4">
             {#each sizes as size (size)}
-                <Button variant="solid" color="primary" {size} icon="lucide:plus" square />
+                <Button {size} icon="lucide:plus" square />
             {/each}
             <span class="mx-2 text-on-surface-variant">|</span>
             <Button variant="outline" color="secondary" icon="lucide:settings" square />
@@ -108,72 +183,17 @@
         </div>
     </section>
 
-    <!-- Loading States -->
+    <!-- Avatar -->
     <section class="space-y-3">
-        <h2 class="text-lg font-semibold">Loading States</h2>
-        <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
-            <Button variant="solid" color="primary" loading label="Loading..." />
-            <Button variant="outline" color="secondary" loading label="Processing" />
-            <Button variant="soft" color="success" loading icon="lucide:loader-2" square />
-            <Button variant="solid" color="info" loading trailing label="Uploading" />
-        </div>
-    </section>
-
-    <!-- Disabled States -->
-    <section class="space-y-3">
-        <h2 class="text-lg font-semibold">Disabled States</h2>
-        <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
-            <Button variant="solid" color="primary" disabled label="Disabled" />
-            <Button variant="outline" color="secondary" disabled label="Disabled" />
-            <Button variant="soft" color="success" disabled label="Disabled" />
-            <Button variant="subtle" color="warning" disabled label="Disabled" />
-            <Button variant="ghost" color="error" disabled label="Disabled" />
-            <Button variant="link" color="info" disabled label="Disabled" />
-        </div>
-    </section>
-
-    <!-- Block (Full Width) -->
-    <section class="space-y-3">
-        <h2 class="text-lg font-semibold">Block (Full Width)</h2>
-        <div class="space-y-2 rounded-lg bg-surface-container-high p-4">
-            <Button variant="solid" color="primary" block label="Full Width Button" />
-            <Button
-                variant="outline"
-                color="secondary"
-                block
-                leadingIcon="lucide:mail"
-                trailingIcon="lucide:arrow-right"
-                label="Send Email"
-            />
-        </div>
-    </section>
-
-    <!-- Custom Content -->
-    <section class="space-y-3">
-        <h2 class="text-lg font-semibold">Custom Content (Children Slot)</h2>
-        <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
-            <Button variant="solid" color="primary">
-                <Icon name="lucide:sparkles" size="16" />
-                <span>Custom Content</span>
-            </Button>
-            <Button variant="outline" color="tertiary">
-                <span class="font-bold">Bold</span>
-                <span class="font-light">& Light</span>
-            </Button>
-        </div>
-    </section>
-
-    <!-- With Avatar -->
-    <section class="space-y-3">
-        <h2 class="text-lg font-semibold">With Avatar</h2>
+        <h2 class="text-lg font-semibold">Avatar</h2>
         <p class="text-sm text-on-surface-variant">
-            Use the <code class="rounded bg-surface-container-highest px-1">avatar</code> prop to display
-            an avatar before the label.
+            Use the <code class="rounded bg-surface-container-highest px-1">avatar</code> prop to
+            display an avatar before the label. Takes precedence over
+            <code class="rounded bg-surface-container-highest px-1">leadingIcon</code>.
         </p>
         <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
             <Button
                 variant="soft"
-                color="primary"
                 avatar={{ src: 'https://i.pravatar.cc/150?img=1', alt: 'John' }}
                 label="John Doe"
             />
@@ -193,12 +213,13 @@
             />
         </div>
 
-        <!-- Avatar sizes across button sizes -->
+        <p class="text-sm text-on-surface-variant">
+            The avatar size automatically adapts to the button size.
+        </p>
         <div class="flex flex-wrap items-end gap-3 rounded-lg bg-surface-container-high p-4">
             {#each sizes as size (size)}
                 <Button
                     variant="soft"
-                    color="primary"
                     {size}
                     avatar={{ src: 'https://i.pravatar.cc/150?img=3', alt: 'User' }}
                     label={size.toUpperCase()}
@@ -207,12 +228,210 @@
         </div>
     </section>
 
+    <!-- Loading -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Loading</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">loading</code> prop to
+            show a loading spinner and disable the button. The spinner replaces the leading icon by
+            default. Use
+            <code class="rounded bg-surface-container-highest px-1">trailing</code> to place it on the
+            trailing side.
+        </p>
+        <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
+            <Button loading label="Loading..." />
+            <Button variant="outline" color="secondary" loading label="Processing" />
+            <Button variant="soft" color="success" loading icon="lucide:loader-2" square />
+            <Button variant="solid" color="info" loading trailing label="Uploading" />
+        </div>
+    </section>
+
+    <!-- Loading Auto -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Loading Auto</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">loadingAuto</code> prop
+            to automatically show loading state while the
+            <code class="rounded bg-surface-container-highest px-1">onclick</code> handler's Promise is
+            pending. The button is disabled until the Promise resolves or rejects.
+        </p>
+        <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
+            <Button
+                loadingAuto
+                label="Save (2s)"
+                leadingIcon="lucide:save"
+                onclick={() => new Promise((r) => setTimeout(r, 2000))}
+            />
+            <Button
+                variant="outline"
+                color="secondary"
+                loadingAuto
+                label="Submit (3s)"
+                onclick={() => new Promise((r) => setTimeout(r, 3000))}
+            />
+            <Button
+                variant="soft"
+                color="error"
+                loadingAuto
+                label="Delete (1s)"
+                leadingIcon="lucide:trash-2"
+                onclick={() => new Promise((r) => setTimeout(r, 1000))}
+            />
+        </div>
+    </section>
+
+    <!-- Disabled -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Disabled</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">disabled</code> prop to disable
+            the button and prevent interaction.
+        </p>
+        <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
+            {#each variants as variant (variant)}
+                <Button {variant} disabled label="Disabled" />
+            {/each}
+        </div>
+    </section>
+
+    <!-- Block -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Block</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">block</code> prop to stretch
+            the button to fill the full width of its container.
+        </p>
+        <div class="space-y-2 rounded-lg bg-surface-container-high p-4">
+            <Button block label="Full Width Button" />
+            <Button
+                variant="outline"
+                color="secondary"
+                block
+                leadingIcon="lucide:mail"
+                trailingIcon="lucide:arrow-right"
+                label="Send Email"
+            />
+        </div>
+    </section>
+
+    <!-- As Link -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">As Link</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">href</code> prop to
+            render as an anchor element. External URLs are auto-detected with
+            <code class="rounded bg-surface-container-highest px-1">target="_blank"</code> and
+            <code class="rounded bg-surface-container-highest px-1">rel="noopener noreferrer"</code
+            >. Use the
+            <code class="rounded bg-surface-container-highest px-1">external</code> prop to force this
+            behavior on internal paths.
+        </p>
+        <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
+            <Button href="/link" label="Internal Link" />
+            <Button
+                variant="outline"
+                color="secondary"
+                href="https://svelte.dev"
+                label="External Link"
+                trailingIcon="lucide:external-link"
+            />
+            <Button
+                variant="soft"
+                color="info"
+                href="/button"
+                label="Current Page"
+                leadingIcon="lucide:link"
+            />
+            <Button variant="ghost" color="error" href="/about" disabled label="Disabled Link" />
+        </div>
+    </section>
+
+    <!-- Type -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Type</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">type</code> prop to set
+            the button type attribute. Defaults to
+            <code class="rounded bg-surface-container-highest px-1">button</code>. Only applies when
+            rendering as a &lt;button&gt; element (no
+            <code class="rounded bg-surface-container-highest px-1">href</code>).
+        </p>
+        <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
+            <Button label="Button (default)" />
+            <Button variant="outline" color="success" type="submit" label="Submit" />
+            <Button variant="ghost" color="secondary" type="reset" label="Reset" />
+        </div>
+    </section>
+
+    <!-- Active Color & Variant -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Active Color & Variant</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use
+            <code class="rounded bg-surface-container-highest px-1">activeColor</code> and
+            <code class="rounded bg-surface-container-highest px-1">activeVariant</code> to change
+            the button appearance when
+            <code class="rounded bg-surface-container-highest px-1">active</code> is true. Falls
+            back to the default
+            <code class="rounded bg-surface-container-highest px-1">color</code> and
+            <code class="rounded bg-surface-container-highest px-1">variant</code> when inactive.
+        </p>
+        <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
+            <Button
+                variant="ghost"
+                color="secondary"
+                active
+                activeColor="primary"
+                activeVariant="solid"
+                label="Dashboard"
+                leadingIcon="lucide:home"
+            />
+            <Button
+                variant="ghost"
+                color="secondary"
+                label="Settings"
+                leadingIcon="lucide:settings"
+            />
+            <Button
+                variant="ghost"
+                color="secondary"
+                active
+                activeColor="error"
+                activeVariant="soft"
+                label="Alerts"
+                leadingIcon="lucide:bell"
+            />
+            <Button variant="ghost" color="secondary" label="Profile" leadingIcon="lucide:user" />
+        </div>
+    </section>
+
+    <!-- Children Slot -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Children</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the default slot to render custom content inside the button instead of the
+            <code class="rounded bg-surface-container-highest px-1">label</code> prop.
+        </p>
+        <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
+            <Button>
+                <Icon name="lucide:sparkles" size="16" />
+                <span>Custom Content</span>
+            </Button>
+            <Button variant="outline" color="tertiary">
+                <span class="font-bold">Bold</span>
+                <span class="font-light">& Light</span>
+            </Button>
+        </div>
+    </section>
+
     <!-- Leading & Trailing Slots -->
     <section class="space-y-3">
         <h2 class="text-lg font-semibold">Leading & Trailing Slots</h2>
         <p class="text-sm text-on-surface-variant">
             Use <code class="rounded bg-surface-container-highest px-1">leadingSlot</code> and
-            <code class="rounded bg-surface-container-highest px-1">trailingSlot</code> for custom content.
+            <code class="rounded bg-surface-container-highest px-1">trailingSlot</code> for fully
+            custom leading/trailing content. They take precedence over
+            <code class="rounded bg-surface-container-highest px-1">avatar</code> and icon props.
         </p>
         <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
             {#snippet statusSlot()}
@@ -242,7 +461,7 @@
             {#snippet kbdSlot()}
                 <kbd
                     class="rounded border border-outline-variant bg-surface-container px-1.5 py-0.5 font-mono text-xs text-on-surface-variant"
-                    >⌘K</kbd
+                    >&#8984;K</kbd
                 >
             {/snippet}
             <Button
@@ -255,28 +474,28 @@
         </div>
     </section>
 
-    <!-- UI Prop Overrides -->
+    <!-- UI -->
     <section class="space-y-3">
-        <h2 class="text-lg font-semibold">UI Prop (Class Overrides)</h2>
+        <h2 class="text-lg font-semibold">UI</h2>
         <p class="text-sm text-on-surface-variant">
-            Override classes for specific slots: <code
-                class="rounded bg-surface-container-highest px-1">base</code
-            >,
+            Use the <code class="rounded bg-surface-container-highest px-1">ui</code> prop to
+            override classes for specific slots:
+            <code class="rounded bg-surface-container-highest px-1">base</code>,
             <code class="rounded bg-surface-container-highest px-1">label</code>,
             <code class="rounded bg-surface-container-highest px-1">leadingIcon</code>,
-            <code class="rounded bg-surface-container-highest px-1">trailingIcon</code>.
+            <code class="rounded bg-surface-container-highest px-1">trailingIcon</code>,
+            <code class="rounded bg-surface-container-highest px-1">leadingAvatar</code>.
         </p>
+
+        <p class="text-xs font-medium text-on-surface-variant uppercase">Base slot</p>
         <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
-            <Button variant="solid" color="primary" label="Pill Button" class="rounded-full" />
+            <Button label="Pill Button" class="rounded-full" />
             <Button
-                variant="solid"
                 color="tertiary"
                 label="With Shadow"
                 ui={{ base: 'shadow-lg shadow-tertiary/30' }}
             />
             <Button
-                variant="solid"
-                color="primary"
                 label="Gradient"
                 ui={{
                     base: 'bg-linear-to-r from-primary to-tertiary hover:from-primary/90 hover:to-tertiary/90'
@@ -290,13 +509,9 @@
             />
         </div>
 
+        <p class="text-xs font-medium text-on-surface-variant uppercase">Label slot</p>
         <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
-            <Button
-                variant="solid"
-                color="primary"
-                label="Uppercase"
-                ui={{ label: 'uppercase tracking-wider' }}
-            />
+            <Button label="Uppercase" ui={{ label: 'uppercase tracking-wider' }} />
             <Button
                 variant="outline"
                 color="secondary"
@@ -306,7 +521,6 @@
             <Button variant="soft" color="success" label="monospace" ui={{ label: 'font-mono' }} />
             <Button
                 variant="ghost"
-                color="primary"
                 label="Gradient Text"
                 ui={{
                     label: 'bg-linear-to-r from-primary to-tertiary bg-clip-text text-transparent'
@@ -314,6 +528,7 @@
             />
         </div>
 
+        <p class="text-xs font-medium text-on-surface-variant uppercase">Icon slots</p>
         <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
             <Button
                 variant="outline"
@@ -348,30 +563,69 @@
         </div>
     </section>
 
-    <!-- Real World Examples -->
+    <!-- Examples -->
     <section class="space-y-3">
-        <h2 class="text-lg font-semibold">Real World Examples</h2>
-        <div class="space-y-4 rounded-lg bg-surface-container-high p-4">
-            <!-- Action Bar -->
+        <h2 class="text-lg font-semibold">Examples</h2>
+
+        <!-- Action Bar -->
+        <div class="space-y-2 rounded-lg bg-surface-container-high p-4">
+            <p class="text-xs font-medium text-on-surface-variant uppercase">Action bar</p>
             <div class="flex items-center gap-2">
-                <Button variant="solid" color="primary" leadingIcon="lucide:save" label="Save" />
+                <Button leadingIcon="lucide:save" label="Save" />
                 <Button variant="outline" color="secondary" label="Cancel" />
                 <div class="flex-1"></div>
                 <Button variant="ghost" color="error" leadingIcon="lucide:trash-2" label="Delete" />
             </div>
+        </div>
 
-            <!-- Social Buttons -->
+        <!-- Navigation -->
+        <div class="space-y-2 rounded-lg bg-surface-container-high p-4">
+            <p class="text-xs font-medium text-on-surface-variant uppercase">Navigation</p>
+            <div class="flex items-center gap-1">
+                <Button
+                    variant="ghost"
+                    color="secondary"
+                    active
+                    activeColor="primary"
+                    activeVariant="soft"
+                    href="/button"
+                    label="Dashboard"
+                    leadingIcon="lucide:home"
+                />
+                <Button
+                    variant="ghost"
+                    color="secondary"
+                    href="/link"
+                    label="Links"
+                    leadingIcon="lucide:link"
+                />
+                <Button
+                    variant="ghost"
+                    color="secondary"
+                    href="/settings"
+                    label="Settings"
+                    leadingIcon="lucide:settings"
+                />
+            </div>
+        </div>
+
+        <!-- Social Buttons -->
+        <div class="space-y-2 rounded-lg bg-surface-container-high p-4">
+            <p class="text-xs font-medium text-on-surface-variant uppercase">Social buttons</p>
             <div class="flex items-center gap-2">
                 <Button variant="soft" color="info" leadingIcon="mdi:twitter" label="Tweet" />
-                <Button variant="soft" color="primary" leadingIcon="mdi:facebook" label="Share" />
+                <Button variant="soft" leadingIcon="mdi:facebook" label="Share" />
                 <Button variant="soft" color="tertiary" leadingIcon="mdi:linkedin" label="Post" />
             </div>
+        </div>
 
-            <!-- Pagination -->
+        <!-- Pagination -->
+        <div class="space-y-2 rounded-lg bg-surface-container-high p-4">
+            <p class="text-xs font-medium text-on-surface-variant uppercase">Pagination</p>
             <div class="flex items-center gap-1">
                 <Button variant="ghost" color="secondary" icon="lucide:chevron-left" square />
                 <Button variant="ghost" color="secondary" label="1" />
-                <Button variant="solid" color="primary" label="2" />
+                <Button variant="solid" label="2" />
                 <Button variant="ghost" color="secondary" label="3" />
                 <Button variant="ghost" color="secondary" label="..." />
                 <Button variant="ghost" color="secondary" label="10" />

--- a/src/routes/link/+page.svelte
+++ b/src/routes/link/+page.svelte
@@ -1,100 +1,78 @@
 <script lang="ts">
     import { Link, Icon } from '$lib/index.js'
-
-    const colors = [
-        'primary',
-        'secondary',
-        'tertiary',
-        'success',
-        'warning',
-        'error',
-        'info'
-    ] as const
 </script>
 
 <div class="space-y-8">
     <div class="space-y-2">
         <h1 class="text-2xl font-bold">Link</h1>
         <p class="text-on-surface-variant">
-            Navigation link with automatic active state detection, color variants, and external link
-            handling.
+            Use the Link component to create hyperlinks with automatic active state detection.
+            Renders as an anchor tag when <code class="rounded bg-surface-container-highest px-1"
+                >href</code
+            >
+            is provided, otherwise renders as a button.
         </p>
     </div>
 
-    <!-- Colors -->
+    <!-- Usage -->
     <section class="space-y-3">
-        <h2 class="text-lg font-semibold">Colors</h2>
-        <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
-            {#each colors as color (color)}
-                <Link href="/link" {color}>{color}</Link>
-            {/each}
-        </div>
-    </section>
-
-    <!-- Active State -->
-    <section class="space-y-3">
-        <h2 class="text-lg font-semibold">Active State</h2>
+        <h2 class="text-lg font-semibold">Usage</h2>
         <p class="text-sm text-on-surface-variant">
-            Active state is auto-detected from the current route. Use <code
-                class="rounded bg-surface-container-highest px-1">active</code
-            > to override.
-        </p>
-        <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
-            <Link href="/link" active={true} color="primary">Active (forced)</Link>
-            <Link href="/link" active={false} color="primary">Inactive (forced)</Link>
-            <Link href="/link" color="secondary">Auto-detected</Link>
-        </div>
-    </section>
-
-    <!-- Active with Custom Classes -->
-    <section class="space-y-3">
-        <h2 class="text-lg font-semibold">Active & Inactive Classes</h2>
-        <p class="text-sm text-on-surface-variant">
-            Apply custom classes based on active state using <code
-                class="rounded bg-surface-container-highest px-1">activeClass</code
+            The Link component is styled by default with <code
+                class="rounded bg-surface-container-highest px-1">text-on-surface-variant</code
             >
-            and <code class="rounded bg-surface-container-highest px-1">inactiveClass</code>.
+            when inactive and
+            <code class="rounded bg-surface-container-highest px-1">text-primary</code>
+            when active, with a
+            <code class="rounded bg-surface-container-highest px-1">hover:text-on-surface</code> transition.
         </p>
         <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
-            <Link href="/link" active={true} activeClass="font-bold underline underline-offset-4">
-                Active (bold + underline)
-            </Link>
-            <Link href="/other" inactiveClass="opacity-50">Inactive (dimmed)</Link>
+            <Link href="/link">Link</Link>
         </div>
     </section>
 
-    <!-- Disabled -->
+    <!-- InactiveClass -->
     <section class="space-y-3">
-        <h2 class="text-lg font-semibold">Disabled</h2>
-        <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
-            {#each colors as color (color)}
-                <Link href="/link" {color} disabled>{color}</Link>
-            {/each}
-        </div>
-    </section>
-
-    <!-- External Links -->
-    <section class="space-y-3">
-        <h2 class="text-lg font-semibold">External Links</h2>
+        <h2 class="text-lg font-semibold">InactiveClass</h2>
         <p class="text-sm text-on-surface-variant">
-            External URLs are auto-detected. Adds <code
-                class="rounded bg-surface-container-highest px-1">rel="noopener noreferrer"</code
-            >
-            and <code class="rounded bg-surface-container-highest px-1">target="_blank"</code> automatically.
+            Use the <code class="rounded bg-surface-container-highest px-1">inactiveClass</code> prop
+            to apply additional classes when the link is inactive.
         </p>
         <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
-            <Link href="https://svelte.dev" color="primary">
-                <Icon name="lucide:external-link" size="14" class="mr-1" />
-                Svelte
-            </Link>
-            <Link href="https://tailwindcss.com" color="secondary">
-                <Icon name="lucide:external-link" size="14" class="mr-1" />
-                Tailwind CSS
-            </Link>
-            <Link href="https://github.com" color="tertiary">
-                <Icon name="lucide:external-link" size="14" class="mr-1" />
-                GitHub
-            </Link>
+            <Link href="/non-existent" inactiveClass="opacity-50">Dimmed when inactive</Link>
+            <Link href="/non-existent" inactiveClass="italic">Italic when inactive</Link>
+        </div>
+    </section>
+
+    <!-- ActiveClass -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">ActiveClass</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">activeClass</code> prop to
+            apply additional classes when the link is active.
+        </p>
+        <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
+            <Link href="/link" activeClass="font-bold">Bold when active</Link>
+            <Link href="/link" activeClass="underline underline-offset-4"
+                >Underlined when active</Link
+            >
+            <Link href="/link" activeClass="font-bold underline underline-offset-4"
+                >Bold + underline</Link
+            >
+        </div>
+    </section>
+
+    <!-- Active -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Active</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">active</code> prop to force
+            the active state, overriding auto-detection from the current route.
+        </p>
+        <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
+            <Link href="/link" active={true}>Active (forced)</Link>
+            <Link href="/link" active={false}>Inactive (forced)</Link>
+            <Link href="/link">Auto-detected</Link>
         </div>
     </section>
 
@@ -102,10 +80,11 @@
     <section class="space-y-3">
         <h2 class="text-lg font-semibold">Matching Modes</h2>
         <p class="text-sm text-on-surface-variant">
-            Control how active state is detected using
-            <code class="rounded bg-surface-container-highest px-1">exact</code>,
+            By default, a link is active when the current URL starts with the <code
+                class="rounded bg-surface-container-highest px-1">href</code
+            >. Use <code class="rounded bg-surface-container-highest px-1">exact</code>,
             <code class="rounded bg-surface-container-highest px-1">exactQuery</code>, and
-            <code class="rounded bg-surface-container-highest px-1">exactHash</code>.
+            <code class="rounded bg-surface-container-highest px-1">exactHash</code> to control this behavior.
         </p>
         <div class="overflow-x-auto">
             <table class="w-full text-sm">
@@ -113,7 +92,7 @@
                     <tr class="border-b border-outline-variant">
                         <th class="px-3 py-2 text-left font-medium text-on-surface-variant">Prop</th
                         >
-                        <th class="px-3 py-2 text-left font-medium text-on-surface-variant">Link</th
+                        <th class="px-3 py-2 text-left font-medium text-on-surface-variant">Href</th
                         >
                         <th class="px-3 py-2 text-left font-medium text-on-surface-variant"
                             >Preview</th
@@ -128,9 +107,7 @@
                         <td class="px-3 py-2 font-mono text-xs text-on-surface-variant">default</td>
                         <td class="px-3 py-2 font-mono text-xs">/link</td>
                         <td class="px-3 py-2">
-                            <Link href="/link" color="primary" activeClass="font-semibold"
-                                >Link</Link
-                            >
+                            <Link href="/link" activeClass="font-semibold">Link</Link>
                         </td>
                         <td class="px-3 py-2 text-on-surface-variant"
                             >Prefix match — active if URL starts with href</td
@@ -140,9 +117,7 @@
                         <td class="px-3 py-2 font-mono text-xs text-on-surface-variant">exact</td>
                         <td class="px-3 py-2 font-mono text-xs">/link</td>
                         <td class="px-3 py-2">
-                            <Link href="/link" color="primary" exact activeClass="font-semibold"
-                                >Link (exact)</Link
-                            >
+                            <Link href="/link" exact activeClass="font-semibold">Link (exact)</Link>
                         </td>
                         <td class="px-3 py-2 text-on-surface-variant"
                             >Only active when pathname is exactly "/link"</td
@@ -154,15 +129,26 @@
                         >
                         <td class="px-3 py-2 font-mono text-xs">/link#section</td>
                         <td class="px-3 py-2">
-                            <Link
-                                href="/link#section"
-                                color="success"
-                                exactHash
-                                activeClass="font-semibold">#section</Link
+                            <Link href="/link#section" exactHash activeClass="font-semibold"
+                                >#section</Link
                             >
                         </td>
                         <td class="px-3 py-2 text-on-surface-variant"
                             >Hash must also match for active state</td
+                        >
+                    </tr>
+                    <tr>
+                        <td class="px-3 py-2 font-mono text-xs text-on-surface-variant"
+                            >exactQuery</td
+                        >
+                        <td class="px-3 py-2 font-mono text-xs">/link?tab=1</td>
+                        <td class="px-3 py-2">
+                            <Link href="/link?tab=1" exactQuery activeClass="font-semibold"
+                                >?tab=1</Link
+                            >
+                        </td>
+                        <td class="px-3 py-2 text-on-surface-variant"
+                            >Query params must exactly match</td
                         >
                     </tr>
                 </tbody>
@@ -170,14 +156,33 @@
         </div>
     </section>
 
-    <!-- Raw Mode -->
+    <!-- disabled -->
     <section class="space-y-3">
-        <h2 class="text-lg font-semibold">Raw Mode</h2>
+        <h2 class="text-lg font-semibold">Disabled</h2>
         <p class="text-sm text-on-surface-variant">
-            Strips all default styling. Only <code class="rounded bg-surface-container-highest px-1"
-                >class</code
-            >, <code class="rounded bg-surface-container-highest px-1">activeClass</code>, and
-            <code class="rounded bg-surface-container-highest px-1">inactiveClass</code> apply.
+            Use the <code class="rounded bg-surface-container-highest px-1">disabled</code> prop to
+            disable the link. On anchors, it removes
+            <code class="rounded bg-surface-container-highest px-1">href</code>, sets
+            <code class="rounded bg-surface-container-highest px-1">aria-disabled</code>
+            and
+            <code class="rounded bg-surface-container-highest px-1">role="link"</code>. On buttons,
+            it uses the native disabled attribute.
+        </p>
+        <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
+            <Link href="/link" disabled>Disabled anchor</Link>
+            <Link disabled>Disabled button</Link>
+        </div>
+    </section>
+
+    <!-- Raw -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Raw</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">raw</code> prop to strip
+            all default styling. Only
+            <code class="rounded bg-surface-container-highest px-1">class</code>,
+            <code class="rounded bg-surface-container-highest px-1">activeClass</code>, and
+            <code class="rounded bg-surface-container-highest px-1">inactiveClass</code> are applied.
         </p>
         <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
             <Link
@@ -185,141 +190,256 @@
                 raw
                 class="text-on-surface underline decoration-primary underline-offset-4 hover:decoration-2"
             >
-                Custom styled link
+                Custom styled
             </Link>
             <Link
                 href="/link"
                 raw
                 class="rounded-md bg-primary-container px-3 py-1 text-on-primary-container hover:bg-primary-container/80"
             >
-                Chip-style link
+                Chip style
             </Link>
+            <Link
+                href="/link"
+                raw
+                active={true}
+                activeClass="bg-primary text-on-primary"
+                inactiveClass="bg-surface-container-highest text-on-surface-variant hover:bg-surface-container-high"
+                class="rounded-full px-4 py-1.5 text-sm font-medium transition-colors"
+            >
+                Pill style
+            </Link>
+        </div>
+    </section>
+
+    <!-- External -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">External</h2>
+        <p class="text-sm text-on-surface-variant">
+            External URLs (<code class="rounded bg-surface-container-highest px-1">http://</code>,
+            <code class="rounded bg-surface-container-highest px-1">https://</code>,
+            <code class="rounded bg-surface-container-highest px-1">//</code>) are auto-detected.
+            The component adds
+            <code class="rounded bg-surface-container-highest px-1">target="_blank"</code> and
+            <code class="rounded bg-surface-container-highest px-1">rel="noopener noreferrer"</code>
+            automatically. Use the
+            <code class="rounded bg-surface-container-highest px-1">external</code> prop to force this
+            behavior on internal paths.
+        </p>
+        <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
+            <Link href="https://svelte.dev">
+                <Icon name="lucide:external-link" size="14" class="mr-1" />
+                Svelte (auto)
+            </Link>
+            <Link href="https://tailwindcss.com">
+                <Icon name="lucide:external-link" size="14" class="mr-1" />
+                Tailwind CSS (auto)
+            </Link>
+            <Link href="/api/docs" external>
+                <Icon name="lucide:external-link" size="14" class="mr-1" />
+                API Docs (forced)
+            </Link>
+        </div>
+    </section>
+
+    <!-- Prefetch -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Prefetch</h2>
+        <p class="text-sm text-on-surface-variant">
+            Since the Link component extends native HTML anchor attributes, you can use SvelteKit's
+            <code class="rounded bg-surface-container-highest px-1"
+                >data-sveltekit-preload-data</code
+            >
+            and
+            <code class="rounded bg-surface-container-highest px-1"
+                >data-sveltekit-preload-code</code
+            >
+            attributes to control prefetching behavior.
+        </p>
+        <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
+            <Link href="/link" data-sveltekit-preload-data="hover">Preload on hover</Link>
+            <Link href="/link" data-sveltekit-preload-data="tap">Preload on tap</Link>
+            <Link href="/link" data-sveltekit-preload-data="off">No preload</Link>
+            <Link href="/link" data-sveltekit-preload-code="eager">Preload code eagerly</Link>
+        </div>
+    </section>
+
+    <!-- As Button -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">As Button</h2>
+        <p class="text-sm text-on-surface-variant">
+            When no <code class="rounded bg-surface-container-highest px-1">href</code> is provided,
+            the component renders a button element with
+            <code class="rounded bg-surface-container-highest px-1">type="button"</code> by default.
+            Use the <code class="rounded bg-surface-container-highest px-1">type</code> prop to change
+            the button type.
+        </p>
+        <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
+            <Link onclick={() => alert('Clicked!')}>Click action</Link>
+            <Link type="submit">Submit type</Link>
+            <Link type="reset">Reset type</Link>
         </div>
     </section>
 
     <!-- UI Slot Overrides -->
     <section class="space-y-3">
-        <h2 class="text-lg font-semibold">UI Slot Overrides</h2>
+        <h2 class="text-lg font-semibold">UI</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">ui</code> prop to override
+            styles on specific slots.
+        </p>
         <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
-            <Link
-                href="/link"
-                color="primary"
-                ui={{ base: 'underline underline-offset-4 decoration-2' }}
-            >
+            <Link href="/link" ui={{ base: 'underline underline-offset-4 decoration-2' }}>
                 Underlined
             </Link>
-            <Link href="/link" color="success" ui={{ base: 'font-bold text-lg' }}>
-                Bold & Large
-            </Link>
-            <Link
-                href="/link"
-                color="error"
-                ui={{ base: 'uppercase tracking-wider text-xs font-semibold' }}
-            >
+            <Link href="/link" ui={{ base: 'font-bold text-lg' }}>Bold & Large</Link>
+            <Link href="/link" ui={{ base: 'uppercase tracking-wider text-xs font-semibold' }}>
                 Uppercase
             </Link>
         </div>
     </section>
 
-    <!-- Colors x State Matrix -->
+    <!-- States Overview -->
     <section class="space-y-3">
-        <h2 class="text-lg font-semibold">Colors x State</h2>
+        <h2 class="text-lg font-semibold">States</h2>
         <div class="overflow-x-auto">
             <table class="w-full">
                 <thead>
                     <tr class="border-b border-outline-variant">
                         <th class="px-3 py-3 text-left text-sm font-medium text-on-surface-variant"
-                            >Color</th
+                            >State</th
                         >
                         <th class="px-3 py-3 text-left text-sm font-medium text-on-surface-variant"
-                            >Default</th
+                            >&lt;a&gt;</th
                         >
                         <th class="px-3 py-3 text-left text-sm font-medium text-on-surface-variant"
-                            >Active</th
-                        >
-                        <th class="px-3 py-3 text-left text-sm font-medium text-on-surface-variant"
-                            >Disabled</th
+                            >&lt;button&gt;</th
                         >
                     </tr>
                 </thead>
                 <tbody>
-                    {#each colors as color (color)}
-                        <tr class="border-b border-outline-variant/50">
-                            <td
-                                class="px-3 py-3 text-sm font-medium text-on-surface-variant capitalize"
-                                >{color}</td
-                            >
-                            <td class="px-3 py-3">
-                                <Link href="/demo" {color}>Link text</Link>
-                            </td>
-                            <td class="px-3 py-3">
-                                <Link href="/link" {color} active={true}>Link text</Link>
-                            </td>
-                            <td class="px-3 py-3">
-                                <Link href="/link" {color} disabled>Link text</Link>
-                            </td>
-                        </tr>
-                    {/each}
+                    <tr class="border-b border-outline-variant/50">
+                        <td class="px-3 py-3 text-sm font-medium text-on-surface-variant"
+                            >Default</td
+                        >
+                        <td class="px-3 py-3">
+                            <Link href="/demo">Link text</Link>
+                        </td>
+                        <td class="px-3 py-3">
+                            <Link>Button text</Link>
+                        </td>
+                    </tr>
+                    <tr class="border-b border-outline-variant/50">
+                        <td class="px-3 py-3 text-sm font-medium text-on-surface-variant">Active</td
+                        >
+                        <td class="px-3 py-3">
+                            <Link href="/link" active={true}>Link text</Link>
+                        </td>
+                        <td class="px-3 py-3">
+                            <Link active={true}>Button text</Link>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="px-3 py-3 text-sm font-medium text-on-surface-variant"
+                            >Disabled</td
+                        >
+                        <td class="px-3 py-3">
+                            <Link href="/link" disabled>Link text</Link>
+                        </td>
+                        <td class="px-3 py-3">
+                            <Link disabled>Button text</Link>
+                        </td>
+                    </tr>
                 </tbody>
             </table>
         </div>
     </section>
 
-    <!-- Real World Examples -->
+    <!-- Examples -->
     <section class="space-y-3">
-        <h2 class="text-lg font-semibold">Real World Examples</h2>
-        <div class="space-y-4 rounded-lg bg-surface-container-high p-4">
-            <!-- Navigation Bar -->
-            <div>
-                <p class="mb-2 text-sm font-medium text-on-surface-variant">Navigation</p>
-                <nav class="flex items-center gap-6">
-                    <Link href="/" color="primary" exact activeClass="font-semibold">Home</Link>
-                    <Link href="/about" color="primary" activeClass="font-semibold">About</Link>
-                    <Link href="/link" color="primary" activeClass="font-semibold" active={true}
-                        >Docs</Link
-                    >
-                    <Link href="/pricing" color="primary" activeClass="font-semibold">Pricing</Link>
-                </nav>
-            </div>
+        <h2 class="text-lg font-semibold">Examples</h2>
 
-            <!-- Sidebar Menu -->
-            <div>
-                <p class="mb-2 text-sm font-medium text-on-surface-variant">Sidebar</p>
-                <div class="flex w-56 flex-col gap-1">
-                    <Link
-                        href="/link"
-                        raw
-                        active={true}
-                        activeClass="bg-primary-container text-on-primary-container font-medium"
-                        inactiveClass="text-on-surface-variant hover:bg-surface-container-highest"
-                        class="rounded-md px-3 py-2 text-sm"
-                    >
-                        <Icon name="lucide:layout-dashboard" size="16" class="mr-2" />
-                        Dashboard
-                    </Link>
-                    <Link
-                        href="/settings"
-                        raw
-                        activeClass="bg-primary-container text-on-primary-container font-medium"
-                        inactiveClass="text-on-surface-variant hover:bg-surface-container-highest"
-                        class="rounded-md px-3 py-2 text-sm"
-                    >
-                        <Icon name="lucide:settings" size="16" class="mr-2" />
-                        Settings
-                    </Link>
-                </div>
-            </div>
+        <!-- Navigation Bar -->
+        <div class="space-y-2 rounded-lg bg-surface-container-high p-4">
+            <p class="text-xs font-medium text-on-surface-variant uppercase">Navigation bar</p>
+            <nav class="flex items-center gap-6">
+                <Link href="/" exact activeClass="font-semibold">Home</Link>
+                <Link href="/about" activeClass="font-semibold">About</Link>
+                <Link href="/link" activeClass="font-semibold" active={true}>Docs</Link>
+                <Link href="/pricing" activeClass="font-semibold">Pricing</Link>
+            </nav>
+        </div>
 
-            <!-- Breadcrumb -->
-            <div>
-                <p class="mb-2 text-sm font-medium text-on-surface-variant">Breadcrumb</p>
-                <nav class="flex items-center gap-1 text-sm">
-                    <Link href="/" color="secondary">Home</Link>
-                    <Icon name="lucide:chevron-right" size="14" class="text-on-surface-variant" />
-                    <Link href="/link" color="secondary">Docs</Link>
-                    <Icon name="lucide:chevron-right" size="14" class="text-on-surface-variant" />
-                    <span class="text-on-surface-variant">Components</span>
-                </nav>
+        <!-- Sidebar Menu -->
+        <div class="space-y-2 rounded-lg bg-surface-container-high p-4">
+            <p class="text-xs font-medium text-on-surface-variant uppercase">Sidebar menu</p>
+            <div class="flex w-56 flex-col gap-0.5">
+                <Link
+                    href="/link"
+                    raw
+                    active={true}
+                    activeClass="bg-primary-container text-on-primary-container font-medium"
+                    inactiveClass="text-on-surface-variant hover:bg-surface-container-highest"
+                    class="flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors"
+                >
+                    <Icon name="lucide:layout-dashboard" size="16" />
+                    Dashboard
+                </Link>
+                <Link
+                    href="/settings"
+                    raw
+                    activeClass="bg-primary-container text-on-primary-container font-medium"
+                    inactiveClass="text-on-surface-variant hover:bg-surface-container-highest"
+                    class="flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors"
+                >
+                    <Icon name="lucide:settings" size="16" />
+                    Settings
+                </Link>
+                <Link
+                    href="/profile"
+                    raw
+                    activeClass="bg-primary-container text-on-primary-container font-medium"
+                    inactiveClass="text-on-surface-variant hover:bg-surface-container-highest"
+                    class="flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors"
+                >
+                    <Icon name="lucide:user" size="16" />
+                    Profile
+                </Link>
+            </div>
+        </div>
+
+        <!-- Breadcrumb -->
+        <div class="space-y-2 rounded-lg bg-surface-container-high p-4">
+            <p class="text-xs font-medium text-on-surface-variant uppercase">Breadcrumb</p>
+            <nav class="flex items-center gap-1 text-sm">
+                <Link href="/">Home</Link>
+                <Icon name="lucide:chevron-right" size="14" class="text-on-surface-variant/50" />
+                <Link href="/link">Components</Link>
+                <Icon name="lucide:chevron-right" size="14" class="text-on-surface-variant/50" />
+                <span class="text-on-surface">Link</span>
+            </nav>
+        </div>
+
+        <!-- Footer Links -->
+        <div class="space-y-2 rounded-lg bg-surface-container-high p-4">
+            <p class="text-xs font-medium text-on-surface-variant uppercase">Footer links</p>
+            <div class="flex items-center gap-4 text-sm">
+                <Link href="https://github.com">
+                    <Icon name="lucide:github" size="14" class="mr-1" />
+                    GitHub
+                </Link>
+                <span class="text-outline-variant">|</span>
+                <Link href="https://svelte.dev">
+                    <Icon name="lucide:external-link" size="14" class="mr-1" />
+                    Svelte
+                </Link>
+                <span class="text-outline-variant">|</span>
+                <Link
+                    href="/link"
+                    raw
+                    class="text-on-surface-variant underline hover:text-on-surface"
+                    >Privacy Policy</Link
+                >
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary

Redesign **Link** and **Button** components to remove `bits-ui` dependency. Link now supports conditional `<a>`/`<button>` rendering, and Button wraps the internal Link component instead of `bits-ui Button.Root`.

### Link component

- **Conditional rendering** — renders `<a>` when `href` is provided, `<button>` when omitted
- **Simplified theme** — removed 7 color variants + 14 compound variants, replaced with MD3-aligned minimal theme (`text-primary` active, `text-on-surface-variant` inactive, `hover:text-on-surface` hover)
- **Active state detection** — `exact`, `exactQuery` (`true` | `'partial'` | `false`), `exactHash` props for fine-grained URL matching
- **External auto-detection** — auto-detects `http://`, `https://`, `//` URLs, adds `target="_blank"` and `rel="noopener noreferrer"`
- **Accessibility** — `role="link"` + `aria-disabled` on disabled anchors, native `disabled` on buttons, `aria-current="page"` on exact match
- **New props** — `ref`, `type`, `external`, `target`, `rel`, `raw`, `activeClass`, `inactiveClass`

### Button component

- **Replace `bits-ui`** — use internal Link component in `raw` mode instead of `Button.Root`
- **Link support** — `href`, `type`, `external`, `active`, `exact` props for anchor rendering
- **`loadingAuto`** — automatically shows loading state while `onclick` Promise is pending, with proper rejection handling and unmount safety
- **`activeColor` / `activeVariant`** — switch color and variant when `active` is true, useful for navigation patterns
- **`activeClass` / `inactiveClass`** — conditional CSS classes delegated to Link

### Type fixes

- Replace `HTMLAnchorAttributes & HTMLButtonAttributes` intersection with `HTMLAttributes<HTMLElement>` to fix "union type too complex" TypeScript error
- Preserves full IDE autocompletion for `id`, `style`, `aria-*`, `data-*`, event handlers
- Applied to Link, Button, and ThemeModeButton type definitions

### Bug fixes

- Fix `URLSearchParams` mutation in active state detection — use immutable sort
- Fix `onclick` override via `restProps` spread — destructure separately, spread `restProps` before explicit props
- Fix unhandled Promise rejection in `loadingAuto` — use `.then(onFulfilled, onRejected)` instead of `.finally()`
- Track `pendingPromise` reference to ignore stale callbacks after unmount or re-click

### Docs

- Rewrite Link docs page with 13 sections: Usage, InactiveClass, ActiveClass, Active, Matching Modes, Disabled, Raw, External, Prefetch, As Button, UI, States, Examples
- Rewrite Button docs page with 20 sections: Usage, Variant, Color, Matrix, Size, Icon, Leading/Trailing Icon, Square, Avatar, Loading, Loading Auto, Disabled, Block, As Link, Type, Active Color & Variant, Children, Slots, UI, Examples

### Stats

10 files changed, **+1080 / -478**

## Test plan

- [x] 1607 total tests pass across 38 test files
- [x] 42 Link tests — conditional rendering, disabled states, type prop, active detection, accessibility
- [x] 61 Button tests — 50 existing + 11 new (link rendering, loadingAuto, active color/variant)
- [x] `svelte-check` — 0 errors
- [x] `npm run build` + `publint` — package builds successfully


🤖 Generated with [Claude Code](https://claude.com/claude-code)
