### PR TITLE
fix(link): native attrs, restProps precedence, raw class join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Link** — `LinkProps` now type-checks native `<button>` form attributes (`name`, `value`, `form`, `formaction`, `formenctype`, `formmethod`, `formnovalidate`, `formtarget`, `popovertarget`, `popovertargetaction`) and `<a>` attributes (`download`, `hreflang`, `ping`, `media`, `referrerpolicy`), which previously raised a type error.
+
+### Fixed
+
+- **Link** — Caller-passed attributes no longer override the component's disabled-state safety attributes (`role`, `aria-disabled`, `tabindex`) or the computed `target`/`rel`/`aria-current`; `{...restProps}` is now spread before the component's own attributes.
+- **Link** — `raw` mode now resolves an array `class` value correctly (via `tailwind-merge`) instead of mis-joining it into comma-separated invalid tokens.
+
 ## [1.8.0] - 2026-05-28
 
 ### Added

--- a/src/lib/Link/Link.svelte
+++ b/src/lib/Link/Link.svelte
@@ -51,6 +51,7 @@
 
 <script lang="ts">
     import { page } from '$app/state'
+    import { twMerge } from 'tailwind-merge'
     import { linkVariants, linkDefaults } from './link.variants.js'
     import { getComponentConfig } from '../config.js'
 
@@ -113,7 +114,7 @@
 
     const baseClass = $derived.by(() => {
         const stateClass = isActive ? activeClass : inactiveClass
-        if (raw) return [className, stateClass].filter(Boolean).join(' ')
+        if (raw) return twMerge(stateClass, className)
 
         const slots = linkVariants({ active: isActive, disabled, raw })
         return slots.base({ class: [config.slots.base, stateClass, className, ui?.base] })
@@ -138,6 +139,7 @@
     <!-- eslint-disable svelte/no-navigation-without-resolve -->
     <a
         bind:this={ref}
+        {...restProps}
         href={disabled ? undefined : href}
         class={baseClass}
         target={resolvedTarget}
@@ -147,7 +149,6 @@
         aria-current={ariaCurrent}
         tabindex={disabled ? -1 : undefined}
         onclick={handleClick}
-        {...restProps}
     >
         <!-- eslint-enable svelte/no-navigation-without-resolve -->
         {@render children?.()}
@@ -155,12 +156,12 @@
 {:else}
     <button
         bind:this={ref}
+        {...restProps}
         type={type ?? 'button'}
         class={baseClass}
         {disabled}
         aria-current={ariaCurrent}
         onclick={handleClick}
-        {...restProps}
     >
         {@render children?.()}
     </button>

--- a/src/lib/Link/Link.svelte.spec.ts
+++ b/src/lib/Link/Link.svelte.spec.ts
@@ -363,4 +363,68 @@ describe('Link', () => {
             await expect.element(el).toHaveClass(/px-4/)
         })
     })
+
+    // ==================== NATIVE ATTRIBUTES ====================
+
+    describe('native attributes', () => {
+        it('should forward button form attributes (name, value, formaction)', async () => {
+            const { container } = render(Link, {
+                type: 'submit',
+                name: 'action',
+                value: 'save',
+                formaction: '/save',
+                active: false
+            })
+            const el = page.elementLocator(container.firstElementChild!)
+            await expect.element(el).toHaveAttribute('name', 'action')
+            await expect.element(el).toHaveAttribute('value', 'save')
+            await expect.element(el).toHaveAttribute('formaction', '/save')
+        })
+
+        it('should forward anchor attributes (download, hreflang)', async () => {
+            const { container } = render(Link, {
+                href: '/file.pdf',
+                download: 'report.pdf',
+                hreflang: 'en',
+                active: false
+            })
+            const el = page.elementLocator(container.firstElementChild!)
+            await expect.element(el).toHaveAttribute('download', 'report.pdf')
+            await expect.element(el).toHaveAttribute('hreflang', 'en')
+        })
+    })
+
+    // ==================== restProps PRECEDENCE ====================
+
+    describe('restProps precedence', () => {
+        it('disabled-state tabindex/role are not overridden by restProps', async () => {
+            const { container } = render(Link, {
+                href: '/x',
+                disabled: true,
+                active: false,
+                tabindex: 5,
+                role: 'button'
+            })
+            const el = container.firstElementChild!
+            expect(el.getAttribute('tabindex')).toBe('-1')
+            expect(el.getAttribute('role')).toBe('link')
+        })
+    })
+
+    // ==================== RAW CLASS ARRAY ====================
+
+    describe('raw class array', () => {
+        it('joins an array class with spaces, not commas', async () => {
+            const { container } = render(Link, {
+                href: '/x',
+                raw: true,
+                active: false,
+                class: ['text-error', 'underline']
+            })
+            const el = container.firstElementChild!
+            expect(el.className).toContain('text-error')
+            expect(el.className).toContain('underline')
+            expect(el.className).not.toContain(',')
+        })
+    })
 })

