### PR TITLE
feat(modal,slideover): standardize size prop and expand transition options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Select / SelectMenu** — `multiple` prop for selecting more than one option. When `true`, `value` becomes `string[]` and the dropdown stays open after each selection. The trigger displays selected labels joined by `separator` (default `, `), and a new `selected` snippet receives `{ items, remove, clear }` for custom rendering such as chips/tags.
 - **SelectMenu** — `createItem` prop (`boolean | 'always' | 'lazy'`) lets users add values not present in `items` by typing in the search box. Defaults to `'lazy'` (offered only when no item matches); `'always'` keeps the create option visible. Companion props: `createItemLabel` (string or `(value) => string`), `createItemIcon`, and `onCreate(value)` callback. Created values are tracked internally so the trigger renders their label even if the caller does not push them into `items`. Pressing <kbd>Enter</kbd> from the search input creates when there are no matches.
+- **Modal / Slideover** — `size` prop standardizing dimensions to `'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` (default `'md'`). For Slideover, `size` controls `max-width` for `left`/`right` sides and `max-height` for `top`/`bottom` sides.
+- **Modal / Slideover** — `transition` prop accepts string values `'none' \| 'fade' \| 'slide' \| 'scale'` in addition to the legacy `boolean`. Modal defaults to `'scale'`; Slideover defaults to `'slide'` (side-aware). `true` keeps mapping to the previous default; `false` maps to `'none'`.
+
+### Deprecated
+
+- **Modal** — `fullscreen` prop is now an alias for `size="full"`. Existing code keeps working unchanged; new code should prefer `size="full"`.
 
 ## [1.6.0] - 2026-04-06
 

--- a/src/lib/Modal/Modal.svelte
+++ b/src/lib/Modal/Modal.svelte
@@ -28,8 +28,9 @@
         description,
         overlay: showOverlay = config.defaultVariants.overlay ?? true,
         scrollable = config.defaultVariants.scrollable ?? false,
-        transition = config.defaultVariants.transition ?? true,
-        fullscreen = config.defaultVariants.fullscreen ?? false,
+        transition = config.defaultVariants.transition ?? 'scale',
+        size = config.defaultVariants.size ?? 'md',
+        fullscreen = false,
         portal = true,
         close: closeProp = true,
         dismissible = true,
@@ -46,6 +47,11 @@
         closeSlot
     }: Props = $props()
 
+    const resolvedSize = $derived(fullscreen ? 'full' : size)
+    const resolvedTransition = $derived(
+        transition === false ? 'none' : transition === true ? 'scale' : transition
+    )
+
     const showClose = $derived(!!closeProp)
     const closeProps = $derived(typeof closeProp === 'object' ? closeProp : {})
 
@@ -57,7 +63,12 @@
     )
 
     const variantSlots = $derived(
-        modalVariants({ transition, fullscreen, overlay: showOverlay, scrollable })
+        modalVariants({
+            transition: resolvedTransition,
+            size: resolvedSize,
+            overlay: showOverlay,
+            scrollable
+        })
     )
 
     const classes = $derived({

--- a/src/lib/Modal/Modal.svelte.spec.ts
+++ b/src/lib/Modal/Modal.svelte.spec.ts
@@ -435,4 +435,116 @@ describe('Modal', () => {
             })
         })
     })
