### PR TITLE
fix(avatar-group): render avatars in array order (left-to-right)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Button** — Removed the internal `leadingAvatarSize` key from the `ui` prop type; it was accepted by the type but silently ignored at runtime.
 - **Link** — Caller-passed attributes no longer override the component's disabled-state safety attributes (`role`, `aria-disabled`, `tabindex`) or the computed `target`/`rel`/`aria-current`; `{...restProps}` is now spread before the component's own attributes.
 - **Link** — `raw` mode now resolves an array `class` value correctly (via `tailwind-merge`) instead of mis-joining it into comma-separated invalid tokens.
+- **AvatarGroup** — Avatars now render in array order left-to-right (the first avatar leftmost and on top). Previously the `flex-row-reverse` layout combined with an un-reversed list displayed them right-to-left (e.g. `[1,2,3]` rendered as `3 2 1`).
 
 ## [1.8.0] - 2026-05-28
 

--- a/src/lib/AvatarGroup/AvatarGroup.svelte
+++ b/src/lib/AvatarGroup/AvatarGroup.svelte
@@ -46,9 +46,11 @@
         }
     })
 
-    const visibleAvatars = $derived(
-        !avatars ? [] : max && max > 0 ? avatars.slice(0, max) : avatars
-    )
+    const visibleAvatars = $derived.by(() => {
+        if (!avatars) return []
+        const shown = max && max > 0 ? avatars.slice(0, max) : avatars
+        return [...shown].reverse()
+    })
 
     const overflowCount = $derived(
         avatars && max && max > 0 ? Math.max(0, avatars.length - max) : 0

--- a/src/lib/AvatarGroup/AvatarGroup.svelte.spec.ts
+++ b/src/lib/AvatarGroup/AvatarGroup.svelte.spec.ts
@@ -217,4 +217,38 @@ describe('AvatarGroup', () => {
             await expect.element(root).toHaveClass(/custom-base/)
         })
     })
+
+    // ==================== DISPLAY ORDER ====================
+    // Root is flex-row-reverse, so DOM order is the reverse of the visual order.
+    // Reversing visibleAvatars makes the array read left-to-right and puts the
+    // first avatar on top; the overflow indicator sits at the visual (right) end.
+
+    describe('display order', () => {
+        it('reverses DOM order so the array reads left-to-right visually', async () => {
+            const { container } = render(AvatarGroup, {
+                avatars: [{ text: '1' }, { text: '2' }, { text: '3' }]
+            })
+            const texts = Array.from(container.querySelectorAll('[data-avatar-fallback]')).map(
+                (el) => el.textContent
+            )
+            expect(texts).toEqual(['3', '2', '1'])
+        })
+
+        it('places the overflow indicator at the visual end', async () => {
+            const { container } = render(AvatarGroup, {
+                avatars: [
+                    { text: '1' },
+                    { text: '2' },
+                    { text: '3' },
+                    { text: '4' },
+                    { text: '5' }
+                ],
+                max: 3
+            })
+            const texts = Array.from(container.querySelectorAll('[data-avatar-fallback]')).map(
+                (el) => el.textContent
+            )
+            expect(texts).toEqual(['+2', '3', '2', '1'])
+        })
+    })
 })


### PR DESCRIPTION
## Summary

The AvatarGroup root uses `flex-row-reverse`, but `visibleAvatars` was not reversed — so a list `[1,2,3,4,5]` rendered **right-to-left** (`5 4 3 2 1`), and with `max` it showed e.g. `3 2 1 +2` instead of `1 2 3 +2`. Verified visually with a numbered demo before fixing.

Fix: reverse a **copy** of `visibleAvatars` (no prop mutation) so the array reads left-to-right with the first avatar painted on top; the overflow indicator stays at the visual (right) end.

## Changes

- `src/lib/AvatarGroup/AvatarGroup.svelte` — reverse a copy of `visibleAvatars`.
- `src/lib/AvatarGroup/AvatarGroup.svelte.spec.ts` — 2 regression tests (display order + overflow placement).
- `CHANGELOG.md` — Fixed entry.

## Also reviewed (no change — see #64)

- `{#each}` keyed by index → won't fix (presentational list, no unique key, not a reproducible bug).
- `as` polymorphic but typed as div attrs → won't fix (any-element `as` has no clean targeted type; rare use).

## Checklist

- [x] `pnpm check` passes (0 errors, 0 warnings)
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm test` passes (2379 tests)
- [x] Added regression tests

Closes #64