--- a/src/lib/Link/link.types.ts
+++ b/src/lib/Link/link.types.ts
@@ -1,103 +1,117 @@
 import type { Snippet } from 'svelte'
-import type { HTMLAttributes } from 'svelte/elements'
+import type { HTMLAttributes, HTMLButtonAttributes, HTMLAnchorAttributes } from 'svelte/elements'
 import type { LinkSlots } from './link.variants.js'
 import type { ClassNameValue } from 'tailwind-merge'
 
-export type LinkProps = Omit<HTMLAttributes<HTMLElement>, 'class'> & {
-    /**
-     * Bindable reference to the root DOM element.
-     */
-    ref?: HTMLElement | null
+export type LinkProps = Omit<HTMLAttributes<HTMLElement>, 'class'> &
+    Pick<
+        HTMLButtonAttributes,
+        | 'name'
+        | 'value'
+        | 'form'
+        | 'formaction'
+        | 'formenctype'
+        | 'formmethod'
+        | 'formnovalidate'
+        | 'formtarget'
+        | 'popovertarget'
+        | 'popovertargetaction'
+    > &
+    Pick<HTMLAnchorAttributes, 'download' | 'hreflang' | 'ping' | 'media' | 'referrerpolicy'> & {
+        /**
+         * Bindable reference to the root DOM element.
+         */
+        ref?: HTMLElement | null
 
-    /**
-     * The destination URL for the anchor element.
-     * When omitted, renders as a `<button>` element.
-     */
-    href?: string
+        /**
+         * The destination URL for the anchor element.
+         * When omitted, renders as a `<button>` element.
+         */
+        href?: string
 
-    /**
-     * Overrides the auto-detected active state.
-     * When omitted, the active state is inferred from the current route.
-     */
-    active?: boolean
+        /**
+         * Overrides the auto-detected active state.
+         * When omitted, the active state is inferred from the current route.
+         */
+        active?: boolean
 
-    /**
-     * Requires an exact pathname match for active state detection.
-     * @default false
-     */
-    exact?: boolean
+        /**
+         * Requires an exact pathname match for active state detection.
+         * @default false
+         */
+        exact?: boolean
 
-    /**
-     * Controls query parameter matching for active state detection.
-     * - `true` — requires an exact match of all query parameters.
-     * - `'partial'` — link's query params must be a subset of the current route.
-     * - `false` — query parameters are ignored.
-     * @default false
-     */
-    exactQuery?: boolean | 'partial'
+        /**
+         * Controls query parameter matching for active state detection.
+         * - `true` — requires an exact match of all query parameters.
+         * - `'partial'` — link's query params must be a subset of the current route.
+         * - `false` — query parameters are ignored.
+         * @default false
+         */
+        exactQuery?: boolean | 'partial'
 
-    /**
-     * Requires an exact hash match for active state detection.
-     * @default false
-     */
-    exactHash?: boolean
+        /**
+         * Requires an exact hash match for active state detection.
+         * @default false
+         */
+        exactHash?: boolean
 
-    /**
-     * Additional CSS class applied when the link is active.
-     */
-    activeClass?: string
+        /**
+         * Additional CSS class applied when the link is active.
+         */
+        activeClass?: string
 
-    /**
-     * Additional CSS class applied when the link is inactive.
-     */
-    inactiveClass?: string
+        /**
+         * Additional CSS class applied when the link is inactive.
+         */
+        inactiveClass?: string
 
-    /**
-     * Disables the link and prevents navigation.
-     * @default false
-     */
-    disabled?: boolean
+        /**
+         * Disables the link and prevents navigation.
+         * @default false
+         */
+        disabled?: boolean
 
-    /**
-     * Strips all default styling, applying only `class`, `activeClass`, and `inactiveClass`.
-     * @default false
-     */
-    raw?: boolean
+        /**
+         * Strips all default styling, applying only `class`, `activeClass`, and `inactiveClass`.
+         * @default false
+         */
+        raw?: boolean
 
-    /**
-     * Treats the link as external, adding `rel="noopener noreferrer"` and `target="_blank"`.
-     * Auto-detected from the `href` when omitted.
-     */
-    external?: boolean
+        /**
+         * Treats the link as external, adding `rel="noopener noreferrer"` and `target="_blank"`.
+         * Auto-detected from the `href` when omitted.
+         */
+        external?: boolean
 
-    /**
-     * The button type attribute. Only applies when rendering as `<button>`.
-     * @default 'button'
-     */
-    type?: 'button' | 'submit' | 'reset'
+        /**
+         * The button type attribute. Only applies when rendering as `<button>`.
+         * @default 'button'
+         */
+        type?: 'button' | 'submit' | 'reset'
 
-    /**
-     * The link target attribute. Only applies when rendering as `<a>`.
-     */
-    target?: string
+        /**
+         * The link target attribute. Only applies when rendering as `<a>`.
+         */
+        target?: string
 
-    /**
-     * The link rel attribute. Only applies when rendering as `<a>`.
-     */
-    rel?: string
+        /**
+         * The link rel attribute. Only applies when rendering as `<a>`.
+         */
+        rel?: string
 
-    /**
-     * Additional CSS classes for the root element.
-     */
-    class?: ClassNameValue
+        /**
+         * Additional CSS classes for the root element.
+         */
+        class?: ClassNameValue
 
-    /**
-     * Override styles for specific link slots.
-     */
-    ui?: Partial<Record<LinkSlots, ClassNameValue>>
+        /**
+         * Override styles for specific link slots.
+         */
+        ui?: Partial<Record<LinkSlots, ClassNameValue>>
 
-    /**
-     * Content rendered inside the link.
-     */
-    children?: Snippet
-}
+        /**
+         * Content rendered inside the link.
+         */
+        children?: Snippet
+    }


