### PR TITLE
feat(separator): add position prop (start/center/end)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Button** — `ButtonProps` now type-checks native `<button>` form attributes (`name`, `value`, `form`, `formaction`, `formenctype`, `formmethod`, `formnovalidate`, `formtarget`, `popovertarget`, `popovertargetaction`) and `<a>` attributes (`download`, `hreflang`, `ping`, `media`, `referrerpolicy`), enabling typed submit buttons and download links that previously raised a type error.
 - **Link** — `LinkProps` now type-checks native `<button>` form attributes (`name`, `value`, `form`, `formaction`, `formenctype`, `formmethod`, `formnovalidate`, `formtarget`, `popovertarget`, `popovertargetaction`) and `<a>` attributes (`download`, `hreflang`, `ping`, `media`, `referrerpolicy`), which previously raised a type error.
 - **Icon** — `IconProps` now type-checks SVG HTML attributes — `role`, `tabindex`, `aria-*` (`aria-label`, `aria-labelledby`, `aria-describedby`, `aria-hidden`), common event handlers, and `data-*` — which previously raised a type error despite reaching the rendered `<svg>` at runtime. This unblocks typed meaningful (non-decorative) icons and test/data hooks.
+- **Separator** — `position` prop (`'start' | 'center' | 'end'`, default `'center'`) controls where the label/icon/avatar/content sits along the separator.
 
 ### Fixed
 

--- a/src/lib/Separator/Separator.svelte
+++ b/src/lib/Separator/Separator.svelte
@@ -24,6 +24,7 @@
         size = config.defaultVariants.size,
         type = config.defaultVariants.type,
         orientation = config.defaultVariants.orientation,
+        position = config.defaultVariants.position,
         decorative = false,
         class: className,
         content,
@@ -46,9 +47,11 @@
 </script>
 
 <Separator.Root bind:ref class={classes.root} {orientation} {decorative} {...restProps}>
-    <div class={classes.border}></div>
-
     {#if hasContent}
+        {#if position !== 'start'}
+            <div class={classes.border}></div>
+        {/if}
+
         <div class={classes.container}>
             {#if content}
                 {@render content()}
@@ -65,6 +68,10 @@
             {/if}
         </div>
 
+        {#if position !== 'end'}
+            <div class={classes.border}></div>
+        {/if}
+    {:else}
         <div class={classes.border}></div>
     {/if}
 </Separator.Root>

--- a/src/lib/Separator/Separator.svelte.spec.ts
+++ b/src/lib/Separator/Separator.svelte.spec.ts
@@ -206,6 +206,38 @@ describe('Separator', () => {
         })
     })
 
+    // ==================== POSITION ====================
+
+    describe('position', () => {
+        it('center (default) renders border, content, border', () => {
+            const { container } = render(Separator, { label: 'OR' })
+            const root = container.firstElementChild!
+            expect(root.children.length).toBe(3)
+            // middle child is the content container
+            expect(root.children[1].textContent).toContain('OR')
+        })
+
+        it('start renders content first, then a single border', () => {
+            const { container } = render(Separator, { label: 'OR', position: 'start' })
+            const root = container.firstElementChild!
+            expect(root.children.length).toBe(2)
+            expect(root.children[0].textContent).toContain('OR')
+        })
+
+        it('end renders a single border, then content', () => {
+            const { container } = render(Separator, { label: 'OR', position: 'end' })
+            const root = container.firstElementChild!
+            expect(root.children.length).toBe(2)
+            expect(root.children[1].textContent).toContain('OR')
+        })
+
+        it('ignores position when there is no content (single border)', () => {
+            const { container } = render(Separator, { position: 'start' })
+            const root = container.firstElementChild!
+            expect(root.children.length).toBe(1)
+        })
+    })
+
     // ==================== COMBINED ====================
 
     describe('combined', () => {

--- a/src/lib/Separator/separator.types.ts
+++ b/src/lib/Separator/separator.types.ts
@@ -24,6 +24,12 @@ export type SeparatorProps = Separator.RootProps & {
     type?: NonNullable<SeparatorVariantProps['type']>
 
     /**
+     * Position of the label/icon/avatar/content along the separator.
+     * @default 'center'
+     */
+    position?: NonNullable<SeparatorVariantProps['position']>
+
+    /**
      * Text content displayed in the center of the separator.
      */
     label?: string

--- a/src/lib/Separator/separator.variants.ts
+++ b/src/lib/Separator/separator.variants.ts
@@ -75,6 +75,11 @@ export const separatorVariants = tv({
                 border: 'h-full flex-1',
                 container: 'my-2'
             }
+        },
+        position: {
+            start: '',
+            center: '',
+            end: ''
         }
     },
     compoundVariants: [
@@ -95,7 +100,8 @@ export const separatorVariants = tv({
         color: 'surface',
         size: 'xs',
         type: 'solid',
-        orientation: 'horizontal'
+        orientation: 'horizontal',
+        position: 'center'
     }
 })
 

--- a/src/routes/separator/+page.svelte
+++ b/src/routes/separator/+page.svelte
@@ -270,4 +270,19 @@
             />
         </div>
     </section>
+
+    <!-- Position -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Position</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1">position</code> prop to
+            place the label/icon/avatar at the start, center, or end. Defaults to
+            <code class="rounded bg-surface-container-highest px-1">center</code>.
+        </p>
+        <div class="space-y-4 rounded-lg bg-surface-container-high p-4">
+            <Separator label="Start" position="start" />
+            <Separator label="Center" position="center" />
+            <Separator label="End" position="end" />
+        </div>
+    </section>
 </div>


### PR DESCRIPTION
## Summary

Adds a `position` prop to **Separator** (`'start' | 'center' | 'end'`, default `'center'`) controlling where the label/icon/avatar/content sits along the line. Came out of the Separator review (otherwise clean). Brings parity with the reference implementation.

- **center** (default): `border – content – border` (unchanged).
- **start**: `content – border`.
- **end**: `border – content`.

No-content separators render a single border regardless of `position`.

## Changes

- `separator.variants.ts` — `position` variant + `defaultVariants.position: 'center'`.
- `separator.types.ts` — `position` prop.
- `Separator.svelte` — conditional border rendering by position.
- `Separator.svelte.spec.ts` — 4 regression tests (start/center/end + no-content).
- `+page.svelte` — Position demo section.
- `CHANGELOG.md` — Added entry.

## Checklist

- [x] `pnpm check` passes (0 errors, 0 warnings)
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm test` passes (2381 tests)
- [x] Added regression tests + demo

Closes #68