### PR TITLE
fix(button): loading icon spin, ui type, native attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Button** — `ButtonProps` now type-checks native `<button>` form attributes (`name`, `value`, `form`, `formaction`, `formenctype`, `formmethod`, `formnovalidate`, `formtarget`, `popovertarget`, `popovertargetaction`) and `<a>` attributes (`download`, `hreflang`, `ping`, `media`, `referrerpolicy`), enabling typed submit buttons and download links that previously raised a type error.
+
+### Fixed
+
+- **Button** — Loading state with both `leadingIcon` and `trailingIcon` no longer renders a static (non-spinning) loader on the opposite side. The spinner now appears only on the side selected by `trailing`, and the other icon keeps its original glyph.
+- **Button** — Removed the internal `leadingAvatarSize` key from the `ui` prop type; it was accepted by the type but silently ignored at runtime.
+
 ## [1.8.0] - 2026-05-28
 
 ### Added

--- a/src/lib/Button/Button.svelte
+++ b/src/lib/Button/Button.svelte
@@ -76,13 +76,14 @@
     const isLeading = $derived((!!icon && !trailing) || (isLoading && !trailing) || !!leadingIcon)
     const isTrailing = $derived((!!icon && trailing) || (isLoading && trailing) || !!trailingIcon)
 
+    const spinLeading = $derived(isLoading && !trailing)
+    const spinTrailing = $derived(isLoading && trailing)
+
     const leadingIconName = $derived(
-        isLoading && isLeading
-            ? loadingIcon
-            : leadingIcon || (isLeading && !trailing ? icon : undefined)
+        spinLeading ? loadingIcon : leadingIcon || (!trailing ? icon : undefined)
     )
     const trailingIconName = $derived(
-        isLoading && isTrailing ? loadingIcon : trailingIcon || (trailing ? icon : undefined)
+        spinTrailing ? loadingIcon : trailingIcon || (trailing ? icon : undefined)
     )
 
     const resolvedColor = $derived(active && activeColor ? activeColor : color)
@@ -96,8 +97,8 @@
             block,
             square: isIconOnly,
             loading: isLoading,
-            leading: isLeading,
-            trailing: isTrailing
+            leading: spinLeading,
+            trailing: spinTrailing
         })
         return {
             base: slots.base({ class: [config.slots.base, fieldGroupClass, className, ui?.base] }),

--- a/src/lib/Button/Button.svelte.spec.ts
+++ b/src/lib/Button/Button.svelte.spec.ts
@@ -485,4 +485,85 @@ describe('Button', () => {
             await expect.element(link).toHaveClass(/ring-success/)
         })
     })
+
+    // ==================== NATIVE ATTRIBUTES ====================
+
+    describe('native attributes', () => {
+        it('should forward button form attributes (name, value, formaction)', async () => {
+            render(Button, {
+                label: 'Save',
+                type: 'submit',
+                name: 'action',
+                value: 'save',
+                formaction: '/save'
+            })
+            const btn = page.getByRole('button', { name: 'Save' })
+            await expect.element(btn).toHaveAttribute('name', 'action')
+            await expect.element(btn).toHaveAttribute('value', 'save')
+            await expect.element(btn).toHaveAttribute('formaction', '/save')
+        })
+
+        it('should forward anchor attributes (download, hreflang) on a link', async () => {
+            render(Button, {
+                label: 'Download',
+                href: '/file.pdf',
+                download: 'report.pdf',
+                hreflang: 'en'
+            })
+            const link = page.getByRole('link', { name: 'Download' })
+            await expect.element(link).toHaveAttribute('download', 'report.pdf')
+            await expect.element(link).toHaveAttribute('hreflang', 'en')
+        })
+    })
+
+    // ==================== LOADING ICON PLACEMENT ====================
+
+    describe('loading icon placement', () => {
+        it('should spin only the leading icon when loading with both icons', async () => {
+            const { container } = render(Button, {
+                label: 'Confirm',
+                loading: true,
+                leadingIcon: 'lucide:check',
+                trailingIcon: 'lucide:chevron-down'
+            })
+            const btn = page.getByRole('button', { name: 'Confirm' })
+            await expect.element(btn).toBeInTheDocument()
+
+            await expect
+                .poll(() => container.querySelectorAll('.animate-spin').length, { timeout: 5000 })
+                .toBe(1)
+
+            const spinner = container.querySelector('.animate-spin')!
+            const label = [...btn.element().querySelectorAll('span')].find(
+                (s) => s.textContent === 'Confirm'
+            )!
+            expect(
+                spinner.compareDocumentPosition(label) & Node.DOCUMENT_POSITION_FOLLOWING
+            ).toBeTruthy()
+        })
+
+        it('should spin only the trailing icon when loading with trailing=true', async () => {
+            const { container } = render(Button, {
+                label: 'Submit',
+                loading: true,
+                trailing: true,
+                leadingIcon: 'lucide:check',
+                trailingIcon: 'lucide:chevron-down'
+            })
+            const btn = page.getByRole('button', { name: 'Submit' })
+            await expect.element(btn).toBeInTheDocument()
+
+            await expect
+                .poll(() => container.querySelectorAll('.animate-spin').length, { timeout: 5000 })
+                .toBe(1)
+
+            const spinner = container.querySelector('.animate-spin')!
+            const label = [...btn.element().querySelectorAll('span')].find(
+                (s) => s.textContent === 'Submit'
+            )!
+            expect(
+                spinner.compareDocumentPosition(label) & Node.DOCUMENT_POSITION_PRECEDING
+            ).toBeTruthy()
+        })
+    })
 })

