### PR TITLE
feat(file-upload,calendar,pin-input): FormField context + PinInput loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-<<<<<<< HEAD
 - **Select / SelectMenu** — `multiple` prop for selecting more than one option. When `true`, `value` becomes `string[]` and the dropdown stays open after each selection. The trigger displays selected labels joined by `separator` (default `, `), and a new `selected` snippet receives `{ items, remove, clear }` for custom rendering such as chips/tags.
 - **SelectMenu** — `createItem` prop (`boolean | 'always' | 'lazy'`) lets users add values not present in `items` by typing in the search box. Defaults to `'lazy'` (offered only when no item matches); `'always'` keeps the create option visible. Companion props: `createItemLabel` (string or `(value) => string`), `createItemIcon`, and `onCreate(value)` callback. Created values are tracked internally so the trigger renders their label even if the caller does not push them into `items`. Pressing <kbd>Enter</kbd> from the search input creates when there are no matches.
 - **Modal / Slideover** — `size` prop standardizing dimensions to `'sm' \| 'md' \| 'lg' \| 'xl' \| 'full'` (default `'md'`). For Slideover, `size` controls `max-width` for `left`/`right` sides and `max-height` for `top`/`bottom` sides.
@@ -18,10 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **FileUpload** — `onReject(rejected)` callback fires with the list of files that were filtered out by `accept`, `maxSize`, or `maxFiles` during a single drop or input change. New `FileUploadRejection` type exported.
 - **Calendar** — `isDateHighlightable` predicate prop for visually marking special dates (holidays, events) without affecting selection or disabled state. Matched cells receive a `data-marked` attribute and render a small dot indicator under the day number; override via the `cellTrigger` slot or `ui.cellTrigger` with the `data-[marked]:` modifier.
 - **Calendar** — `maxDays` is now wired through to bits-ui in `type="multiple"` mode (it was already wired for `range`). Set it to cap how many dates the user can pick.
+- **PinInput** — `loading` and `loadingIcon` props. When `loading` is true, a spinner overlays the cells and the input is disabled, ideal for OTP verification flows.
+- **FileUpload** — `id` is now applied to the focusable element (the dropzone area, or the `Button` when `variant="button"`) so a parent `<FormField>`'s label can target it.
+- **Calendar** — new `id` and `name` props on the root. `id` flows to bits-ui's root for label association; `name` is exposed as `data-name` for downstream consumers.
 
 ### Changed
 
 - **FileUpload** — `accept` rejections now also surface through `onReject` (previously silent). No behavior change unless an `onReject` callback is provided.
+- **FileUpload / Calendar** — now read the parent `<FormField>` context. Errors propagate to `aria-invalid` + visual highlight (FileUpload) or error color (Calendar), and `aria-describedby` wires up to the FormField's description and error text. Focus, blur, and change events are emitted to the parent `<Form>` when wrapped in a FormField.
 
 ### Deprecated
 

--- a/src/lib/Calendar/Calendar.svelte
+++ b/src/lib/Calendar/Calendar.svelte
@@ -16,6 +16,7 @@
     import Icon from '../Icon/Icon.svelte'
     import type { DateValue } from '@internationalized/date'
     import type { Month } from 'bits-ui'
+    import { useFormField, useFormFieldEmit } from '../hooks/useFormField.svelte.js'
 
     const config = getComponentConfig('calendar', calendarDefaults)
 
@@ -25,6 +26,8 @@
         onValueChange,
         placeholder = $bindable(),
         onPlaceholderChange,
+        id,
+        name,
         range = false,
         prevMonthIcon = 'lucide:chevron-left',
         nextMonthIcon = 'lucide:chevron-right',
@@ -60,11 +63,31 @@
         ...restProps
     }: Props = $props()
 
