### PR TITLE
feat(file-upload): add maxSize, maxFiles, and onReject validation props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SelectMenu** — `createItem` prop (`boolean | 'always' | 'lazy'`) lets users add values not present in `items` by typing in the search box. Defaults to `'lazy'` (offered only when no item matches); `'always'` keeps the create option visible. Companion props: `createItemLabel` (string or `(value) => string`), `createItemIcon`, and `onCreate(value)` callback. Created values are tracked internally so the trigger renders their label even if the caller does not push them into `items`. Pressing <kbd>Enter</kbd> from the search input creates when there are no matches.
 - **Modal / Slideover** — `size` prop standardizing dimensions to `'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` (default `'md'`). For Slideover, `size` controls `max-width` for `left`/`right` sides and `max-height` for `top`/`bottom` sides.
 - **Modal / Slideover** — `transition` prop accepts string values `'none' \| 'fade' \| 'slide' \| 'scale'` in addition to the legacy `boolean`. Modal defaults to `'scale'`; Slideover defaults to `'slide'` (side-aware). `true` keeps mapping to the previous default; `false` maps to `'none'`.
+- **FileUpload** — `maxSize` (bytes per file) and `maxFiles` (count cap) validation props. Files exceeding either limit are rejected without entering `value`. The root element exposes `data-full` when the `maxFiles` limit is reached.
+- **FileUpload** — `onReject(rejected)` callback fires with the list of files that were filtered out by `accept`, `maxSize`, or `maxFiles` during a single drop or input change. New `FileUploadRejection` type exported.
+
+### Changed
+
+- **FileUpload** — `accept` rejections now also surface through `onReject` (previously silent). No behavior change unless an `onReject` callback is provided.
 
 ### Deprecated
 

--- a/src/lib/FileUpload/FileUpload.svelte
+++ b/src/lib/FileUpload/FileUpload.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-    import type { FileUploadProps } from './file-upload.types.js'
+    import type { FileUploadProps, FileUploadRejection } from './file-upload.types.js'
 
     export type Props = FileUploadProps
 </script>
@@ -22,6 +22,9 @@
         onValueChange,
         multiple = false,
         accept,
+        maxSize,
+        maxFiles,
+        onReject,
         dropzone = true,
         interactive = true,
         label = 'Drop files here or click to upload',
@@ -69,6 +72,7 @@
 
     const isDisabled = $derived(disabled || loading)
     const isDragging = $derived(dragCounter > 0)
+    const isFull = $derived(maxFiles !== undefined && value.length >= maxFiles)
     const showFilesInside = $derived(
         layout === 'grid' && !multiple && value.length > 0 && preview && variant === 'area'
     )
@@ -150,17 +154,52 @@
             })
     }
 
+    function validateIngress(file: File): FileUploadRejection['reason'] | null {
+        if (accept && !isFileAccepted(file)) return 'accept'
+        if (maxSize !== undefined && file.size > maxSize) return 'maxSize'
+        return null
+    }
+
+    function applyMaxFiles(candidates: File[]): {
+        accepted: File[]
+        rejected: FileUploadRejection[]
+    } {
+        if (maxFiles === undefined) return { accepted: candidates, rejected: [] }
+        const remaining = Math.max(0, maxFiles - value.length)
+        if (candidates.length <= remaining) return { accepted: candidates, rejected: [] }
+        return {
+            accepted: candidates.slice(0, remaining),
+            rejected: candidates.slice(remaining).map((file) => ({ file, reason: 'maxFiles' }))
+        }
+    }
+
     function addFiles(newFiles: File[]) {
         if (isDisabled) return
-        const filtered = accept ? newFiles.filter(isFileAccepted) : newFiles
-        if (!filtered.length) return
+
+        const rejected: FileUploadRejection[] = []
+        const passed: File[] = []
+        for (const file of newFiles) {
+            const reason = validateIngress(file)
+            if (reason) rejected.push({ file, reason })
+            else passed.push(file)
+        }
+
+        let accepted: File[]
         if (!multiple) {
-            value = [filtered[0]]
+            accepted = passed.slice(0, 1)
         } else {
             const existing = new Set(value.map(fileKey))
-            value = [...value, ...filtered.filter((f) => !existing.has(fileKey(f)))]
+            const deduped = passed.filter((f) => !existing.has(fileKey(f)))
+            const result = applyMaxFiles(deduped)
+            accepted = result.accepted
+            rejected.push(...result.rejected)
         }
-        onValueChange?.(value)
+
+        if (accepted.length) {
+            value = multiple ? [...value, ...accepted] : accepted
+            onValueChange?.(value)
+        }
+        if (rejected.length) onReject?.(rejected)
     }
 
     function removeFile(index: number) {
@@ -254,7 +293,7 @@
     }
 </script>
 
