### PR TITLE
feat(calendar): isDateHighlightable predicate + wire maxDays for multiple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+<<<<<<< HEAD
 - **Select / SelectMenu** — `multiple` prop for selecting more than one option. When `true`, `value` becomes `string[]` and the dropdown stays open after each selection. The trigger displays selected labels joined by `separator` (default `, `), and a new `selected` snippet receives `{ items, remove, clear }` for custom rendering such as chips/tags.
 - **SelectMenu** — `createItem` prop (`boolean | 'always' | 'lazy'`) lets users add values not present in `items` by typing in the search box. Defaults to `'lazy'` (offered only when no item matches); `'always'` keeps the create option visible. Companion props: `createItemLabel` (string or `(value) => string`), `createItemIcon`, and `onCreate(value)` callback. Created values are tracked internally so the trigger renders their label even if the caller does not push them into `items`. Pressing <kbd>Enter</kbd> from the search input creates when there are no matches.
 - **Modal / Slideover** — `size` prop standardizing dimensions to `'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` (default `'md'`). For Slideover, `size` controls `max-width` for `left`/`right` sides and `max-height` for `top`/`bottom` sides.
 - **Modal / Slideover** — `transition` prop accepts string values `'none' \| 'fade' \| 'slide' \| 'scale'` in addition to the legacy `boolean`. Modal defaults to `'scale'`; Slideover defaults to `'slide'` (side-aware). `true` keeps mapping to the previous default; `false` maps to `'none'`.
 - **FileUpload** — `maxSize` (bytes per file) and `maxFiles` (count cap) validation props. Files exceeding either limit are rejected without entering `value`. The root element exposes `data-full` when the `maxFiles` limit is reached.
 - **FileUpload** — `onReject(rejected)` callback fires with the list of files that were filtered out by `accept`, `maxSize`, or `maxFiles` during a single drop or input change. New `FileUploadRejection` type exported.
+- **Calendar** — `isDateHighlightable` predicate prop for visually marking special dates (holidays, events) without affecting selection or disabled state. Matched cells receive a `data-marked` attribute and render a small dot indicator under the day number; override via the `cellTrigger` slot or `ui.cellTrigger` with the `data-[marked]:` modifier.
+- **Calendar** — `maxDays` is now wired through to bits-ui in `type="multiple"` mode (it was already wired for `range`). Set it to cap how many dates the user can pick.
 
 ### Changed
 

--- a/src/lib/Calendar/Calendar.svelte
+++ b/src/lib/Calendar/Calendar.svelte
@@ -42,6 +42,7 @@
         weekdayFormat = 'short',
         isDateDisabled,
         isDateUnavailable,
+        isDateHighlightable,
         fixedWeeks = true,
         numberOfMonths = 1,
         calendarLabel,
@@ -203,7 +204,12 @@
                                 <CalCell {date} month={month.value} class={classes.cell}>
                                     <CalDay class={classes.cellTrigger}>
                                         {#snippet child({ props })}
-                                            <span {...props}>
+                                            <span
+                                                {...props}
+                                                data-marked={isDateHighlightable?.(date)
+                                                    ? ''
+                                                    : undefined}
+                                            >
                                                 {#if daySlot}
                                                     {@render daySlot({ day: date })}
                                                 {:else}
@@ -265,12 +271,14 @@
     {@const calType = (restProps as { type?: 'single' | 'multiple' }).type ?? 'single'}
     {@const calInitialFocus = (restProps as { initialFocus?: boolean }).initialFocus}
     {#if calType === 'multiple'}
+        {@const calMaxDays = (restProps as { maxDays?: number }).maxDays}
         <Calendar.Root
             bind:ref
             bind:value={value as CalendarMultipleProps['value']}
             onValueChange={onValueChange as CalendarMultipleProps['onValueChange']}
             {...commonProps}
             type="multiple"
+            maxDays={calMaxDays}
             initialFocus={calInitialFocus}
             class={classes.root}
         >

--- a/src/lib/Calendar/Calendar.svelte.spec.ts
+++ b/src/lib/Calendar/Calendar.svelte.spec.ts
@@ -557,4 +557,98 @@ describe('Calendar', () => {
             })
         })
     })