### PR DESCRIPTION
## Summary

Three Link fixes from a full review of the component. Each was verified with a runnable demo/probe (svelte-check / vitest) **before** the fix.

- **Native attributes (types):** `LinkProps` used a generic `HTMLAttributes<HTMLElement>`, so native `<button>` form attrs (`name`/`value`/`form`/`formaction`) and `<a>` attrs (`download`/`hreflang`/…) raised a **hard type error**. Added them via `Pick` (no broad intersection, to avoid `type`/`href`/`target`/`rel` conflicts).
- **restProps precedence (bug / a11y):** `{...restProps}` was spread **last**, so caller attributes could override the disabled-state safety attrs (`role`, `aria-disabled`, `tabindex=-1`) and the computed `target`/`rel`/`aria-current`. Now spread **first** so the component's own attributes win.
- **raw class join (bug):** `raw` mode joined classes with `.join(' ')`, mis-joining an array `class` into comma-separated invalid tokens. Now resolved via `tailwind-merge`.

By design (unchanged): `aria-current="page"` only when `active && exact`.

## Changes

- `src/lib/Link/link.types.ts` — `Pick` native button/anchor attrs.
- `src/lib/Link/Link.svelte` — spread `restProps` first; `twMerge` for raw class.
- `src/lib/Link/Link.svelte.spec.ts` — 4 regression tests.
- `CHANGELOG.md` — Added / Fixed entries.

## Checklist

- [x] `pnpm check` passes (0 errors, 0 warnings)
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm test` passes (2372 tests)
- [x] Added regression tests
- [x] Updated `CHANGELOG.md`

Closes #60