+
+    // ==================== SIZE ====================
+
+    describe('size', () => {
+        const sizes: Array<[NonNullable<import('./modal.types.js').ModalProps['size']>, RegExp]> = [
+            ['sm', /max-w-md/],
+            ['md', /max-w-lg/],
+            ['lg', /max-w-2xl/],
+            ['xl', /max-w-4xl/]
+        ]
+
+        for (const [size, expected] of sizes) {
+            it(`should apply size="${size}" width class`, async () => {
+                render(Modal, { open: true, title: 'Test', size })
+                await vi.waitFor(() => {
+                    const content = getContent()
+                    expect(content).not.toBeNull()
+                    expect(content!.className).toMatch(expected)
+                })
+            })
+        }
+
+        it('should apply inset-0 when size="full"', async () => {
+            render(Modal, { open: true, title: 'Test', size: 'full' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content).not.toBeNull()
+                expect(content!.className).toContain('inset-0')
+                expect(content!.className).not.toMatch(/rounded-lg/)
+            })
+        })
+
+        it('should default to size="md" (max-w-lg)', async () => {
+            render(Modal, { open: true, title: 'Test' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content!.className).toMatch(/max-w-lg/)
+            })
+        })
+
+        it('fullscreen prop maps to size="full" for backwards compat', async () => {
+            render(Modal, { open: true, title: 'Test', fullscreen: true })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content!.className).toContain('inset-0')
+            })
+        })
+
+        it('fullscreen overrides explicit size', async () => {
+            render(Modal, { open: true, title: 'Test', fullscreen: true, size: 'sm' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content!.className).toContain('inset-0')
+                expect(content!.className).not.toMatch(/max-w-md/)
+            })
+        })
+    })
+
+    // ==================== TRANSITION VARIANTS ====================
+
+    describe('transition variants', () => {
+        it('should apply scale animation by default', async () => {
+            render(Modal, { open: true, title: 'Test' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content!.className).toMatch(/scale-in/)
+            })
+        })
+
+        it('should apply scale animation for transition="scale"', async () => {
+            render(Modal, { open: true, title: 'Test', transition: 'scale' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content!.className).toMatch(/scale-in/)
+            })
+        })
+
+        it('should apply fade-only animation for transition="fade"', async () => {
+            render(Modal, { open: true, title: 'Test', transition: 'fade' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content!.className).toMatch(/fade-in/)
+                expect(content!.className).not.toMatch(/scale-in/)
+                expect(content!.className).not.toMatch(/slide-in/)
+            })
+        })
+
+        it('should apply slide animation for transition="slide"', async () => {
+            render(Modal, { open: true, title: 'Test', transition: 'slide' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content!.className).toMatch(/slide-in-from-top/)
+                expect(content!.className).not.toMatch(/scale-in/)
+            })
+        })
+
+        it('should apply no animation for transition="none"', async () => {
+            render(Modal, { open: true, title: 'Test', transition: 'none' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content!.className).not.toMatch(/scale-in|fade-in|slide-in/)
+            })
+        })
+
+        it('transition={true} maps to scale (legacy default)', async () => {
+            render(Modal, { open: true, title: 'Test', transition: true })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content!.className).toMatch(/scale-in/)
+            })
+        })
+    })
 })