-<div {...restProps} bind:this={ref} class={classes.root}>
+<div {...restProps} bind:this={ref} class={classes.root} data-full={isFull ? '' : undefined}>
     <!-- Hidden file input — uses auto-generated id internally -->
     <input
         bind:this={inputRef}

--- a/src/lib/FileUpload/FileUpload.svelte.spec.ts
+++ b/src/lib/FileUpload/FileUpload.svelte.spec.ts
@@ -449,4 +449,157 @@ describe('FileUpload', () => {
             expect(document.querySelector('[aria-label^="Remove"]')).toBeNull()
         })
     })
+
+    // ==================== MAX SIZE ====================
+
+    describe('maxSize', () => {
+        it('should accept files at or below the limit', async () => {
+            const onValueChange = vi.fn()
+            render(FileUpload, { multiple: true, maxSize: 1024, onValueChange })
+            await simulateFileInput([makeFile('ok.txt', 'text/plain', 1024)])
+            expect(onValueChange).toHaveBeenCalledTimes(1)
+            expect(onValueChange.mock.calls[0][0]).toHaveLength(1)
+        })
+
+        it('should reject files larger than the limit', async () => {
+            const onValueChange = vi.fn()
+            const onReject = vi.fn()
+            render(FileUpload, { multiple: true, maxSize: 1024, onValueChange, onReject })
+            await simulateFileInput([makeFile('big.txt', 'text/plain', 2048)])
+            expect(onValueChange).not.toHaveBeenCalled()
+            expect(onReject).toHaveBeenCalledTimes(1)
+            expect(onReject.mock.calls[0][0]).toEqual([
+                expect.objectContaining({ reason: 'maxSize' })
+            ])
+        })
+
+        it('should accept files when maxSize is undefined (no limit)', async () => {
+            const onValueChange = vi.fn()
+            render(FileUpload, { multiple: true, onValueChange })
+            await simulateFileInput([makeFile('huge.bin', 'application/octet-stream', 10_000_000)])
+            expect(onValueChange).toHaveBeenCalledTimes(1)
+        })
+
+        it('should mix accepted and rejected files in one input', async () => {
+            const onValueChange = vi.fn()
+            const onReject = vi.fn()
+            render(FileUpload, { multiple: true, maxSize: 1024, onValueChange, onReject })
+            await simulateFileInput([
+                makeFile('ok.txt', 'text/plain', 512),
+                makeFile('big.txt', 'text/plain', 4096)
+            ])
+            expect(onValueChange).toHaveBeenCalledTimes(1)
+            expect(onValueChange.mock.calls[0][0]).toHaveLength(1)
+            expect(onValueChange.mock.calls[0][0][0].name).toBe('ok.txt')
+            expect(onReject).toHaveBeenCalledTimes(1)
+            expect(onReject.mock.calls[0][0]).toHaveLength(1)
+            expect(onReject.mock.calls[0][0][0].file.name).toBe('big.txt')
+        })
+    })
+
+    // ==================== MAX FILES ====================
+
+    describe('maxFiles', () => {
+        it('should accept files within the limit', async () => {
+            const onValueChange = vi.fn()
+            render(FileUpload, { multiple: true, maxFiles: 3, onValueChange })
+            await simulateFileInput([makeFile('a.txt'), makeFile('b.txt')])
+            expect(onValueChange).toHaveBeenCalledTimes(1)
+            expect(onValueChange.mock.calls[0][0]).toHaveLength(2)
+        })
+
+        it('should reject files exceeding the limit', async () => {
+            const onReject = vi.fn()
+            const onValueChange = vi.fn()
+            render(FileUpload, { multiple: true, maxFiles: 2, onReject, onValueChange })
+            await simulateFileInput([makeFile('a.txt'), makeFile('b.txt'), makeFile('c.txt')])
+            expect(onValueChange.mock.calls[0][0]).toHaveLength(2)
+            expect(onReject).toHaveBeenCalledTimes(1)
+            expect(onReject.mock.calls[0][0]).toHaveLength(1)
+            expect(onReject.mock.calls[0][0][0]).toEqual(
+                expect.objectContaining({ reason: 'maxFiles' })
+            )
+            expect(onReject.mock.calls[0][0][0].file.name).toBe('c.txt')
+        })
+
+        it('should reject everything when value is already at the limit', async () => {
+            const onReject = vi.fn()
+            const onValueChange = vi.fn()
+            render(FileUpload, {
+                multiple: true,
+                maxFiles: 2,
+                value: [makeFile('a.txt'), makeFile('b.txt')],
+                onReject,
+                onValueChange
+            })
+            await simulateFileInput([makeFile('c.txt')])
+            expect(onValueChange).not.toHaveBeenCalled()
+            expect(onReject).toHaveBeenCalledTimes(1)
+            expect(onReject.mock.calls[0][0]).toEqual([
+                expect.objectContaining({ reason: 'maxFiles' })
+            ])
+        })
+
+        it('should expose data-full attribute when limit is reached', async () => {
+            const { container } = render(FileUpload, {
+                multiple: true,
+                maxFiles: 2,
+                value: [makeFile('a.txt'), makeFile('b.txt')]
+            })
+            const root = container.querySelector('[data-full]') as HTMLElement
+            expect(root).not.toBeNull()
+        })
+
+        it('should not expose data-full attribute below the limit', async () => {
+            const { container } = render(FileUpload, {
+                multiple: true,
+                maxFiles: 5,
+                value: [makeFile('a.txt')]
+            })
+            expect(container.querySelector('[data-full]')).toBeNull()
+        })
+    })
+
+    // ==================== ON REJECT ====================
+
+    describe('onReject', () => {
+        it('should not fire when no files are rejected', async () => {
+            const onReject = vi.fn()
+            render(FileUpload, { multiple: true, onReject })
+            await simulateFileInput([makeFile('a.txt')])
+            expect(onReject).not.toHaveBeenCalled()
+        })
+
+        it('should report accept rejection reason', async () => {
+            const onReject = vi.fn()
+            render(FileUpload, { multiple: true, accept: 'image/*', onReject })
+            await simulateFileInput([makeFile('a.txt', 'text/plain')])
+            expect(onReject).toHaveBeenCalledTimes(1)
+            expect(onReject.mock.calls[0][0]).toEqual([
+                expect.objectContaining({ reason: 'accept' })
+            ])
+        })
+
+        it('should mix multiple rejection reasons in a single call', async () => {
+            const onReject = vi.fn()
+            render(FileUpload, {
+                multiple: true,
+                accept: 'image/*',
+                maxSize: 1024,
+                maxFiles: 1,
+                onReject
+            })
+            await simulateFileInput([
+                makeFile('text.txt', 'text/plain', 100),
+                makeFile('big.png', 'image/png', 4096),
+                makeFile('small1.png', 'image/png', 500),
+                makeFile('small2.png', 'image/png', 500)
+            ])
+            expect(onReject).toHaveBeenCalledTimes(1)
+            const reasons = onReject.mock.calls[0][0].map((r: { reason: string }) => r.reason)
+            expect(reasons).toContain('accept')
+            expect(reasons).toContain('maxSize')
+            expect(reasons).toContain('maxFiles')
+        })
+    })
 })