+    const formFieldContext = useFormField()
+    const emit = useFormFieldEmit()
+
+    const hasError = $derived(
+        formFieldContext?.error !== undefined && formFieldContext?.error !== false
+    )
+    const resolvedColor = $derived(hasError ? 'error' : color)
+    const resolvedSize = $derived(size ?? formFieldContext?.size)
+    const resolvedId = $derived(id ?? formFieldContext?.ariaId)
+    const resolvedName = $derived(name ?? formFieldContext?.name)
+    const ariaDescribedBy = $derived(
+        !formFieldContext
+            ? undefined
+            : hasError
+              ? `${formFieldContext.ariaId}-error`
+              : `${formFieldContext.ariaId}-description ${formFieldContext.ariaId}-help`
+    )
+
     // Only Cell and Day differ between Calendar & RangeCalendar
     const CalCell = $derived(range ? RangeCalendar.Cell : Calendar.Cell)
     const CalDay = $derived(range ? RangeCalendar.Day : Calendar.Day)
 
-    const variantSlots = $derived(calendarVariants({ color, size, variant, weekNumbers }))
+    const variantSlots = $derived(
+        calendarVariants({ color: resolvedColor, size: resolvedSize, variant, weekNumbers })
+    )
     const classes = $derived({
         root: variantSlots.root({ class: [config.slots.root, className, ui?.root] }),
         header: variantSlots.header({ class: [config.slots.header, ui?.header] }),
@@ -96,6 +119,7 @@
     }
 
     const commonProps = $derived({
+        id: resolvedId,
         placeholder,
         onPlaceholderChange: (val: DateValue) => {
             placeholder = val
@@ -115,8 +139,18 @@
         calendarLabel,
         locale,
         readonly,
-        disableDaysOutsideMonth
+        disableDaysOutsideMonth,
+        'aria-describedby': ariaDescribedBy,
+        'aria-invalid': hasError ? true : undefined,
+        'data-name': resolvedName,
+        onfocusin: () => emit.onFocus(),
+        onfocusout: () => emit.onBlur()
     })
+
+    function handleValueChange(val: unknown) {
+        ;(onValueChange as ((value: unknown) => void) | undefined)?.(val)
+        emit.onChange()
+    }
 </script>
 
 {#snippet calendarContent(months: Month<DateValue>[], weekdays: string[])}
@@ -254,7 +288,7 @@
     <RangeCalendar.Root
         bind:ref
         bind:value={value as CalendarRangeProps['value']}
-        onValueChange={onValueChange as CalendarRangeProps['onValueChange']}
+        onValueChange={handleValueChange as CalendarRangeProps['onValueChange']}
         {...commonProps}
         minDays={rp.minDays}
         maxDays={rp.maxDays}
@@ -275,7 +309,7 @@
         <Calendar.Root
             bind:ref
             bind:value={value as CalendarMultipleProps['value']}
-            onValueChange={onValueChange as CalendarMultipleProps['onValueChange']}
+            onValueChange={handleValueChange as CalendarMultipleProps['onValueChange']}
             {...commonProps}
             type="multiple"
             maxDays={calMaxDays}
@@ -290,7 +324,7 @@
         <Calendar.Root
             bind:ref
             bind:value={value as CalendarSingleProps['value']}
-            onValueChange={onValueChange as CalendarSingleProps['onValueChange']}
+            onValueChange={handleValueChange as CalendarSingleProps['onValueChange']}
             {...commonProps}
             type="single"
             initialFocus={calInitialFocus}

--- a/src/lib/Calendar/Calendar.svelte.spec.ts
+++ b/src/lib/Calendar/Calendar.svelte.spec.ts
@@ -629,9 +629,6 @@ describe('Calendar', () => {
                 isDateHighlightable: (d: DateValue) => d.day === 1 || d.day === 15 || d.day === 28
             })
             await vi.waitFor(() => {
-                // The visible grid contains the target month plus padding from
-                // adjacent months; the predicate matches by day-of-month so it
-                // can fire more than 3 times. Just assert ≥ 3.
                 expect(markedDaysInCalendar().length).toBeGreaterThanOrEqual(3)
             })
         })
@@ -648,6 +645,31 @@ describe('Calendar', () => {
                 expect(root).not.toBeNull()
                 const el = root!.querySelector('[data-calendar-day][data-selected][data-marked]')
                 expect(el).not.toBeNull()
+            })
+        })
+    })
+
+    // ==================== FORMFIELD / ARIA ====================
+
+    describe('formfield + aria', () => {
+        it('should apply id prop to the calendar root', async () => {
+            render(Calendar, { id: 'my-cal' })
+            await vi.waitFor(() => {
+                expect(getRoot()?.id).toBe('my-cal')
+            })
+        })
+
+        it('should expose data-name when name prop is set', async () => {
+            render(Calendar, { name: 'dob' })
+            await vi.waitFor(() => {
+                expect(getRoot()?.getAttribute('data-name')).toBe('dob')
+            })
+        })
+
+        it('should not set aria-invalid when no FormField error is present', async () => {
+            render(Calendar)
+            await vi.waitFor(() => {
+                expect(getRoot()?.getAttribute('aria-invalid')).toBeNull()
             })
         })
     })

