### PR TITLE
chore(ci): run CI on dev branch PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
     pull_request:
-        branches: [main]
+        branches: [main, dev]
     push:
-        branches: [main]
+        branches: [main, dev]
 
 jobs:
     ci:


### PR DESCRIPTION
## Summary

CI only ran on `main`, so PRs into the `dev` integration branch went through **no checks**. This adds `dev` to the `pull_request` and `push` branch filters.

Closes the CI gap noted in the governance setup.

## Changes

- `.github/workflows/ci.yml` — `branches: [main]` → `branches: [main, dev]` for both `pull_request` and `push`.
