### PR TITLE
docs(alert): correct variant default to 'solid'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Button** — Removed the internal `leadingAvatarSize` key from the `ui` prop type; it was accepted by the type but silently ignored at runtime.
 - **Link** — Caller-passed attributes no longer override the component's disabled-state safety attributes (`role`, `aria-disabled`, `tabindex`) or the computed `target`/`rel`/`aria-current`; `{...restProps}` is now spread before the component's own attributes.
 - **Link** — `raw` mode now resolves an array `class` value correctly (via `tailwind-merge`) instead of mis-joining it into comma-separated invalid tokens.
+- **Alert** — Corrected the `variant` prop's documented default from `'soft'` to `'solid'` to match the actual runtime default.
 
 ## [1.8.0] - 2026-05-28
 

--- a/src/lib/Alert/alert.types.ts
+++ b/src/lib/Alert/alert.types.ts
@@ -52,7 +52,7 @@ export type AlertProps = Omit<HTMLAttributes<HTMLDivElement>, 'class' | 'title'>
 
     /**
      * The visual style variant.
-     * @default 'soft'
+     * @default 'solid'
      */
     variant?: NonNullable<AlertVariantProps['variant']>
 


### PR DESCRIPTION
## Summary

The Alert `variant` prop documented `@default 'soft'`, but the actual runtime default is `'solid'` (matches the reference and the existing `should default to solid variant` test). Verified with a probe before fixing. Corrected the JSDoc so IntelliSense shows the real default — no runtime/API change.

## Changes

- `src/lib/Alert/alert.types.ts` — JSDoc `@default 'soft'` → `'solid'`.
- `CHANGELOG.md` — Fixed entry.

## Also reviewed (no change — see #66)

- `as` polymorphic but typed as div attrs → won't fix (same as Card / AvatarGroup).
- `actions` keyed by index → won't fix (presentational list, no unique key).

## Checklist

- [x] `pnpm check` passes (0 errors, 0 warnings)
- [x] Runtime default already covered by an existing test

Closes #66