--- a/src/lib/Calendar/calendar.types.ts
+++ b/src/lib/Calendar/calendar.types.ts
@@ -63,6 +63,16 @@ type BaseCalendarProps = {
      * Bindable reference to the root DOM element.
      */
     ref?: HTMLElement | null
+    /**
+     * The HTML `id` attribute for the root element. Used by a parent
+     * `<FormField>` so the label's `for` attribute can target the calendar.
+     */
+    id?: string
+    /**
+     * The field name. Used by a parent `<Form>` to look up validation state
+     * for this calendar when wrapped in `<FormField>`.
+     */
+    name?: string
     /** @default 'lucide:chevron-left' */
     prevMonthIcon?: string
     /** @default 'lucide:chevron-right' */

--- a/src/lib/Calendar/calendar.variants.ts
+++ b/src/lib/Calendar/calendar.variants.ts
@@ -2,7 +2,7 @@ import { tv, type VariantProps } from 'tailwind-variants'
 
 export const calendarVariants = tv({
     slots: {
-        root: '',
+        root: 'w-fit',
         header: 'flex items-center justify-between',
         body: 'flex flex-col space-y-4 pt-4 sm:flex-row sm:space-x-4 sm:space-y-0',
         heading: 'text-center font-medium truncate mx-auto',

--- a/src/lib/FileUpload/FileUpload.svelte
+++ b/src/lib/FileUpload/FileUpload.svelte
@@ -12,6 +12,7 @@
     import Icon from '../Icon/Icon.svelte'
     import Button from '../Button/Button.svelte'
     import Modal from '../Modal/Modal.svelte'
+    import { useFormField, useFormFieldEmit } from '../hooks/useFormField.svelte.js'
 
     const config = getComponentConfig('fileUpload', fileUploadDefaults)
     const icons = getComponentConfig('icons', iconsDefaults)
@@ -42,6 +43,7 @@
         required = false,
         fileIcon = icons.file,
         imagePreview = true,
+        id,
         name,
         leadingSlot,
         labelSlot,
@@ -62,6 +64,9 @@
     let previewOpen = $state(false)
     let previewFile = $state<File | null>(null)
 
+    const formFieldContext = useFormField()
+    const emit = useFormFieldEmit()
+
     // Stable file identity key with separator to avoid collisions
     const fileKey = (f: File) => `${f.name}:${f.size}:${f.lastModified}`
 
@@ -69,6 +74,20 @@
     // state. SvelteMap mutations would cascade re-renders every time a URL is cached/evicted.
     // eslint-disable-next-line svelte/prefer-svelte-reactivity
     const urlCache = new Map<string, string>()
+
+    const hasError = $derived(
+        formFieldContext?.error !== undefined && formFieldContext?.error !== false
+    )
+    const resolvedHighlight = $derived(highlight || hasError)
+    const resolvedId = $derived(id ?? formFieldContext?.ariaId)
+    const resolvedName = $derived(name ?? formFieldContext?.name)
+    const ariaDescribedBy = $derived(
+        !formFieldContext
+            ? undefined
+            : hasError
+              ? `${formFieldContext.ariaId}-error`
+              : `${formFieldContext.ariaId}-description ${formFieldContext.ariaId}-help`
+    )
 
     const isDisabled = $derived(disabled || loading)
     const isDragging = $derived(dragCounter > 0)
@@ -80,13 +99,13 @@
     // Pass booleans directly so compound variants with `false` values match correctly
     const slots = $derived(
         fileUploadVariants({
-            color,
+            color: hasError ? 'error' : color,
             size,
             variant,
             layout,
             dropzone,
             interactive: interactive && !isDisabled,
-            highlight,
+            highlight: resolvedHighlight,
             multiple,
             disabled: isDisabled
         })
@@ -198,6 +217,7 @@
         if (accepted.length) {
             value = multiple ? [...value, ...accepted] : accepted
             onValueChange?.(value)
+            emit.onChange()
         }
         if (rejected.length) onReject?.(rejected)
     }
@@ -215,6 +235,7 @@
         }
         value = value.filter((_, i) => i !== index)
         onValueChange?.(value)
+        emit.onChange()
     }
 
     export function clearAll() {
@@ -224,6 +245,7 @@
         urlCache.clear()
         value = []
         onValueChange?.(value)
+        emit.onChange()
     }
 
     function handleInputChange(e: Event) {
@@ -299,7 +321,7 @@
         bind:this={inputRef}
         type="file"
         id={autoId}
-        {name}
+        name={resolvedName}
         {accept}
         {multiple}
         {required}
@@ -314,18 +336,23 @@
         <!-- Area / Dropzone -->
         <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
         <div
+            id={resolvedId}
             class={classes.base}
             data-dragging={isDragging ? '' : undefined}
             role={interactive ? 'button' : undefined}
             tabindex={interactive && !isDisabled ? 0 : undefined}
             aria-disabled={isDisabled || undefined}
             aria-label={interactive ? label : undefined}
+            aria-invalid={resolvedHighlight ? true : undefined}
+            aria-describedby={ariaDescribedBy}
             onclick={handleAreaClick}
             ondragenter={handleDragEnter}
             ondragover={handleDragOver}
             ondragleave={handleDragLeave}
             ondrop={handleDrop}
             onkeydown={handleKeydown}
+            onfocus={() => emit.onFocus()}
+            onblur={() => emit.onBlur()}
         >
             {#if showFilesInside}
                 <!-- Grid single: file fills the area as overlay -->
@@ -429,6 +456,7 @@
     {:else}
         <!-- Button variant -->
         <Button
+            id={resolvedId}
             {color}
             {size}
             disabled={isDisabled}
@@ -436,7 +464,11 @@
             {loadingIcon}
             leadingIcon={loading ? undefined : icon}
             {label}
+            aria-invalid={resolvedHighlight ? true : undefined}
+            aria-describedby={ariaDescribedBy}
             onclick={handleAreaClick}
+            onfocus={() => emit.onFocus()}
+            onblur={() => emit.onBlur()}
         />
     {/if}
 

--- a/src/lib/FileUpload/FileUpload.svelte.spec.ts
+++ b/src/lib/FileUpload/FileUpload.svelte.spec.ts
@@ -602,4 +602,37 @@ describe('FileUpload', () => {
             expect(reasons).toContain('maxFiles')
         })
     })
+
+    // ==================== FORMFIELD / ARIA ====================
+
+    describe('formfield + aria', () => {
+        it('should put id on the focusable area (variant=area)', () => {
+            render(FileUpload, { id: 'upload-1' })
+            const area = getArea()
+            expect(area?.id).toBe('upload-1')
+        })
+
+        it('should put id on the button (variant=button)', () => {
+            render(FileUpload, { id: 'upload-btn', variant: 'button', label: 'Upload' })
+            const btn = document.querySelector('button[id="upload-btn"]')
+            expect(btn).not.toBeNull()
+        })
+
+        it('should set aria-invalid when highlight is true', () => {
+            render(FileUpload, { highlight: true })
+            const area = getArea()
+            expect(area?.getAttribute('aria-invalid')).toBe('true')
+        })
+
+        it('should not set aria-invalid when highlight is false', () => {
+            render(FileUpload, {})
+            const area = getArea()
+            expect(area?.getAttribute('aria-invalid')).toBeNull()
+        })
+
+        it('should pass name through to hidden file input', () => {
+            render(FileUpload, { name: 'avatar' })
+            expect(getInput().name).toBe('avatar')
+        })
+    })
 })

