### PR TITLE
chore: remove Nuxt references from component review issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/component_review.yml
+++ b/.github/ISSUE_TEMPLATE/component_review.yml
@@ -1,5 +1,5 @@
 name: 🔍 Component Review
-description: Track a thorough review of a component (props, types, a11y, performance, Nuxt parity)
+description: Track a thorough review of a component (props, types, a11y, performance, reference parity)
 title: '[Review]: '
 labels: ['status: needs-triage']
 body:
@@ -31,7 +31,7 @@ body:
               - label: 'Bug detection (conditional rendering, spread order, context reactivity, edge cases)'
               - label: 'Accessibility (roles, `aria-*`, keyboard, icon-only names)'
               - label: 'Exports & public API (`index.ts` exposes only user-facing types)'
-              - label: 'Parity with Nuxt UI v4'
+              - label: 'Parity with the reference implementation'
 
     - type: textarea
       id: findings
@@ -48,7 +48,7 @@ body:
     - type: input
       id: reference
       attributes:
-          label: Nuxt UI v4 reference
-          placeholder: https://github.com/nuxt/ui/tree/v4/src/runtime/components
+          label: Reference implementation
+          placeholder: Link to the reference implementation used for parity (optional)
       validations:
           required: false


### PR DESCRIPTION
## Summary

Public issues must not name the external UI library used as a parity reference — it remains an **internal** review reference only. This neutralizes the `component_review` issue template wording.

## Changes

- Parity checkbox → `Parity with the reference implementation`
- Reference field label → `Reference implementation` (neutral placeholder)
- Form description → `reference parity`
