### PR TITLE
chore: repo governance — issue/PR templates, CONTRIBUTING, SECURITY

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: 🐛 Bug Report
+description: Report a bug or unexpected behavior in a component
+title: '[Bug]: '
+labels: ['bug', 'status: needs-triage']
+body:
+    - type: markdown
+      attributes:
+          value: Thanks for reporting a bug! Please search existing issues first, then fill out the form below.
+
+    - type: input
+      id: component
+      attributes:
+          label: Component
+          description: Which component is affected?
+          placeholder: Button
+      validations:
+          required: true
+
+    - type: textarea
+      id: description
+      attributes:
+          label: Describe the bug
+          description: A clear and concise description of what the bug is and what you expected instead.
+      validations:
+          required: true
+
+    - type: textarea
+      id: reproduction
+      attributes:
+          label: Reproduction
+          description: A minimal repro — a link (StackBlitz / Svelte REPL / repo) or a code snippet. Bugs without a repro may be closed.
+      validations:
+          required: true
+
+    - type: input
+      id: version
+      attributes:
+          label: sv5ui version
+          placeholder: 1.8.0
+      validations:
+          required: true
+
+    - type: dropdown
+      id: area
+      attributes:
+          label: Area
+          description: Which aspect does this bug relate to? (optional)
+          options:
+              - 'Not sure'
+              - a11y
+              - types
+              - performance
+              - security
+              - build
+              - testing
+      validations:
+          required: false
+
+    - type: checkboxes
+      id: checks
+      attributes:
+          label: Checklist
+          options:
+              - label: I searched existing issues and this is not a duplicate.
+                required: true
+              - label: I reproduced this on the latest version of sv5ui.
+                required: false