--- a/src/lib/PinInput/PinInput.svelte
+++ b/src/lib/PinInput/PinInput.svelte
@@ -7,10 +7,12 @@
 <script lang="ts">
     import { PinInput, useId } from 'bits-ui'
     import { pinInputVariants, pinInputDefaults } from './pin-input.variants.js'
-    import { getComponentConfig } from '../config.js'
+    import { getComponentConfig, iconsDefaults } from '../config.js'
     import { useFormField, useFormFieldEmit } from '../hooks/useFormField.svelte.js'
+    import Icon from '../Icon/Icon.svelte'
 
     const config = getComponentConfig('pinInput', pinInputDefaults)
+    const icons = getComponentConfig('icons', iconsDefaults)
 
     let {
         ref = $bindable(null),
@@ -33,6 +35,8 @@
         autofocus = false,
         autofocusDelay = 0,
         highlight = false,
+        loading = false,
+        loadingIcon = icons.loading,
         fixed = false,
         color = config.defaultVariants.color,
         size,
@@ -44,6 +48,8 @@
 
     const formFieldContext = useFormField()
     const emit = useFormFieldEmit()
+
+    const isDisabled = $derived(disabled || loading)
 
     const autoInputId = useId()
     const hasError = $derived(
@@ -86,7 +92,7 @@
             size: resolvedSize,
             highlight: resolvedHighlight,
             fixed,
-            disabled
+            disabled: isDisabled
         })
     )
 
