### PR TITLE
v1.5.1 — Table: action prop, scrollbar-thin & sticky corner fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
             - name: Type check
               run: pnpm check
 
-            - name: Build package
-              run: pnpm exec svelte-kit sync && pnpm exec svelte-package
+            - name: Build
+              run: pnpm build
 
             - name: Install Playwright browsers
               run: pnpm exec playwright install --with-deps chromium

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Table** — `action` prop for applying Svelte actions (e.g. `useInfiniteScroll`) directly on the root element, eliminating the need for a wrapper div
+- **Table** — `scrollbar-thin` on root wrapper for thinner scrollbar styling
+
+### Fixed
+
+- **Table** — Sticky header/footer `backdrop-blur-sm` causing rounded corners to be lost (added matching `rounded-t-xl`/`rounded-b-xl`)
+
 ## [1.5.0] - 2026-04-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-04-02
+
 ### Added
 
 - **Table** — `action` prop for applying Svelte actions (e.g. `useInfiniteScroll`) directly on the root element, eliminating the need for a wrapper div
@@ -134,7 +136,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tailwind CSS 4 + Tailwind Variants integration
 - bits-ui and Vaul Svelte headless primitives
 
-[Unreleased]: https://github.com/ndlabdev/sv5ui/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/ndlabdev/sv5ui/compare/v1.5.1...HEAD
+[1.5.1]: https://github.com/ndlabdev/sv5ui/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/ndlabdev/sv5ui/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/ndlabdev/sv5ui/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/ndlabdev/sv5ui/compare/v1.2.0...v1.3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sv5ui",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "description": "A modern Svelte 5 UI component library with Tailwind CSS",
     "author": "ndlabdev",
     "license": "MIT",

--- a/src/lib/Table/Table.svelte
+++ b/src/lib/Table/Table.svelte
@@ -89,6 +89,7 @@
         striped = false,
         hoverable = config.defaultVariants.hoverable ?? true,
         sticky = false,
+        action,
 
         // Callbacks
         onRowClick,
@@ -111,6 +112,16 @@
 
         ...restProps
     }: TableProps<T> = $props()
+
+    // =========================================================================
+    // Apply Svelte action on root element
+    // =========================================================================
+    $effect(() => {
+        if (ref && action) {
+            const result = action(ref)
+            return () => result?.destroy?.()
+        }
+    })
 
     // =========================================================================
     // Change notifications — skip initial mount, fire only on subsequent changes

--- a/src/lib/Table/table.types.ts
+++ b/src/lib/Table/table.types.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Snippet } from 'svelte'
+import type { Action } from 'svelte/action'
 import type { HTMLAttributes } from 'svelte/elements'
 import type { ClassNameValue } from 'tailwind-merge'
 import type { TableVariantProps, TableSlots } from './table.variants.js'
@@ -279,6 +280,9 @@ export interface TableProps<T extends Record<string, any> = Record<string, any>>
 
     /** Sticky header/footer. @default false */
     sticky?: boolean | 'header' | 'footer'
+
+    /** Svelte action to apply on the root scroll container (e.g. infinite scroll). */
+    action?: Action<HTMLElement>
 
     // ---- Callbacks ----
 