+
+    // ==================== MAX DAYS (multiple) ====================
+
+    describe('maxDays (multiple)', () => {
+        it('should forward maxDays to bits-ui Calendar.Root', async () => {
+            render(Calendar, {
+                type: 'multiple',
+                maxDays: 3,
+                placeholder: new CalendarDate(2026, 5, 1)
+            })
+            await vi.waitFor(() => {
+                expect(getRoot()).not.toBeNull()
+            })
+        })
+
+        it('should not allow selecting more than maxDays dates', async () => {
+            const value: DateValue[] = []
+            render(Calendar, {
+                type: 'multiple',
+                maxDays: 2,
+                value,
+                placeholder: new CalendarDate(2026, 5, 1)
+            })
+            await vi.waitFor(() => expect(getDays().length).toBeGreaterThan(0))
+
+            // Click three different in-month dates
+            const inMonth = Array.from(getDays()).filter(
+                (d) => !d.hasAttribute('data-outside-month') && !d.hasAttribute('data-disabled')
+            ) as HTMLElement[]
+            inMonth[0]?.click()
+            inMonth[1]?.click()
+            inMonth[2]?.click()
+
+            await vi.waitFor(() => {
+                const selected = document.querySelectorAll('[data-calendar-day][data-selected]')
+                expect(selected.length).toBeLessThanOrEqual(2)
+            })
+        })
+    })
+
+    // ==================== IS DATE HIGHLIGHTABLE ====================
+
+    describe('isDateHighlightable', () => {
+        const markedDaysInCalendar = () => {
+            const root = getRoot()
+            if (!root) return []
+            return Array.from(root.querySelectorAll('[data-calendar-day][data-marked]'))
+        }
+
+        it('should not mark any cell when prop is undefined', async () => {
+            render(Calendar, { placeholder: new CalendarDate(2026, 5, 1) })
+            await vi.waitFor(() => expect(getDays().length).toBeGreaterThan(0))
+            expect(markedDaysInCalendar().length).toBe(0)
+        })
+
+        it('should mark cells where the predicate returns true', async () => {
+            const target = new CalendarDate(2026, 5, 15)
+            render(Calendar, {
+                placeholder: new CalendarDate(2026, 5, 1),
+                isDateHighlightable: (d: DateValue) => d.compare(target) === 0
+            })
+            await vi.waitFor(() => {
+                expect(markedDaysInCalendar().length).toBe(1)
+            })
+        })
+
+        it('should mark multiple cells across the visible month', async () => {
+            render(Calendar, {
+                placeholder: new CalendarDate(2026, 5, 1),
+                isDateHighlightable: (d: DateValue) => d.day === 1 || d.day === 15 || d.day === 28
+            })
+            await vi.waitFor(() => {
+                // The visible grid contains the target month plus padding from
+                // adjacent months; the predicate matches by day-of-month so it
+                // can fire more than 3 times. Just assert ≥ 3.
+                expect(markedDaysInCalendar().length).toBeGreaterThanOrEqual(3)
+            })
+        })
+
+        it('should keep data-marked alongside data-selected on the same cell', async () => {
+            const target = new CalendarDate(2026, 5, 10)
+            render(Calendar, {
+                placeholder: new CalendarDate(2026, 5, 1),
+                value: target,
+                isDateHighlightable: (d: DateValue) => d.compare(target) === 0
+            })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+                const el = root!.querySelector('[data-calendar-day][data-selected][data-marked]')
+                expect(el).not.toBeNull()
+            })
+        })
+    })
 })

--- a/src/lib/Calendar/calendar.types.ts
+++ b/src/lib/Calendar/calendar.types.ts
@@ -36,6 +36,15 @@ type SharedCalendarRootProps = {
     weekdayFormat?: Intl.DateTimeFormatOptions['weekday']
     isDateDisabled?: DateMatcher
     isDateUnavailable?: DateMatcher
+    /**
+     * Predicate that returns `true` for dates that should be visually marked
+     * (e.g. holidays, events). Marked dates remain selectable; only their
+     * appearance changes. The cell trigger gets a `data-marked` attribute
+     * which the variants render as a small dot indicator.
+     *
+     * Called for every visible cell, so keep it cheap and pure.
+     */
+    isDateHighlightable?: DateMatcher
     /** @default true */
     fixedWeeks?: boolean
     /** @default 1 */

--- a/src/lib/Calendar/calendar.variants.ts
+++ b/src/lib/Calendar/calendar.variants.ts
@@ -20,6 +20,7 @@ export const calendarVariants = tv({
             'data-unavailable:line-through data-unavailable:text-on-surface-variant data-unavailable:pointer-events-none',
             'data-today:font-semibold',
             'data-[outside-month]:text-on-surface-variant',
+            'data-[marked]:after:content-[""] data-[marked]:after:absolute data-[marked]:after:bottom-0.5 data-[marked]:after:left-1/2 data-[marked]:after:-translate-x-1/2 data-[marked]:after:size-1 data-[marked]:after:rounded-full data-[marked]:after:bg-current',
             'transition'
         ],
         cellWeek: 'relative text-center text-on-surface-variant',

--- a/src/routes/calendar/+page.svelte
+++ b/src/routes/calendar/+page.svelte
@@ -19,6 +19,13 @@
         end: new CalendarDate(2024, 3, 20)
     })
 