@@ -107,15 +113,23 @@
     })
 </script>
 
-<div class="contents" {...restProps}>
+<div class="relative inline-flex" {...restProps}>
     {#if resolvedName}
         <input type="hidden" name={resolvedName} {value} />
+    {/if}
+    {#if loading}
+        <span
+            class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-surface/60"
+            aria-hidden="true"
+        >
+            <Icon name={loadingIcon} class="size-5 animate-spin text-on-surface-variant" />
+        </span>
     {/if}
     <PinInput.Root
         bind:ref
         {value}
         maxlength={length}
-        {disabled}
+        disabled={isDisabled}
         {textalign}
         onComplete={handleComplete}
         pasteTransformer={resolvedPasteTransformer}

--- a/src/lib/PinInput/PinInput.svelte.spec.ts
+++ b/src/lib/PinInput/PinInput.svelte.spec.ts
@@ -369,4 +369,41 @@ describe('PinInput', () => {
             expect(cell.className).toMatch(/ring-success/)
         })
     })
+
+    // ==================== LOADING ====================
+
+    describe('loading', () => {
+        it('should not show spinner overlay by default', () => {
+            render(PinInput)
+            expect(document.querySelector('[aria-hidden="true"] .animate-spin')).toBeNull()
+        })
+
+        it('should show spinner overlay when loading is true', async () => {
+            render(PinInput, { loading: true })
+            await vi.waitFor(() => {
+                const overlay = document.querySelector(
+                    'span[aria-hidden="true"].pointer-events-none'
+                )
+                expect(overlay).not.toBeNull()
+                expect(overlay!.querySelector('svg')).not.toBeNull()
+            })
+        })
+
+        it('should disable the hidden input when loading is true', () => {
+            render(PinInput, { loading: true })
+            const input = getInput()
+            expect(input?.disabled).toBe(true)
+        })
+
+        it('should accept custom loadingIcon', async () => {
+            render(PinInput, { loading: true, loadingIcon: 'lucide:loader-2' })
+            await vi.waitFor(() => {
+                const overlay = document.querySelector(
+                    'span[aria-hidden="true"].pointer-events-none'
+                )
+                expect(overlay).not.toBeNull()
+                expect(overlay!.querySelector('svg')).not.toBeNull()
+            })
+        })
+    })
 })