--- a/src/lib/Modal/modal.types.ts
+++ b/src/lib/Modal/modal.types.ts
@@ -65,16 +65,28 @@ export interface ModalProps extends RootProps, ContentProps {
     scrollable?: ModalVariantProps['scrollable']
 
     /**
-     * Animate the modal on open and close.
-     * @default true
+     * Controls the entrance/exit animation.
+     * - `'none'` / `false`: no animation
+     * - `'fade'`: overlay + content fade
+     * - `'slide'`: overlay fade + content slide-in from top
+     * - `'scale'` / `true`: overlay fade + content scale-in (default)
+     * @default 'scale'
      */
-    transition?: ModalVariantProps['transition']
+    transition?: ModalVariantProps['transition'] | boolean
+
+    /**
+     * Controls the modal width. The `'full'` value expands to fill the
+     * entire viewport (replaces the deprecated `fullscreen` prop).
+     * @default 'md'
+     */
+    size?: ModalVariantProps['size']
 
     /**
      * Expand the modal to fill the entire viewport.
+     * @deprecated Use `size="full"` instead. Retained as an alias for backward compatibility.
      * @default false
      */
-    fullscreen?: ModalVariantProps['fullscreen']
+    fullscreen?: boolean
 
     // --- Behavior ---
 

--- a/src/lib/Modal/modal.variants.ts
+++ b/src/lib/Modal/modal.variants.ts
@@ -16,20 +16,45 @@ export const modalVariants = tv({
     },
     variants: {
         transition: {
-            true: {
+            none: {},
+            fade: {
+                overlay:
+                    'data-[state=open]:animate-[fade-in_200ms_ease-out] data-[state=closed]:animate-[fade-out_150ms_ease-in]',
+                content:
+                    'data-[state=open]:animate-[fade-in_200ms_ease-out] data-[state=closed]:animate-[fade-out_150ms_ease-in]'
+            },
+            slide: {
+                overlay:
+                    'data-[state=open]:animate-[fade-in_200ms_ease-out] data-[state=closed]:animate-[fade-out_150ms_ease-in]',
+                content:
+                    'data-[state=open]:animate-[slide-in-from-top_200ms_ease-out] data-[state=closed]:animate-[slide-out-to-top_150ms_ease-in]'
+            },
+            scale: {
                 overlay:
                     'data-[state=open]:animate-[fade-in_200ms_ease-out] data-[state=closed]:animate-[fade-out_150ms_ease-in]',
                 content:
                     'data-[state=open]:animate-[scale-in_200ms_cubic-bezier(0.32,0.72,0,1)] data-[state=closed]:animate-[scale-out_150ms_cubic-bezier(0.32,0.72,0,1)]'
             }
         },
-        fullscreen: {
-            true: {
-                content: 'inset-0'
+        size: {
+            sm: {
+                content:
+                    'w-[calc(100vw-2rem)] max-w-md rounded-lg shadow-lg ring ring-outline-variant'
             },
-            false: {
+            md: {
                 content:
                     'w-[calc(100vw-2rem)] max-w-lg rounded-lg shadow-lg ring ring-outline-variant'
+            },
+            lg: {
+                content:
+                    'w-[calc(100vw-2rem)] max-w-2xl rounded-lg shadow-lg ring ring-outline-variant'
+            },
+            xl: {
+                content:
+                    'w-[calc(100vw-2rem)] max-w-4xl rounded-lg shadow-lg ring ring-outline-variant'
+            },
+            full: {
+                content: 'inset-0'
             }
         },
         overlay: {
@@ -51,14 +76,14 @@ export const modalVariants = tv({
     compoundVariants: [
         {
             scrollable: true,
-            fullscreen: false,
+            size: ['sm', 'md', 'lg', 'xl'],
             class: {
                 overlay: 'grid place-items-center p-4 sm:py-8'
             }
         },
         {
             scrollable: false,
-            fullscreen: false,
+            size: ['sm', 'md', 'lg', 'xl'],
             class: {
                 content:
                     'top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 max-h-[calc(100dvh-2rem)] sm:max-h-[calc(100dvh-4rem)] overflow-hidden'
@@ -66,8 +91,8 @@ export const modalVariants = tv({
         }
     ],
     defaultVariants: {
-        transition: true,
-        fullscreen: false,
+        transition: 'scale',
+        size: 'md',
         overlay: true,
         scrollable: false
     }

--- a/src/lib/Slideover/Slideover.svelte
+++ b/src/lib/Slideover/Slideover.svelte
@@ -28,7 +28,8 @@
         description,
         side = config.defaultVariants.side ?? 'right',
         overlay: showOverlay = config.defaultVariants.overlay ?? true,
-        transition = config.defaultVariants.transition ?? true,
+        transition = config.defaultVariants.transition ?? 'slide',
+        size = config.defaultVariants.size ?? 'md',
         inset = config.defaultVariants.inset ?? false,
         portal = true,
         close: closeProp = true,
@@ -56,8 +57,18 @@
         !!headerSlot || hasHeading || !!actionsSlot || showClose || !!closeSlot
     )
 
+    const resolvedTransition = $derived(
+        transition === false ? 'none' : transition === true ? 'slide' : transition
+    )
+
     const variantSlots = $derived(
-        slideoverVariants({ transition, side, inset, overlay: showOverlay })
+        slideoverVariants({
+            transition: resolvedTransition,
+            side,
+            size,
+            inset,
+            overlay: showOverlay
+        })
     )
 
     const classes = $derived({

--- a/src/lib/Slideover/Slideover.svelte.spec.ts
+++ b/src/lib/Slideover/Slideover.svelte.spec.ts
@@ -500,4 +500,120 @@ describe('Slideover', () => {
             })
         })
     })
+
+    // ==================== SIZE ====================
+
+    describe('size', () => {
+        const widthSizes: Array<[string, RegExp]> = [
+            ['sm', /max-w-sm/],
+            ['md', /max-w-md/],
+            ['lg', /max-w-lg/],
+            ['xl', /max-w-xl/]
+        ]
+        const heightSizes: Array<[string, RegExp]> = [
+            ['sm', /max-h-\[40dvh\]/],
+            ['md', /max-h-\[60dvh\]/],
+            ['lg', /max-h-\[75dvh\]/],
+            ['xl', /max-h-\[90dvh\]/]
+        ]
+
+        for (const [size, expected] of widthSizes) {
+            it(`should apply max-width for side="right" + size="${size}"`, async () => {
+                render(Slideover, { open: true, title: 'Test', side: 'right', size: size as 'sm' })
+                await vi.waitFor(() => {
+                    const content = getContent()
+                    expect(content!.className).toMatch(expected)
+                })
+            })
+        }
+
+        for (const [size, expected] of heightSizes) {
+            it(`should apply max-height for side="bottom" + size="${size}"`, async () => {
+                render(Slideover, { open: true, title: 'Test', side: 'bottom', size: size as 'sm' })
+                await vi.waitFor(() => {
+                    const content = getContent()
+                    expect(content!.className).toMatch(expected)
+                })
+            })
+        }
+
+        it('should apply max-w-full for left/right + size="full"', async () => {
+            render(Slideover, { open: true, title: 'Test', side: 'right', size: 'full' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content!.className).toMatch(/max-w-full/)
+            })
+        })
+
+        it('should apply max-h-full for top/bottom + size="full"', async () => {
+            render(Slideover, { open: true, title: 'Test', side: 'top', size: 'full' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content!.className).toMatch(/max-h-full/)
+            })
+        })
+
+        it('should default to size="md" (max-w-md for right side)', async () => {
+            render(Slideover, { open: true, title: 'Test' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content!.className).toMatch(/max-w-md/)
+            })
+        })
+    })
+
+    // ==================== TRANSITION VARIANTS ====================
+
+    describe('transition variants', () => {
+        it('should apply slide animation by default (right side)', async () => {
+            render(Slideover, { open: true, title: 'Test' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content!.className).toMatch(/slide-in-full-right/)
+            })
+        })
+
+        it('should apply fade-only animation for transition="fade"', async () => {
+            render(Slideover, { open: true, title: 'Test', transition: 'fade' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content!.className).toMatch(/fade-in/)
+                expect(content!.className).not.toMatch(/slide-in/)
+                expect(content!.className).not.toMatch(/scale-in/)
+            })
+        })
+
+        it('should apply scale animation for transition="scale"', async () => {
+            render(Slideover, { open: true, title: 'Test', transition: 'scale' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content!.className).toMatch(/scale-in/)
+                expect(content!.className).not.toMatch(/slide-in/)
+            })
+        })
+
+        it('should apply no animation for transition="none"', async () => {
+            render(Slideover, { open: true, title: 'Test', transition: 'none' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content!.className).not.toMatch(/scale-in|fade-in|slide-in/)
+            })
+        })
+
+        it('transition={true} maps to slide (legacy default)', async () => {
+            render(Slideover, { open: true, title: 'Test', transition: true })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content!.className).toMatch(/slide-in-full-right/)
+            })
+        })
+
+        it('should apply side-specific slide for left when transition="slide"', async () => {
+            render(Slideover, { open: true, title: 'Test', side: 'left', transition: 'slide' })
+            await vi.waitFor(() => {
+                const content = getContent()
+                expect(content!.className).toMatch(/slide-in-full-left/)
+            })
+        })
+    })
 })