--- a/.github/ISSUE_TEMPLATE/component_review.yml
+++ b/.github/ISSUE_TEMPLATE/component_review.yml
@@ -1,0 +1,54 @@
+name: 🔍 Component Review
+description: Track a thorough review of a component (props, types, a11y, performance, Nuxt parity)
+title: '[Review]: '
+labels: ['status: needs-triage']
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Use this to track a full review of a component, following the SV5UI review checklist.
+              Each confirmed finding should become its own issue (bug/enhancement) and be linked back here.
+
+    - type: input
+      id: component
+      attributes:
+          label: Component under review
+          placeholder: Button
+      validations:
+          required: true
+
+    - type: checkboxes
+      id: scope
+      attributes:
+          label: Review scope
+          description: Tick each category as it is covered.
+          options:
+              - label: 'Layout & structure (DOM nesting, slot/snippet structure, `restProps` position)'
+              - label: 'Performance & reactivity (`$derived` vs `$derived.by`, no needless `$effect`, variants computed once)'
+              - label: 'TypeScript & type safety (no `any`/`unknown` in public types, correct `Omit`, exported surface)'
+              - label: 'Props & defaults (`$bindable` ref, config `defaultVariants`, sensible defaults)'
+              - label: 'Variant definitions (slot names, design tokens, compoundVariants, no hardcoded colors)'
+              - label: 'Bug detection (conditional rendering, spread order, context reactivity, edge cases)'
+              - label: 'Accessibility (roles, `aria-*`, keyboard, icon-only names)'
+              - label: 'Exports & public API (`index.ts` exposes only user-facing types)'
+              - label: 'Parity with Nuxt UI v4'
+
+    - type: textarea
+      id: findings
+      attributes:
+          label: Findings
+          description: Summarize findings. Link each to its own bug/enhancement issue.
+          value: |
+              | # | Severity | Category | Summary | Issue | Decision |
+              | - | -------- | -------- | ------- | ----- | -------- |
+              |   |          |          |         |       |          |
+      validations:
+          required: false
+
+    - type: input
+      id: reference
+      attributes:
+          label: Nuxt UI v4 reference
+          placeholder: https://github.com/nuxt/ui/tree/v4/src/runtime/components
+      validations:
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+    - name: 📖 Documentation
+      url: https://sv5ui.vercel.app
+      about: Read the component documentation and live examples.
+    - name: 💬 Questions & Discussions
+      url: https://github.com/ndlabdev/sv5ui/discussions
+      about: Ask a question or discuss an idea (not a bug or feature request).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,57 @@
+name: ✨ Feature Request
+description: Suggest a new component, prop, or improvement
+title: '[Feature]: '
+labels: ['enhancement', 'status: needs-triage']
+body:
+    - type: markdown
+      attributes:
+          value: Thanks for the suggestion! Please search existing issues first to avoid duplicates.
+
+    - type: input
+      id: component
+      attributes:
+          label: Component
+          description: Existing component to improve, or the name of a proposed new one.
+          placeholder: Button — or a proposed new component name
+      validations:
+          required: true
+
+    - type: textarea
+      id: problem
+      attributes:
+          label: Problem / motivation
+          description: What problem does this solve? What are you trying to do that you can't today?
+      validations:
+          required: true
+
+    - type: textarea
+      id: solution
+      attributes:
+          label: Proposed solution
+          description: Describe the API you'd like — props, slots, behavior.
+      validations:
+          required: true
+
+    - type: input
+      id: nuxt-parity
+      attributes:
+          label: Nuxt UI v4 reference
+          description: sv5ui mirrors Nuxt UI v4 where possible. Link the equivalent component/prop if one exists.
+          placeholder: https://ui.nuxt.com/components/button
+      validations:
+          required: false
+
+    - type: textarea
+      id: alternatives
+      attributes:
+          label: Alternatives considered
+      validations:
+          required: false
+
+    - type: checkboxes
+      id: checks
+      attributes:
+          label: Checklist
+          options:
+              - label: I searched existing issues and this is not a duplicate.
+                required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!-- Thanks for contributing to sv5ui! Please fill out the sections below. -->
+
+## Summary
+
+<!-- What does this PR do and why? -->
+
+Closes #
+
+## Type of change
+
+- [ ] 🐛 Bug fix
+- [ ] ✨ New feature / component
+- [ ] 📖 Documentation
+- [ ] ♻️ Refactor / chore
+- [ ] ⚠️ Breaking change
+
+## Changes
+
+<!-- Bullet list of the concrete changes. -->
+
+-
+
+## Checklist
+
+- [ ] Linked the related issue (`Closes #…`)
+- [ ] `pnpm check` passes (0 errors, 0 warnings)
+- [ ] `pnpm lint` passes
+- [ ] `pnpm test` passes
+- [ ] Added or updated tests for the change
+- [ ] Updated `CHANGELOG.md` under `[Unreleased]`
+- [ ] Followed component conventions (no comments outside `*.types.ts`, Material 3 design tokens, Nuxt UI v4 parity)
+
+## Screenshots / notes
+
+<!-- Optional: before/after screenshots, trade-offs, follow-ups. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing to sv5ui
+
+Thanks for your interest in contributing! This guide explains how to set up the project, the conventions every component follows, and the workflow from issue to merged PR.
+
+## Prerequisites
+
+- **Node.js** 22+
+- **pnpm** 10+ (the repo is pinned to pnpm; do not use npm/yarn for installs)
+
+## Setup
+
+```bash
+pnpm install
+pnpm dev        # start the docs/demo app (src/routes)
+```
+
+## Quality gates
+
+Every change must pass these locally before opening a PR (CI runs the same on `main`):
+
+```bash
+pnpm check      # svelte-check — type checking (must be 0 errors, 0 warnings)
+pnpm lint       # prettier --check + eslint
+pnpm test       # vitest (browser + node projects)
+pnpm build      # package build
+```
+
+Use `pnpm format` to auto-fix formatting.
+
+## Workflow
+
+We use an **issue-driven** flow. `dev` is the integration branch; `main` is the released branch.
+
+1. **Open an issue** first (bug, feature, or component review) using the issue templates. Wait for triage (labels + priority) unless it's trivial.
+2. **Branch from `dev`** using the naming convention below.
+3. **Implement** following the conventions, with tests and a `CHANGELOG.md` entry.
+4. **Open a PR targeting `dev`** with `Closes #<issue>` in the body and the checklist filled.
+5. After review and approval, it's merged into `dev`. Releases merge `dev → main`.
+
+> Note: CI currently runs on PRs to `main`. Until that also covers `dev`, **run the quality gates locally** before every PR to `dev`.
+
+### Branch naming
+
+```
+fix/<issue#>-short-slug      # bug fix
+feat/<issue#>-short-slug     # new feature / component
+docs/<issue#>-short-slug     # documentation
+chore/<short-slug>           # tooling, CI, deps, governance
+```
+
+### Commit messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+fix(button): correct loading icon spin
+feat(timeline): add Timeline component
+docs(readme): document defineConfig
+chore(ci): run checks on dev branch
+```
+
+Allowed types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `style`, `perf`. The scope is usually the component name (lowercase).
+
+## Coding conventions
+
+These are enforced by review and keep 40+ components consistent:
+
+- **No comments in code** except inside `*.types.ts` files. Rely on naming and types instead.
+- **Material Design 3 design tokens only** — use `bg-primary`, `text-on-surface`, `ring-outline-variant`, etc. Never hardcode colors.
+- **Mirror Nuxt UI v4** — match its slot names, variant names, and `defaultVariants` where reasonable. Diverge only with a documented reason.
+- **Styling via `tailwind-variants`** (`*.variants.ts`), with slots and `compoundVariants` for color × variant combinations.
+- **Svelte 5 runes** — `$derived` for simple derivations, `$derived.by` only for multi-line logic; avoid `$effect` unless necessary; `$bindable` for two-way props.
+- **Public types** must not leak `any`/`unknown` or internal slot/variant types. Export only what users need (`Props`, and user-facing `Size`/`Color`/`Variant`).
+
+## Component structure
+
+Each component lives in `src/lib/<Component>/`:
+
+```
+<Component>.svelte           # component (imports types + variants)
+<component>.types.ts          # public Props type (the only place comments are allowed)
+<component>.variants.ts       # tailwind-variants definition + defaults for the config system
+<Component>.svelte.spec.ts    # tests (vitest, *.svelte.spec.ts runs in the browser project)
+index.ts                      # exports the component + user-facing types only
+```
+
+### Adding a new component
+
+- [ ] Create the five files above following an existing component (e.g. `Button`) as a template.
+- [ ] Wire defaults into the config system (`defineConfig` support via the `*Defaults` export).
+- [ ] Export it from `src/lib/index.ts`.
+- [ ] Add a demo page under `src/routes/<component>/+page.svelte`.
+- [ ] Write tests covering rendering, props, variants, and behavior.
+- [ ] Add a `CHANGELOG.md` entry under `[Unreleased]`.
+
+## Changelog
+
+This project follows [Keep a Changelog](https://keepachangelog.com/) and [SemVer](https://semver.org/). Add an entry under `## [Unreleased]` in `CHANGELOG.md`, grouped by `Added` / `Changed` / `Fixed` / `Removed`, scoped by component (e.g. `**Button** — …`).
+
+## Release process (maintainers)
+
+1. Bump the version in `package.json`.
+2. Move `[Unreleased]` entries into a new versioned section in `CHANGELOG.md`.
+3. PR `dev → main`.
+4. Tag the release and run `gh release create` so it appears in the Releases sidebar.
+
+## Reporting security issues
+
+Please do **not** open public issues for security vulnerabilities. See [SECURITY.md](./SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported versions
+
+sv5ui follows semantic versioning. Security fixes are applied to the latest minor release.
+
+| Version | Supported |
+| ------- | --------- |
+| 1.x     | ✅        |
+| < 1.0   | ❌        |
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Instead, report them privately via GitHub's [**Report a vulnerability**](https://github.com/ndlabdev/sv5ui/security/advisories/new) form (repository **Security** tab → **Report a vulnerability**). This keeps the details private until a fix is released.
+
+Please include:
+
+- The affected component(s) and version.
+- A description of the vulnerability and its impact.
+- A minimal reproduction (code snippet or repro link) and the conditions required to trigger it.
+
+## What to expect
+
+- **Acknowledgement** within a few days.
+- An assessment of severity and affected versions, and a coordinated disclosure timeline.
+- Credit in the release notes once a fix ships, unless you prefer to remain anonymous.
+
+## Scope
+
+sv5ui is a UI component library — it renders markup and does not handle authentication, secrets, or server logic. The most relevant classes of issues are:
+
+- **XSS / unsafe rendering** — e.g. a component forwarding untrusted input into a dangerous sink (such as a `javascript:` URL in `href`, or unsanitized HTML).
+- **Prototype pollution** or unsafe merges in the config system.
+- **Supply-chain** concerns in build/publish tooling.
+
+> Note: passing **untrusted user data** into props that map directly to DOM attributes (e.g. `href`, `src`) is the consumer's responsibility to sanitize, consistent with Svelte/SvelteKit defaults. If you believe a component creates an unexpected sink beyond standard behavior, please report it.


### PR DESCRIPTION
## Summary

Establishes an issue-driven governance baseline for the repo. Foundation for the new contribution workflow.

> Targeting `main` because issue/PR templates only activate from the default branch.

## Changes

- **Labels** — added `area:*`, `priority:*`, `status:*` taxonomy (created via API; not in this diff).
- **Issue Forms** (`.github/ISSUE_TEMPLATE/`):
  - `bug_report.yml`, `feature_request.yml`, `component_review.yml` (mirrors the SV5UI review checklist)
  - `config.yml` — disables blank issues, links docs & discussions
- **PR template** — quality-gate checklist (check/lint/test, changelog, conventions).
- **CONTRIBUTING.md** — setup, issue→branch→PR flow, branch naming, conventional commits, coding conventions, component structure, release process.
- **SECURITY.md** — supported versions, private vulnerability reporting, scope.

## Notes

- These are docs/config only — no library code, no build impact.
- Follow-up (B4, not in this PR): extend CI to run on `dev` PRs; optional GitHub Project board.