--- a/src/lib/Table/table.variants.ts
+++ b/src/lib/Table/table.variants.ts
@@ -2,7 +2,7 @@ import { tv, type VariantProps } from 'tailwind-variants'
 
 export const tableVariants = tv({
     slots: {
-        root: 'relative w-full overflow-x-auto rounded-xl border border-outline-variant/50 bg-surface [contain:inline-size]',
+        root: 'relative w-full overflow-x-auto scrollbar-thin rounded-xl border border-outline-variant/50 bg-surface [contain:inline-size]',
         base: 'min-w-full',
         caption: 'sr-only',
         thead: 'relative bg-surface-container-low',
@@ -41,14 +41,14 @@ export const tableVariants = tv({
         },
         sticky: {
             true: {
-                thead: 'sticky top-0 inset-x-0 bg-surface-container-low/95 backdrop-blur-sm z-10',
-                tfoot: 'sticky bottom-0 inset-x-0 bg-surface-container-low/95 backdrop-blur-sm z-10'
+                thead: 'sticky top-0 inset-x-0 bg-surface-container-low/95 backdrop-blur-sm z-10 rounded-t-xl',
+                tfoot: 'sticky bottom-0 inset-x-0 bg-surface-container-low/95 backdrop-blur-sm z-10 rounded-b-xl'
             },
             header: {
-                thead: 'sticky top-0 inset-x-0 bg-surface-container-low/95 backdrop-blur-sm z-10'
+                thead: 'sticky top-0 inset-x-0 bg-surface-container-low/95 backdrop-blur-sm z-10 rounded-t-xl'
             },
             footer: {
-                tfoot: 'sticky bottom-0 inset-x-0 bg-surface-container-low/95 backdrop-blur-sm z-10'
+                tfoot: 'sticky bottom-0 inset-x-0 bg-surface-container-low/95 backdrop-blur-sm z-10 rounded-b-xl'
             }
         },
         striped: {

--- a/src/routes/use-infinite-scroll/+page.svelte
+++ b/src/routes/use-infinite-scroll/+page.svelte
@@ -188,51 +188,51 @@
             />
             <Button size="xs" variant="outline" onclick={resetTable}>Reset</Button>
         </div>
-        <div use:tableScroll.action class="h-112 overflow-y-auto rounded-lg">
-            <Table
-                data={users}
-                {columns}
-                rowKey="id"
-                manualPagination
-                total={users.length}
-                pageSize={users.length}
-                sticky="header"
-                hoverable
-                loading={tableScroll.loading}
-            >
-                {#snippet cellSlot({ column, value })}
-                    {@const cellValue = String(value ?? '')}
-                    {#if column.key === 'status'}
-                        <Badge
-                            label={cellValue}
-                            color={cellValue === 'active'
-                                ? 'success'
-                                : cellValue === 'pending'
-                                  ? 'warning'
-                                  : 'surface'}
-                            variant="soft"
-                            size="sm"
-                        />
-                    {:else if column.key === 'role'}
-                        <Badge label={cellValue} color="info" variant="subtle" size="sm" />
-                    {:else}
-                        {cellValue}
-                    {/if}
-                {/snippet}
+        <Table
+            data={users}
+            {columns}
+            rowKey="id"
+            manualPagination
+            total={users.length}
+            pageSize={users.length}
+            sticky="header"
+            hoverable
+            loading={tableScroll.loading}
+            action={tableScroll.action}
+            class="h-112 overflow-y-auto"
+        >
+            {#snippet cellSlot({ column, value })}
+                {@const cellValue = String(value ?? '')}
+                {#if column.key === 'status'}
+                    <Badge
+                        label={cellValue}
+                        color={cellValue === 'active'
+                            ? 'success'
+                            : cellValue === 'pending'
+                              ? 'warning'
+                              : 'surface'}
+                        variant="soft"
+                        size="sm"
+                    />
+                {:else if column.key === 'role'}
+                    <Badge label={cellValue} color="info" variant="subtle" size="sm" />
+                {:else}
+                    {cellValue}
+                {/if}
+            {/snippet}
 
-                {#snippet bodyBottomSlot()}
-                    {#if !tableHasMore}
-                        <tr>
-                            <td
-                                colspan={columns.length}
-                                class="py-4 text-center text-sm text-on-surface-variant"
-                            >
-                                All users loaded
-                            </td>
-                        </tr>
-                    {/if}
-                {/snippet}
-            </Table>
-        </div>
+            {#snippet bodyBottomSlot()}
+                {#if !tableHasMore}
+                    <tr>
+                        <td
+                            colspan={columns.length}
+                            class="py-4 text-center text-sm text-on-surface-variant"
+                        >
+                            All users loaded
+                        </td>
+                    </tr>
+                {/if}
+            {/snippet}
+        </Table>
     </section>
 </div>


### PR DESCRIPTION
## 🆕 Added

### Table — `action` prop

Apply Svelte actions directly on the Table root element, removing the need for a wrapper `<div>`.

```svelte
const scroll = useInfiniteScroll({ onLoad: fetchMore })

<Table
  {data}
  action={scroll.action}
  sticky="header"
  class="h-112 overflow-y-auto"
/>
```

### Table — `scrollbar-thin`

Table root wrapper now includes `scrollbar-thin` by default for a cleaner scrollbar appearance.

## 🐛 Bug Fixes

- **Table** — Sticky header/footer `backdrop-blur-sm` was causing the table's rounded corners (`rounded-xl`) to be lost. Added `rounded-t-xl` to `<thead>` and `rounded-b-xl` to `<tfoot>` when sticky is enabled.

## 📊 Stats

- **2020 tests** passing across 49 test files

**Full Changelog**: https://github.com/ndlabdev/sv5ui/compare/v1.5.0...v1.5.1