+    let capValues: DateValue[] | undefined = $state([])
+    let markedValue: DateValue | undefined = $state(undefined)
+
+    const todayDate = today(getLocalTimeZone())
+    const markedDays = new Set([1, 7, 14, 23])
+    const isDayMarked = (d: DateValue) => markedDays.has(d.day)
+
     function formatDate(date: DateValue | undefined): string {
         if (!date) return 'Pick a date'
         return date.toDate('UTC').toLocaleDateString('en-US', {
@@ -323,6 +330,41 @@
                     headCell: 'text-primary/60'
                 }}
             />
+        </div>
+    </section>
+
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold text-on-surface">Max days (multiple)</h2>
+        <p class="text-sm text-on-surface-variant">
+            Cap how many dates can be selected in <code>type="multiple"</code> via
+            <code>maxDays</code>. The same prop is available on range calendars (and
+            <code>minDays</code> too).
+        </p>
+        <div class="rounded-lg bg-surface-container-high p-4">
+            <Calendar type="multiple" bind:value={capValues} maxDays={3} placeholder={todayDate} />
+            <p class="mt-3 text-sm text-on-surface-variant">
+                {capValues?.length ?? 0} / 3 selected
+            </p>
+        </div>
+    </section>
+
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold text-on-surface">Highlight specific dates</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code>isDateHighlightable</code> to mark special dates (holidays, events) with a
+            small dot indicator. Marked dates remain selectable; only their appearance changes.
+            Style overrides via <code>ui.cellTrigger</code> with the <code>data-[marked]:</code>
+            modifier.
+        </p>
+        <div class="rounded-lg bg-surface-container-high p-4">
+            <Calendar
+                bind:value={markedValue}
+                isDateHighlightable={isDayMarked}
+                placeholder={todayDate}
+            />
+            <p class="mt-3 text-sm text-on-surface-variant">
+                Highlighted: days {Array.from(markedDays).join(', ')} of the visible month.
+            </p>
         </div>
     </section>
 </div>


### PR DESCRIPTION
## Summary

Two Calendar additions:

### 1. \`isDateHighlightable\` predicate (NEW)

Mark special dates (holidays, events) visually without affecting selection. The predicate is called per visible cell; when it returns \`true\`, the day's \`<span>\` gets a \`data-marked\` attribute and renders a small \`bg-current\` dot under the day number.

\`\`\`svelte
<Calendar isDateHighlightable={(d) => holidays.has(d.day)} />
\`\`\`

- Available on all modes (single / multiple / range) — declared on \`SharedCalendarRootProps\`.
- Reuses bits-ui \`DateMatcher\` type \`(date: DateValue) => boolean\`.
- Marked cells stay selectable; selected/today/disabled states layer on top.
- Override via \`ui.cellTrigger\` with the \`data-[marked]:\` modifier.

### 2. \`maxDays\` wired for \`type="multiple"\`

\`maxDays\` was already declared on \`CalendarMultipleProps\` and supported by bits-ui, but the multiple branch of \`Calendar.svelte\` did not forward it (the range branch already wires both \`minDays\` and \`maxDays\`). Now the prop actually enforces a cap on how many dates the user can pick.

\`\`\`svelte
<Calendar type="multiple" maxDays={3} />
\`\`\`

## Behavior change (minor)

Users who previously passed \`maxDays\` to \`type="multiple"\` expecting it to work — it now does. Probability low (no enforcement = unusable, so users likely didn't pass it). Documented in CHANGELOG.

## Test plan

- [x] \`npm run check\` — 0 errors, 0 warnings
- [x] \`npm run lint\` — clean (only pre-existing Table complexity warnings)
- [x] \`npm test\` — **2118/2118 passed** (6 new Calendar tests: 2 maxDays + 4 isDateHighlightable)
- [x] Dev server — \`/calendar\` HTTP 200; 2 new demo sections (max days multiple, highlight specific dates)
- [ ] Manual: visually verify the dot indicator on all 4 variants (solid/outline/soft/subtle) and all 8 colors
- [ ] Manual: verify dot remains visible when cell is selected
- [ ] Manual: confirm \`maxDays={2}\` on multiple actually blocks the 3rd click

🤖 Generated with [Claude Code](https://claude.com/claude-code)