--- a/src/lib/PinInput/pin-input.types.ts
+++ b/src/lib/PinInput/pin-input.types.ts
@@ -93,6 +93,19 @@ export type PinInputProps = Pick<
         highlight?: boolean
 
         /**
+         * Show a loading spinner over the cells and disable interaction.
+         * Useful when verifying an OTP code against a backend.
+         * @default false
+         */
+        loading?: boolean
+
+        /**
+         * Icon displayed as the loading indicator. Defaults to `icons.loading`
+         * from the global app config (`lucide:loader-circle`).
+         */
+        loadingIcon?: string
+
+        /**
          * Prevent responsive text size changes on mobile.
          * @default false
          */

--- a/src/routes/calendar/+page.svelte
+++ b/src/routes/calendar/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-    import { Calendar, Button, Popover, Icon } from '$lib/index.js'
+    import { Calendar, Button, Popover, Icon, Form, FormField } from '$lib/index.js'
+    import type { FormApi } from '$lib/index.js'
+    import { z } from 'zod'
     import { CalendarDate, today, getLocalTimeZone } from '@internationalized/date'
     import type { DateValue } from '@internationalized/date'
     import type { DateRange } from 'bits-ui'
@@ -25,6 +27,20 @@
     const todayDate = today(getLocalTimeZone())
     const markedDays = new Set([1, 7, 14, 23])
     const isDayMarked = (d: DateValue) => markedDays.has(d.day)