--- a/src/lib/Slideover/slideover.types.ts
+++ b/src/lib/Slideover/slideover.types.ts
@@ -64,10 +64,22 @@ export interface SlideoverProps extends RootProps, ContentProps {
     overlay?: SlideoverVariantProps['overlay']
 
     /**
-     * Animate the slideover on open and close.
-     * @default true
+     * Controls the entrance/exit animation.
+     * - `'none'` / `false`: no animation
+     * - `'fade'`: overlay + content fade
+     * - `'slide'` / `true`: overlay fade + content slide-in from the chosen side (default)
+     * - `'scale'`: overlay fade + content scale-in
+     * @default 'slide'
      */
-    transition?: SlideoverVariantProps['transition']
+    transition?: SlideoverVariantProps['transition'] | boolean
+
+    /**
+     * Controls the panel dimension along its axis. For `side="left"` /
+     * `side="right"` this sets `max-width`; for `side="top"` / `side="bottom"`
+     * this sets `max-height`.
+     * @default 'md'
+     */
+    size?: SlideoverVariantProps['size']
 
     /**
      * Display the slideover with inset margins and rounded corners.

--- a/src/lib/Slideover/slideover.variants.ts
+++ b/src/lib/Slideover/slideover.variants.ts
@@ -16,24 +16,44 @@ export const slideoverVariants = tv({
     },
     variants: {
         transition: {
-            true: {
+            none: {},
+            fade: {
+                overlay:
+                    'data-[state=open]:animate-[fade-in_200ms_ease-out] data-[state=closed]:animate-[fade-out_150ms_ease-in]',
+                content:
+                    'data-[state=open]:animate-[fade-in_200ms_ease-out] data-[state=closed]:animate-[fade-out_150ms_ease-in]'
+            },
+            slide: {
                 overlay:
                     'data-[state=open]:animate-[fade-in_200ms_ease-out] data-[state=closed]:animate-[fade-out_150ms_ease-in]'
+            },
+            scale: {
+                overlay:
+                    'data-[state=open]:animate-[fade-in_200ms_ease-out] data-[state=closed]:animate-[fade-out_150ms_ease-in]',
+                content:
+                    'data-[state=open]:animate-[scale-in_200ms_cubic-bezier(0.32,0.72,0,1)] data-[state=closed]:animate-[scale-out_150ms_cubic-bezier(0.32,0.72,0,1)]'
             }
         },
         side: {
             top: {
-                content: 'fixed top-0 inset-x-0 max-h-[90dvh]'
+                content: 'fixed top-0 inset-x-0'
             },
             right: {
-                content: 'fixed right-0 inset-y-0 w-full max-w-md'
+                content: 'fixed right-0 inset-y-0 w-full'
             },
             bottom: {
-                content: 'fixed bottom-0 inset-x-0 max-h-[90dvh]'
+                content: 'fixed bottom-0 inset-x-0'
             },
             left: {
-                content: 'fixed left-0 inset-y-0 w-full max-w-md'
+                content: 'fixed left-0 inset-y-0 w-full'
             }
+        },
+        size: {
+            sm: {},
+            md: {},
+            lg: {},
+            xl: {},
+            full: {}
         },
         inset: {
             true: {},
@@ -48,8 +68,9 @@ export const slideoverVariants = tv({
         }
     },
     compoundVariants: [
+        // Side-specific slide animations
         {
-            transition: true,
+            transition: 'slide',
             side: 'top',
             class: {
                 content:
@@ -57,7 +78,7 @@ export const slideoverVariants = tv({
             }
         },
         {
-            transition: true,
+            transition: 'slide',
             side: 'right',
             class: {
                 content:
@@ -65,7 +86,7 @@ export const slideoverVariants = tv({
             }
         },
         {
-            transition: true,
+            transition: 'slide',
             side: 'bottom',
             class: {
                 content:
@@ -73,19 +94,30 @@ export const slideoverVariants = tv({
             }
         },
         {
-            transition: true,
+            transition: 'slide',
             side: 'left',
             class: {
                 content:
                     'data-[state=open]:animate-[slide-in-full-left_200ms_ease-out,fade-in_200ms_ease-out] data-[state=closed]:animate-[slide-out-full-left_150ms_ease-in,fade-out_150ms_ease-in]'
             }
         },
+        // Sizes — left/right control width, top/bottom control height
+        { side: ['left', 'right'], size: 'sm', class: { content: 'max-w-sm' } },
+        { side: ['left', 'right'], size: 'md', class: { content: 'max-w-md' } },
+        { side: ['left', 'right'], size: 'lg', class: { content: 'max-w-lg' } },
+        { side: ['left', 'right'], size: 'xl', class: { content: 'max-w-xl' } },
+        { side: ['left', 'right'], size: 'full', class: { content: 'max-w-full' } },
+        { side: ['top', 'bottom'], size: 'sm', class: { content: 'max-h-[40dvh]' } },
+        { side: ['top', 'bottom'], size: 'md', class: { content: 'max-h-[60dvh]' } },
+        { side: ['top', 'bottom'], size: 'lg', class: { content: 'max-h-[75dvh]' } },
+        { side: ['top', 'bottom'], size: 'xl', class: { content: 'max-h-[90dvh]' } },
+        { side: ['top', 'bottom'], size: 'full', class: { content: 'max-h-full' } },
+        // Inset positioning + rounded corners + shadow ring per side
         {
             inset: true,
             side: 'top',
             class: {
-                content:
-                    'top-4 inset-x-4 max-h-[calc(90dvh-2rem)] rounded-xl shadow-lg ring ring-outline-variant'
+                content: 'top-4 inset-x-4 rounded-xl shadow-lg ring ring-outline-variant'
             }
         },
         {
@@ -99,8 +131,7 @@ export const slideoverVariants = tv({
             inset: true,
             side: 'bottom',
             class: {
-                content:
-                    'bottom-4 inset-x-4 max-h-[calc(90dvh-2rem)] rounded-xl shadow-lg ring ring-outline-variant'
+                content: 'bottom-4 inset-x-4 rounded-xl shadow-lg ring ring-outline-variant'
             }
         },
         {
@@ -112,8 +143,9 @@ export const slideoverVariants = tv({
         }
     ],
     defaultVariants: {
-        transition: true,
+        transition: 'slide',
         side: 'right',
+        size: 'md',
         inset: false,
         overlay: true
     }

--- a/src/routes/modal/+page.svelte
+++ b/src/routes/modal/+page.svelte
@@ -22,6 +22,20 @@
     let alertOpen = $state(false)
     let imageOpen = $state(false)
 
+    let sizeOpens = $state<Record<string, boolean>>({
+        sm: false,
+        md: false,
+        lg: false,
+        xl: false,
+        full: false
+    })
+    let transitionOpens = $state<Record<string, boolean>>({
+        scale: false,
+        fade: false,
+        slide: false,
+        none: false
+    })
+
     function logCallback(name: string) {
         callbackLog = [...callbackLog.slice(-4), `${new Date().toLocaleTimeString()} — ${name}`]
     }
@@ -589,6 +603,58 @@
                     {/snippet}
                 </Modal>
             </div>
+        </div>
+    </section>
+
+    <Separator />
+
+    <section>
+        <h2 class="mb-3 text-lg font-semibold">Size</h2>
+        <p class="mb-4 text-sm text-on-surface-variant">
+            Use <code>size</code> to control the modal width: <code>sm</code> /
+            <code>md</code> (default) / <code>lg</code> / <code>xl</code> /
+            <code>full</code>. The legacy <code>fullscreen</code> prop is kept as an alias for
+            <code>size="full"</code>.
+        </p>
+        <div class="flex flex-wrap gap-2">
+            {#each ['sm', 'md', 'lg', 'xl', 'full'] as const as s (s)}
+                <Modal
+                    bind:open={sizeOpens[s]}
+                    size={s}
+                    title={`Size: ${s}`}
+                    description="Resize your browser to see how the modal width scales."
+                >
+                    <Button variant="outline" label={`size="${s}"`} />
+                    {#snippet body()}
+                        <p class="text-sm text-on-surface-variant">
+                            Current size is <code>{s}</code>.
+                        </p>
+                    {/snippet}
+                </Modal>
+            {/each}
+        </div>
+    </section>
+
+    <Separator />
+
+    <section>
+        <h2 class="mb-3 text-lg font-semibold">Transition</h2>
+        <p class="mb-4 text-sm text-on-surface-variant">
+            Pick how the modal animates in and out. Default is <code>scale</code>; pass
+            <code>fade</code>, <code>slide</code>, or <code>none</code> to override. Boolean
+            <code>true</code> / <code>false</code> still work as legacy aliases.
+        </p>
+        <div class="flex flex-wrap gap-2">
+            {#each ['scale', 'fade', 'slide', 'none'] as const as t (t)}
+                <Modal
+                    bind:open={transitionOpens[t]}
+                    transition={t}
+                    title={`Transition: ${t}`}
+                    description="Open and close to see the animation."
+                >
+                    <Button variant="outline" label={`transition="${t}"`} />
+                </Modal>
+            {/each}
         </div>
     </section>
 </div>

--- a/src/routes/slideover/+page.svelte
+++ b/src/routes/slideover/+page.svelte
@@ -30,6 +30,20 @@
     let cartOpen = $state(false)
     let notificationsOpen = $state(false)
 
+    let sizeOpens = $state<Record<string, boolean>>({
+        sm: false,
+        md: false,
+        lg: false,
+        xl: false,
+        full: false
+    })
+    let transitionOpens = $state<Record<string, boolean>>({
+        slide: false,
+        fade: false,
+        scale: false,
+        none: false
+    })
+
     function logCallback(name: string) {
         callbackLog = [...callbackLog.slice(-4), `${new Date().toLocaleTimeString()} — ${name}`]
     }
@@ -954,6 +968,60 @@
                     {/snippet}
                 </Slideover>
             </div>
+        </div>
+    </section>
+
+    <Separator />
+
+    <section>
+        <h2 class="mb-3 text-lg font-semibold">Size</h2>
+        <p class="mb-4 text-sm text-on-surface-variant">
+            Use <code>size</code> to control the panel along its axis.
+            <code>left</code> / <code>right</code> change <code>max-width</code>;
+            <code>top</code> / <code>bottom</code> change <code>max-height</code>. Available values:
+            <code>sm</code>
+            / <code>md</code> (default) / <code>lg</code> /
+            <code>xl</code> / <code>full</code>.
+        </p>
+        <div class="flex flex-wrap gap-2">
+            {#each ['sm', 'md', 'lg', 'xl', 'full'] as const as s (s)}
+                <Slideover
+                    bind:open={sizeOpens[s]}
+                    size={s}
+                    title={`Size: ${s}`}
+                    description={`right side, size="${s}"`}
+                >
+                    <Button variant="outline" label={`size="${s}"`} />
+                    {#snippet body()}
+                        <p class="text-sm text-on-surface-variant">
+                            Current size is <code>{s}</code>.
+                        </p>
+                    {/snippet}
+                </Slideover>
+            {/each}
+        </div>
+    </section>
+
+    <Separator />
+
+    <section>
+        <h2 class="mb-3 text-lg font-semibold">Transition</h2>
+        <p class="mb-4 text-sm text-on-surface-variant">
+            Pick the entrance/exit animation. Default is <code>slide</code> (side-aware); pass
+            <code>fade</code>, <code>scale</code>, or <code>none</code> to override. Boolean
+            <code>true</code> / <code>false</code> still work as legacy aliases.
+        </p>
+        <div class="flex flex-wrap gap-2">
+            {#each ['slide', 'fade', 'scale', 'none'] as const as t (t)}
+                <Slideover
+                    bind:open={transitionOpens[t]}
+                    transition={t}
+                    title={`Transition: ${t}`}
+                    description="Open and close to see the animation."
+                >
+                    <Button variant="outline" label={`transition="${t}"`} />
+                </Slideover>
+            {/each}
         </div>
     </section>
 </div>


### PR DESCRIPTION
## Summary

- Unified `size` prop (`sm | md | lg | xl | full`) on **Modal** and **Slideover**.
  - Modal: controls width.
  - Slideover: controls dimension along the panel's axis — `max-width` for `left`/`right`, `max-height` for `top`/`bottom`.
- Expanded `transition` prop on both components to accept string values: `'none' | 'fade' | 'slide' | 'scale'`. Boolean still works as legacy alias.
  - Modal default: `'scale'`.
  - Slideover default: side-aware `'slide'`.
- `Modal.fullscreen` is now a deprecated alias for `size=\"full\"`. Backwards-compatible.

## API additions

| Component | Prop | Type | Default |
| --- | --- | --- | --- |
| Modal | `size` | `'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` | `'md'` |
| Modal | `transition` | `boolean \| 'none' \| 'fade' \| 'slide' \| 'scale'` | `'scale'` |
| Slideover | `size` | `'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` | `'md'` |
| Slideover | `transition` | `boolean \| 'none' \| 'fade' \| 'slide' \| 'scale'` | `'slide'` |

## Backwards compatibility

- `Modal.fullscreen={true}` → maps to `size=\"full\"` (deprecation note on the prop type).
- `transition={true}` → maps to component default (`'scale'` for Modal, `'slide'` for Slideover).
- `transition={false}` → maps to `'none'`.

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run lint` — clean (only pre-existing Table complexity warnings)
- [x] `npm test` — **2143/2143 passed** (31 new tests: 14 Modal + 17 Slideover for size & transition variants)
- [x] Dev server — `/modal` and `/slideover` both HTTP 200; new demo sections show all sizes + all transitions
- [ ] Manual: open each new transition variant and confirm animation matches expectation
- [ ] Manual: resize browser with each size on both components

🤖 Generated with [Claude Code](https://claude.com/claude-code)