--- a/src/lib/FileUpload/file-upload.types.ts
+++ b/src/lib/FileUpload/file-upload.types.ts
@@ -3,6 +3,23 @@ import type { HTMLAttributes } from 'svelte/elements'
 import type { ClassNameValue } from 'tailwind-merge'
 import type { FileUploadVariantProps, FileUploadSlots } from './file-upload.variants.js'
 
+/**
+ * Reason a file was rejected by FileUpload.
+ *
+ * - `accept`: file did not match the `accept` MIME/extension filter
+ * - `maxSize`: file exceeded the `maxSize` byte limit
+ * - `maxFiles`: file would have pushed the selection past `maxFiles`
+ */
+export type FileUploadRejectionReason = 'accept' | 'maxSize' | 'maxFiles'
+
+/**
+ * A single rejected file along with the reason it was rejected.
+ */
+export interface FileUploadRejection {
+    file: File
+    reason: FileUploadRejectionReason
+}
+
 export type FileUploadProps = Omit<HTMLAttributes<HTMLElement>, 'class' | 'children'> & {
     /**
      * Bindable reference to the root DOM element.
@@ -30,6 +47,33 @@ export type FileUploadProps = Omit<HTMLAttributes<HTMLElement>, 'class' | 'child
      * Accepted file types as MIME types or extensions (e.g. "image/*,.pdf").
      */
     accept?: string
+
+    /**
+     * Maximum allowed size per file, in bytes. Files exceeding this are
+     * rejected and reported through `onReject`.
+     *
+     * @example
+     * ```svelte
+     * <FileUpload maxSize={5 * 1024 * 1024} /> <!-- 5 MB -->
+     * ```
+     */
+    maxSize?: number
+
+    /**
+     * Maximum number of files that can be selected. When the current
+     * selection plus the incoming files would exceed this, the excess
+     * files are rejected and reported through `onReject`. The root element
+     * exposes a `data-full` attribute when the limit is reached, so the
+     * upload area can be styled accordingly.
+     */
+    maxFiles?: number
+
+    /**
+     * Called when one or more incoming files are rejected by `accept`,
+     * `maxSize`, or `maxFiles`. Receives the full rejection list for a
+     * single user action (one drop or one input change).
+     */
+    onReject?: (rejected: FileUploadRejection[]) => void
 
     /**
      * Enable drag-and-drop file upload.

--- a/src/lib/FileUpload/index.ts
+++ b/src/lib/FileUpload/index.ts
@@ -1,2 +1,6 @@
 export { default as FileUpload } from './FileUpload.svelte'
-export type { FileUploadProps } from './file-upload.types.js'
+export type {
+    FileUploadProps,
+    FileUploadRejection,
+    FileUploadRejectionReason
+} from './file-upload.types.js'

--- a/src/routes/file-upload/+page.svelte
+++ b/src/routes/file-upload/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { FileUpload, Button } from '$lib/index.js'
+    import type { FileUploadRejection } from '$lib/index.js'
 
     const colors = [
         'primary',
@@ -24,6 +25,18 @@
     let noDropzoneFiles = $state<File[]>([])
     let noPreviewFiles = $state<File[]>([])
     let imageFiles = $state<File[]>([])
+
+    let maxSizeFiles = $state<File[]>([])
+    let maxFilesFiles = $state<File[]>([])
+    let validationFiles = $state<File[]>([])
+    let rejections = $state<FileUploadRejection[]>([])
+    let combinedRejections = $state<FileUploadRejection[]>([])
+
+    function reasonLabel(reason: FileUploadRejection['reason']): string {
+        if (reason === 'maxSize') return 'too large'
+        if (reason === 'maxFiles') return 'too many'
+        return 'wrong type'
+    }
 </script>
 
 <div class="space-y-8">
@@ -414,6 +427,85 @@
                     color="tertiary"
                 />
             </div>
+        </div>
+    </section>
+
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Max size per file</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code>maxSize</code> (bytes) to reject files above a threshold. Rejections are
+            reported through <code>onReject</code>.
+        </p>
+        <div class="rounded-lg bg-surface-container-high p-4">
+            <FileUpload
+                bind:value={maxSizeFiles}
+                multiple
+                maxSize={1024 * 1024}
+                label="Max 1 MB per file"
+                description="Try a small text file vs. a high-res image"
+                onReject={(r) => (rejections = r)}
+            />
+            {#if rejections.length}
+                <ul class="mt-3 space-y-1 text-sm text-error">
+                    {#each rejections as r (`${r.file.name}-${r.reason}`)}
+                        <li>
+                            {r.file.name} — {reasonLabel(r.reason)}
+                        </li>
+                    {/each}
+                </ul>
+            {/if}
+        </div>
+    </section>
+
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Max files count</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code>maxFiles</code> to cap the number of files in the selection. When the cap is
+            reached, the root element exposes <code>data-full</code> so CSS can style the area as inactive.
+        </p>
+        <div class="rounded-lg bg-surface-container-high p-4">
+            <FileUpload
+                bind:value={maxFilesFiles}
+                multiple
+                maxFiles={3}
+                label="Up to 3 files"
+                description="Try selecting 4 — the 4th is rejected"
+                ui={{
+                    base: 'data-[full]:opacity-60 data-[full]:pointer-events-none'
+                }}
+            />
+            <p class="mt-3 text-sm text-on-surface-variant">
+                {maxFilesFiles.length} / 3 selected
+            </p>
+        </div>
+    </section>
+
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Combined validation</h2>
+        <p class="text-sm text-on-surface-variant">
+            All three rules (<code>accept</code>, <code>maxSize</code>, <code>maxFiles</code>) work
+            together. <code>onReject</code> reports every rejected file in one call with its reason.
+        </p>
+        <div class="rounded-lg bg-surface-container-high p-4">
+            <FileUpload
+                bind:value={validationFiles}
+                multiple
+                accept="image/*"
+                maxSize={2 * 1024 * 1024}
+                maxFiles={5}
+                label="Up to 5 images, max 2 MB each"
+                description="image/* — up to 5 files — max 2 MB"
+                onReject={(r) => (combinedRejections = r)}
+            />
+            {#if combinedRejections.length}
+                <ul class="mt-3 space-y-1 text-sm text-error">
+                    {#each combinedRejections as r (`${r.file.name}-${r.reason}`)}
+                        <li>
+                            {r.file.name} — {reasonLabel(r.reason)}
+                        </li>
+                    {/each}
+                </ul>
+            {/if}
         </div>
     </section>
 </div>


### PR DESCRIPTION
## Summary

Three new validation props on **FileUpload**, plus a callback surface for rejected files.

| Prop | Type | Behavior |
| --- | --- | --- |
| `maxSize` | `number` (bytes) | Reject files above the threshold |
| `maxFiles` | `number` | Reject files past the cap; root gets `data-full` when reached |
| `onReject` | `(rejected: FileUploadRejection[]) => void` | Fires once per user action with all rejections (accept + maxSize + maxFiles) |

New exported types: `FileUploadRejection`, `FileUploadRejectionReason`.

## Pipeline

\`addFiles\` is refactored into:
1. \`validateIngress(file)\` — checks \`accept\` then \`maxSize\`
2. Dedup against existing \`value\` (multiple mode only)
3. \`applyMaxFiles(deduped)\` — slices remaining capacity, pushes excess to rejected
4. Apply accepted to \`value\`; emit single \`onReject\` call with all rejections

\`data-full\` attribute on the root makes it trivial to style the area as inactive:

\`\`\`svelte
<FileUpload
    maxFiles={3}
    ui={{ base: 'data-[full]:opacity-60 data-[full]:pointer-events-none' }}
/>
\`\`\`

## Behavior change (non-breaking)

\`accept\` rejections previously dropped silently. They now also surface through \`onReject\` — observable **only** if a caller provides the callback, so existing code is unaffected.

## Test plan

- [x] \`npm run check\` — 0 errors, 0 warnings
- [x] \`npm run lint\` — clean (only pre-existing Table complexity warnings)
- [x] \`npm test\` — **2124/2124 passed** (12 new FileUpload tests: maxSize × 4, maxFiles × 5, onReject × 3)
- [x] Dev server — \`/file-upload\` HTTP 200; 3 new demo sections (max size, max files, combined validation)
- [ ] Manual: drop oversized + valid files together → only valid added, rejected listed
- [ ] Manual: reach \`maxFiles\` limit → area shows reduced opacity via \`data-full\`

## Out of scope

- Folder picker (\`webkitdirectory\`) and drag-drop folders — dropped from this PR (see roadmap).
- \`reset()\` imperative method — \`clearAll()\` already exists and is exported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)