### PR TITLE
feat(icon): type-check SVG attributes (aria, role, data-*, events)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Icon** — `IconProps` now type-checks SVG HTML attributes — `role`, `tabindex`, `aria-*` (`aria-label`, `aria-labelledby`, `aria-describedby`, `aria-hidden`), common event handlers, and `data-*` — which previously raised a type error despite reaching the rendered `<svg>` at runtime. This unblocks typed meaningful (non-decorative) icons and test/data hooks.
+
 ## [1.8.0] - 2026-05-28
 
 ### Added

--- a/src/lib/Icon/Icon.svelte.spec.ts
+++ b/src/lib/Icon/Icon.svelte.spec.ts
@@ -180,4 +180,21 @@ describe('Icon', () => {
             await expect.element(svg).toBeInTheDocument()
         })
     })
+
+    // ==================== FORWARDED ATTRIBUTES ====================
+
+    describe('forwarded attributes', () => {
+        it('forwards aria-label, role, and data-* to the svg', async () => {
+            const { container } = render(Icon, {
+                name: 'lucide:search',
+                'aria-label': 'Search',
+                role: 'img',
+                'data-testid': 'search-icon'
+            })
+            const svg = await getSvg(container)
+            await expect.element(svg).toHaveAttribute('aria-label', 'Search')
+            await expect.element(svg).toHaveAttribute('role', 'img')
+            await expect.element(svg).toHaveAttribute('data-testid', 'search-icon')
+        })
+    })
 })

--- a/src/lib/Icon/icon.types.ts
+++ b/src/lib/Icon/icon.types.ts
@@ -1,10 +1,27 @@
 import type { IconProps as IconifyProps } from '@iconify/svelte'
+import type { SVGAttributes } from 'svelte/elements'
 import type { ClassNameValue } from 'tailwind-merge'
 
-export interface IconProps extends Omit<
-    IconifyProps,
-    'icon' | 'width' | 'height' | 'rotate' | 'flip' | 'class'
-> {
+export interface IconProps
+    extends
+        Omit<IconifyProps, 'icon' | 'width' | 'height' | 'rotate' | 'flip' | 'class'>,
+        Pick<
+            SVGAttributes<SVGSVGElement>,
+            | 'role'
+            | 'tabindex'
+            | 'aria-label'
+            | 'aria-labelledby'
+            | 'aria-describedby'
+            | 'aria-hidden'
+            | 'onclick'
+            | 'onkeydown'
+            | 'onmouseenter'
+            | 'onmouseleave'
+            | 'onfocus'
+            | 'onblur'
+        > {
+    /** Custom data attributes are forwarded to the rendered `<svg>`. */
+    [key: `data-${string}`]: unknown
     /**
      * Icon name in Iconify format: "collection:icon-name"
      * @example "lucide:home", "mdi:account", "heroicons:star"


### PR DESCRIPTION
## Summary

`IconProps` extended only the icon library's narrow prop type (`{ id, style }` + icon customisations), so SVG HTML attributes — `aria-label`, `role`, `data-*`, and event handlers (`onclick`) — were **rejected by the type** even though they reach the rendered `<svg>` at runtime via `restProps`. This blocked typing a meaningful (non-decorative) icon and common test/data hooks.

Verified with a probe (svelte-check) before the fix: 3 type errors for `aria-label` / `data-testid` / `onclick`; control props `id` / `style` did not error.

## Approach

A full `SVGAttributes<SVGSVGElement>` intersection was attempted first but produced type conflicts (`id`/`mode`) and a "union too complex" error at the wrapper's spread. The robust fix is a **targeted `Pick`** of the relevant SVG attributes plus a `data-${string}` index — this keeps the icon-library-specific props, compiles cleanly, and avoids the complexity blowup.

## Changes

- `src/lib/Icon/icon.types.ts` — `Pick` of `role`/`tabindex`/`aria-*`/common event handlers + `data-${string}` index.
- `src/lib/Icon/Icon.svelte.spec.ts` — regression test (aria-label/role/data-* type-check and forward to the svg).
- `CHANGELOG.md` — Added entry.

## Checklist

- [x] `pnpm check` passes (0 errors, 0 warnings)
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm test` passes (2369 tests)
- [x] Added regression test

Closes #62