--- a/src/lib/Button/button.types.ts
+++ b/src/lib/Button/button.types.ts
@@ -1,185 +1,199 @@
 import type { Snippet } from 'svelte'
-import type { HTMLAttributes } from 'svelte/elements'
+import type { HTMLAttributes, HTMLButtonAttributes, HTMLAnchorAttributes } from 'svelte/elements'
 import type { ClassNameValue } from 'tailwind-merge'
 import type { ButtonVariantProps, ButtonSlots } from './button.variants.js'
 import type { AvatarProps } from '../Avatar/avatar.types.js'
 
-export type ButtonProps = Omit<HTMLAttributes<HTMLElement>, 'class' | 'color'> & {
-    /**
-     * Bindable reference to the root DOM element.
-     */
-    ref?: HTMLElement | null
+export type ButtonProps = Omit<HTMLAttributes<HTMLElement>, 'class' | 'color'> &
+    Pick<
+        HTMLButtonAttributes,
+        | 'name'
+        | 'value'
+        | 'form'
+        | 'formaction'
+        | 'formenctype'
+        | 'formmethod'
+        | 'formnovalidate'
+        | 'formtarget'
+        | 'popovertarget'
+        | 'popovertargetaction'
+    > &
+    Pick<HTMLAnchorAttributes, 'download' | 'hreflang' | 'ping' | 'media' | 'referrerpolicy'> & {
+        /**
+         * Bindable reference to the root DOM element.
+         */
+        ref?: HTMLElement | null
 
-    /**
-     * Controls the visual style of the button.
-     * @default 'solid'
-     */
-    variant?: NonNullable<ButtonVariantProps['variant']>
+        /**
+         * Controls the visual style of the button.
+         * @default 'solid'
+         */
+        variant?: NonNullable<ButtonVariantProps['variant']>
 
-    /**
-     * Sets the color scheme applied to the button.
-     * @default 'primary'
-     */
-    color?: NonNullable<ButtonVariantProps['color']>
+        /**
+         * Sets the color scheme applied to the button.
+         * @default 'primary'
+         */
+        color?: NonNullable<ButtonVariantProps['color']>
 
-    /**
-     * Controls the dimensions and text size of the button.
-     * @default 'md'
-     */
-    size?: NonNullable<ButtonVariantProps['size']>
+        /**
+         * Controls the dimensions and text size of the button.
+         * @default 'md'
+         */
+        size?: NonNullable<ButtonVariantProps['size']>
 
-    /**
-     * Text content displayed inside the button.
-     * Use this as a shorthand instead of the `children` snippet.
-     */
-    label?: string
+        /**
+         * Text content displayed inside the button.
+         * Use this as a shorthand instead of the `children` snippet.
+         */
+        label?: string
 
-    /**
-     * Renders a loading spinner and disables interaction.
-     * @default false
-     */
-    loading?: boolean
+        /**
+         * Renders a loading spinner and disables interaction.
+         * @default false
+         */
+        loading?: boolean
 
-    /**
-     * Automatically shows loading state while the onclick handler's Promise is pending.
-     * @default false
-     */
-    loadingAuto?: boolean
+        /**
+         * Automatically shows loading state while the onclick handler's Promise is pending.
+         * @default false
+         */
+        loadingAuto?: boolean
 
-    /**
-     * Icon displayed as the loading indicator.
-     * Supports any valid Iconify icon name.
-     * @default Uses `icons.loading` from app config
-     */
-    loadingIcon?: string
+        /**
+         * Icon displayed as the loading indicator.
+         * Supports any valid Iconify icon name.
+         * @default Uses `icons.loading` from app config
+         */
+        loadingIcon?: string
 
-    /**
-     * Disables the button and prevents interaction.
-     * @default false
-     */
-    disabled?: boolean
+        /**
+         * Disables the button and prevents interaction.
+         * @default false
+         */
+        disabled?: boolean
 
-    /**
-     * Stretches the button to fill the full width of its container.
-     * @default false
-     */
-    block?: boolean
+        /**
+         * Stretches the button to fill the full width of its container.
+         * @default false
+         */
+        block?: boolean
 
-    /**
-     * Forces equal width and height, ideal for icon-only buttons.
-     * @default false
-     */
-    square?: boolean
+        /**
+         * Forces equal width and height, ideal for icon-only buttons.
+         * @default false
+         */
+        square?: boolean
 
-    /**
-     * Renders the button in icon-only mode without a label.
-     * Supports any valid Iconify icon name.
-     */
-    icon?: string
+        /**
+         * Renders the button in icon-only mode without a label.
+         * Supports any valid Iconify icon name.
+         */
+        icon?: string
 
-    /**
-     * Icon placed before the label.
-     * Supports any valid Iconify icon name.
-     */
-    leadingIcon?: string
+        /**
+         * Icon placed before the label.
+         * Supports any valid Iconify icon name.
+         */
+        leadingIcon?: string
 
-    /**
-     * Icon placed after the label.
-     * Supports any valid Iconify icon name.
-     */
-    trailingIcon?: string
+        /**
+         * Icon placed after the label.
+         * Supports any valid Iconify icon name.
+         */
+        trailingIcon?: string
 
-    /**
-     * Moves the icon to the trailing (right) side.
-     * Only takes effect when using the `icon` prop.
-     * @default false
-     */
-    trailing?: boolean
+        /**
+         * Moves the icon to the trailing (right) side.
+         * Only takes effect when using the `icon` prop.
+         * @default false
+         */
+        trailing?: boolean
 
-    /**
-     * Avatar displayed before the label.
-     * Takes precedence over `leadingIcon`.
-     */
-    avatar?: AvatarProps
+        /**
+         * Avatar displayed before the label.
+         * Takes precedence over `leadingIcon`.
+         */
+        avatar?: AvatarProps
 
-    // ==================== LINK PROPS ====================
+        // ==================== LINK PROPS ====================
 
-    /**
-     * The destination URL. When provided, renders as an anchor element.
-     */
-    href?: string
+        /**
+         * The destination URL. When provided, renders as an anchor element.
+         */
+        href?: string
 
-    /**
-     * The button type attribute. Only applies when rendering as `<button>`.
-     * @default 'button'
-     */
-    type?: 'button' | 'submit' | 'reset'
+        /**
+         * The button type attribute. Only applies when rendering as `<button>`.
+         * @default 'button'
+         */
+        type?: 'button' | 'submit' | 'reset'
 
-    /**
-     * Treats the link as external, adding `rel="noopener noreferrer"` and `target="_blank"`.
-     * Auto-detected from the `href` when omitted.
-     */
-    external?: boolean
+        /**
+         * Treats the link as external, adding `rel="noopener noreferrer"` and `target="_blank"`.
+         * Auto-detected from the `href` when omitted.
+         */
+        external?: boolean
 
-    /**
-     * Overrides the auto-detected active state.
-     */
-    active?: boolean
+        /**
+         * Overrides the auto-detected active state.
+         */
+        active?: boolean
 
-    /**
-     * Requires an exact pathname match for active state detection.
-     * @default false
-     */
-    exact?: boolean
+        /**
+         * Requires an exact pathname match for active state detection.
+         * @default false
+         */
+        exact?: boolean
 
-    /**
-     * Color scheme applied when the button is active.
-     * Falls back to the `color` prop when omitted.
-     */
-    activeColor?: NonNullable<ButtonVariantProps['color']>
+        /**
+         * Color scheme applied when the button is active.
+         * Falls back to the `color` prop when omitted.
+         */
+        activeColor?: NonNullable<ButtonVariantProps['color']>
 
-    /**
-     * Visual style applied when the button is active.
-     * Falls back to the `variant` prop when omitted.
-     */
-    activeVariant?: NonNullable<ButtonVariantProps['variant']>
+        /**
+         * Visual style applied when the button is active.
+         * Falls back to the `variant` prop when omitted.
+         */
+        activeVariant?: NonNullable<ButtonVariantProps['variant']>
 
-    /**
-     * Additional CSS class applied when the button link is active.
-     */
-    activeClass?: string
+        /**
+         * Additional CSS class applied when the button link is active.
+         */
+        activeClass?: string
 
-    /**
-     * Additional CSS class applied when the button link is inactive.
-     */
-    inactiveClass?: string
+        /**
+         * Additional CSS class applied when the button link is inactive.
+         */
+        inactiveClass?: string
 
-    // ==================== SLOTS & STYLING ====================
+        // ==================== SLOTS & STYLING ====================
 
-    /**
-     * Custom content rendered before the label.
-     * Takes precedence over `avatar` and `leadingIcon`.
-     */
-    leadingSlot?: Snippet
+        /**
+         * Custom content rendered before the label.
+         * Takes precedence over `avatar` and `leadingIcon`.
+         */
+        leadingSlot?: Snippet
 
-    /**
-     * Custom content rendered after the label.
-     * Takes precedence over `trailingIcon`.
-     */
-    trailingSlot?: Snippet
+        /**
+         * Custom content rendered after the label.
+         * Takes precedence over `trailingIcon`.
+         */
+        trailingSlot?: Snippet
 
-    /**
-     * Custom content for the button label area.
-     */
-    children?: Snippet
+        /**
+         * Custom content for the button label area.
+         */
+        children?: Snippet
 
-    /**
-     * Additional CSS classes for the root element.
-     */
-    class?: ClassNameValue
+        /**
+         * Additional CSS classes for the root element.
+         */
+        class?: ClassNameValue
 
-    /**
-     * Override styles for specific button slots.
-     */
-    ui?: Partial<Record<ButtonSlots, ClassNameValue>>
-}
+        /**
+         * Override styles for specific button slots.
+         */
+        ui?: Partial<Record<Exclude<ButtonSlots, 'leadingAvatarSize'>, ClassNameValue>>
+    }