+
+    const calendarFormSchema = z.object({
+        birthday: z.custom<DateValue>((v) => v !== null && v !== undefined, {
+            message: 'Birthday is required'
+        })
+    })
+
+    let calendarFormState = $state<{ birthday: DateValue | undefined }>({ birthday: undefined })
+    let calendarFormApi = $state<FormApi<unknown>>()
+    let calendarSubmitted = $state<string | null>(null)
+
+    function handleCalendarSubmit(event: { data: unknown }) {
+        calendarSubmitted = JSON.stringify(event.data, null, 2)
+    }
 
     function formatDate(date: DateValue | undefined): string {
         if (!date) return 'Pick a date'
@@ -365,6 +381,50 @@
             <p class="mt-3 text-sm text-on-surface-variant">
                 Highlighted: days {Array.from(markedDays).join(', ')} of the visible month.
             </p>
+        </div>
+    </section>
+
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold text-on-surface">Inside a Form (Zod schema)</h2>
+        <p class="text-sm text-on-surface-variant">
+            Calendar reads the parent <code>FormField</code> + <code>Form</code> context. Try
+            submitting without picking a date — the Zod schema fails and the calendar switches to
+            error color with <code>aria-invalid</code>. Pick any date and the error clears
+            automatically as the schema re-runs on the value change.
+        </p>
+        <div class="rounded-lg border border-outline-variant bg-surface-container p-6">
+            <Form
+                bind:api={calendarFormApi}
+                bind:state={calendarFormState}
+                schema={calendarFormSchema}
+                onsubmit={handleCalendarSubmit}
+                class="max-w-md space-y-4"
+            >
+                <FormField name="birthday" label="Birthday" required>
+                    <Calendar bind:value={calendarFormState.birthday} />
+                </FormField>
+
+                <div class="flex items-center gap-3">
+                    <Button type="submit" loading={calendarFormApi?.loading}>Submit</Button>
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        color="secondary"
+                        onclick={() => calendarFormApi?.clear()}
+                    >
+                        Clear errors
+                    </Button>
+                </div>
+            </Form>
+
+            {#if calendarSubmitted}
+                <div
+                    class="mt-4 rounded-md border border-primary/20 bg-primary-container p-3 text-sm text-on-primary-container"
+                >
+                    <p class="font-medium">Submitted:</p>
+                    <pre class="mt-1 text-xs">{calendarSubmitted}</pre>
+                </div>
+            {/if}
         </div>
     </section>
 </div>

--- a/src/routes/file-upload/+page.svelte
+++ b/src/routes/file-upload/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-    import { FileUpload, Button } from '$lib/index.js'
-    import type { FileUploadRejection } from '$lib/index.js'
+    import { FileUpload, Button, Form, FormField } from '$lib/index.js'
+    import type { FileUploadRejection, FormApi } from '$lib/index.js'
+    import { z } from 'zod'
 
     const colors = [
         'primary',
@@ -36,6 +37,30 @@
         if (reason === 'maxSize') return 'too large'
         if (reason === 'maxFiles') return 'too many'
         return 'wrong type'
+    }
+
+    const fileUploadSchema = z.object({
+        avatar: z.array(z.instanceof(File)).min(1, 'Avatar is required'),
+        gallery: z.array(z.instanceof(File)).min(2, 'Pick at least 2 images')
+    })
+
+    let fileUploadFormState = $state<{ avatar: File[]; gallery: File[] }>({
+        avatar: [],
+        gallery: []
+    })
+    let fileUploadFormApi = $state<FormApi<unknown>>()
+    let fileUploadSubmitted = $state<string | null>(null)
+
+    function handleFileUploadSubmit(event: { data: unknown }) {
+        const data = event.data as { avatar: File[]; gallery: File[] }
+        fileUploadSubmitted = JSON.stringify(
+            {
+                avatar: data.avatar.map((f) => f.name),
+                gallery: data.gallery.map((f) => f.name)
+            },
+            null,
+            2
+        )
     }
 </script>
 
@@ -505,6 +530,64 @@
                         </li>
                     {/each}
                 </ul>
+            {/if}
+        </div>
+    </section>
+
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Inside a Form (Zod schema)</h2>
+        <p class="text-sm text-on-surface-variant">
+            FileUpload reads the parent <code>FormField</code> + <code>Form</code> context. When the
+            Zod schema fails, the FormField shows the error and FileUpload picks up
+            <code>aria-invalid</code> + the error highlight color. Once you pick the required number of
+            files, the schema passes and the error clears automatically — no manual error state.
+        </p>
+        <div class="rounded-lg border border-outline-variant bg-surface-container p-6">
+            <Form
+                bind:api={fileUploadFormApi}
+                bind:state={fileUploadFormState}
+                schema={fileUploadSchema}
+                onsubmit={handleFileUploadSubmit}
+                class="max-w-md space-y-4"
+            >
+                <FormField name="avatar" label="Avatar" description="JPG or PNG, max 5 MB" required>
+                    <FileUpload
+                        bind:value={fileUploadFormState.avatar}
+                        accept="image/*"
+                        label="Drop avatar here"
+                    />
+                </FormField>
+
+                <FormField name="gallery" label="Gallery" required>
+                    <FileUpload
+                        bind:value={fileUploadFormState.gallery}
+                        multiple
+                        layout="grid"
+                        accept="image/*"
+                        label="Drop at least 2 images"
+                    />
+                </FormField>
+
+                <div class="flex items-center gap-3">
+                    <Button type="submit" loading={fileUploadFormApi?.loading}>Submit</Button>
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        color="secondary"
+                        onclick={() => fileUploadFormApi?.clear()}
+                    >
+                        Clear errors
+                    </Button>
+                </div>
+            </Form>
+
+            {#if fileUploadSubmitted}
+                <div
+                    class="mt-4 rounded-md border border-primary/20 bg-primary-container p-3 text-sm text-on-primary-container"
+                >
+                    <p class="font-medium">Submitted:</p>
+                    <pre class="mt-1 text-xs">{fileUploadSubmitted}</pre>
+                </div>
             {/if}
         </div>
     </section>

--- a/src/routes/pin-input/+page.svelte
+++ b/src/routes/pin-input/+page.svelte
@@ -238,4 +238,23 @@
             </div>
         </div>
     </section>
+
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold text-on-surface">Loading</h2>
+        <p class="text-sm text-on-surface-variant">
+            Pass <code>loading</code> to overlay a spinner and disable input while verifying the
+            code (e.g. checking an OTP against the backend). Use <code>loadingIcon</code> to customize
+            the spinner.
+        </p>
+        <div class="flex flex-wrap items-center gap-6 rounded-lg bg-surface-container-high p-4">
+            <div class="space-y-2">
+                <p class="text-sm font-medium text-on-surface-variant">Loading</p>
+                <PinInput loading length={6} />
+            </div>
+            <div class="space-y-2">
+                <p class="text-sm font-medium text-on-surface-variant">Loading + masked</p>
+                <PinInput loading mask color="primary" length={4} />
+            </div>
+        </div>
+    </section>
 </div>


### PR DESCRIPTION
## Summary

Three related polish changes that close cross-cutting gaps from the roadmap audit.

### FileUpload — FormField + ARIA
- \`id\` now lands on the focusable element (dropzone area or Button when \`variant="button"\`) so a parent \`<FormField>\`'s label \`for=...\` works.
- \`aria-invalid\` + \`aria-describedby\` propagate from the FormField error.
- Highlight color auto-switches to \`error\` when the field has an error.
- Focus / blur / change events emit to the parent \`<Form>\` so schema validators re-run.

### Calendar — FormField + ARIA + layout fix
- New \`id\` / \`name\` props on \`BaseCalendarProps\`. \`id\` flows to bits-ui's root; \`name\` is exposed as \`data-name\`.
- Auto error color + \`aria-invalid\` / \`aria-describedby\` from FormField context.
- \`onfocusin\` / \`onfocusout\` emit to Form; \`handleValueChange\` wrapper emits \`onChange\` for schema re-validation.
- **Layout fix**: \`root: 'w-fit'\` so the calendar shrinks to content regardless of parent width. Previously, placing a Calendar inside a constrained block container (e.g. \`max-w-md\` Form) stretched the weekday header to full width while day cells stayed at fixed \`size-8\` — producing a visual mismatch between headers and dates.

### PinInput — loading state
- New \`loading\` and \`loadingIcon\` props. When \`loading=true\`, a spinner overlays the cells and the input is disabled — useful for OTP verification flows.

### Demos
All three demos updated to follow the canonical \`<Form>\` pattern from the Form demo:
- \`bind:api={form}\` for programmatic access
- \`bind:state={state}\` shared with each \`bind:value\`
- Zod schema passed via \`schema={...}\`
- Typed \`onsubmit\` handler reading \`event.data\`
- \`Submitted:\` result block + \"Clear errors\" companion button
- Button \`loading={form?.loading}\`

## Test plan

- [x] \`npm run check\` — 0 errors, 0 warnings
- [x] \`npm run lint\` — clean (only pre-existing Table complexity warnings)
- [x] Component tests — **166/166 passed** (13 new: 5 FileUpload + 3 Calendar + 4 PinInput + 1 existing)
- [x] Playwright integration verify on dev server — clicking submit on empty forms surfaces:
    - Calendar: \"Birthday is required\" + \`aria-invalid=\"true\"\` on root
    - FileUpload: \"Avatar is required\" + \"Pick at least 2 images\"
- [x] Playwright layout verify — Calendar in Form (max-w-md): \"Sun\" header centerX = \"26\" cell centerX (diff = 0px)
- [ ] Manual: verify error clears on first selection (Calendar.onChange + FileUpload.addFiles fire \`emit.onChange()\` which re-runs schema)

## Audit cleanup (Roadmap §C)

| Item | Outcome |
| --- | --- |
| Slot/prop naming | Drop — two patterns intentional |
| ARIA / FormField wiring | **Done** for FileUpload + Calendar (this PR) |
| Transition API | Drop — boolean vs enum is intentional per component class |
| SSR guards | Drop — usages confined to client-only contexts |
| Loading state | **Done** for PinInput (this PR); Slider semantic mismatch |

🤖 Generated with [Claude Code](https://claude.com/claude-code)