### PR TITLE
ci: add --provenance flag to npm publish to bypass 2FA OTP

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,6 @@ jobs:
               run: pnpm exec svelte-kit sync && pnpm exec svelte-package
 
             - name: Publish to npm
-              run: npm publish --access public
+              run: npm publish --access public --provenance
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `--provenance` flag to `npm publish` to bypass OTP requirement when 2FA is enabled on the npm account
- Works because `id-token: write` permission is already set in the workflow, which is required for provenance signing

## Test plan

- [ ] Merge PR into main
- [ ] Delete and re-push tag `v1.3.0` to trigger the publish workflow
- [ ] Verify the package appears on npmjs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)