### PR DESCRIPTION
## Summary

Three Button fixes surfaced during a thorough props/type/a11y review of the component (each verified with a runnable demo/probe before fixing):

- **Loading spinner (bug):** when a button had **both** `leadingIcon` and `trailingIcon` while `loading`, the opposite side rendered a **static, non-spinning** loader. Now the spinner appears only on the side selected by `trailing`; the other icon keeps its original glyph.
- **`ui` type leak:** `ui` accepted the internal `leadingAvatarSize` slot key (a size token, not a class), which was **silently ignored** at runtime. Removed it from the type so misuse is caught at compile time.
- **Polymorphic native attrs:** `ButtonProps` used a generic `HTMLAttributes<HTMLElement>`, so native `<button>` form attrs (`name`, `value`, `form`, `formaction`, …) and `<a>` attrs (`download`, `hreflang`, …) raised a **hard type error** — a submit button needing `name`/`value` couldn't be typed. Added them via `Pick` (no full intersection, to avoid `type`/`href`/`disabled` and event-handler conflicts).

## Verification

- `npm run check` — 0 errors / 0 warnings (whole project, incl. Link consumers `User`, `Breadcrumb`).
- `npm run lint` — 0 errors.
- Tests — 65/65 pass, including **4 new** Button tests (2 spinner-placement regression, 2 native-attribute forwarding).
- Confirmed no ripple from `Button → restProps → Link` spread.

> Note: `button.types.ts` shows a large diff because wrapping the props object in an intersection reindented the whole block (mostly whitespace).

## Notes

Reviewed but intentionally **not** changed (matches common framework/library norms): icon-only accessible-name enforcement, and `href` protocol allow-listing. The `onclick`-returns-Promise concern was a false alarm (Svelte types handlers as `=> any`).---
Closes #57
