### PR TITLE
docs(accordion): clarify forceMount behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Button** — `ButtonProps` now type-checks native `<button>` form attributes (`name`, `value`, `form`, `formaction`, `formenctype`, `formmethod`, `formnovalidate`, `formtarget`, `popovertarget`, `popovertargetaction`) and `<a>` attributes (`download`, `hreflang`, `ping`, `media`, `referrerpolicy`), enabling typed submit buttons and download links that previously raised a type error.
 - **Link** — `LinkProps` now type-checks native `<button>` form attributes (`name`, `value`, `form`, `formaction`, `formenctype`, `formmethod`, `formnovalidate`, `formtarget`, `popovertarget`, `popovertargetaction`) and `<a>` attributes (`download`, `hreflang`, `ping`, `media`, `referrerpolicy`), which previously raised a type error.
 - **Icon** — `IconProps` now type-checks SVG HTML attributes — `role`, `tabindex`, `aria-*` (`aria-label`, `aria-labelledby`, `aria-describedby`, `aria-hidden`), common event handlers, and `data-*` — which previously raised a type error despite reaching the rendered `<svg>` at runtime. This unblocks typed meaningful (non-decorative) icons and test/data hooks.
+- **Accordion** — Clarified the `forceMount` prop's documentation: it enables a JavaScript slide transition and unmounts closed content (the inherited primitive doc previously implied the opposite — always-mounted content).
 
 ### Fixed
 

--- a/src/lib/Accordion/Accordion.svelte.spec.ts
+++ b/src/lib/Accordion/Accordion.svelte.spec.ts
@@ -467,4 +467,17 @@ describe('Accordion', () => {
             })
         })
     })
+
+    // ==================== FORCE MOUNT ====================
+
+    describe('forceMount', () => {
+        it('unmounts a closed item content when forceMount=true (slide-transition mode)', () => {
+            const { container } = render(Accordion, {
+                forceMount: true,
+                items: [{ label: 'Sec', content: 'FM_MARKER', value: 'a' }]
+            })
+            // Item is closed (no value); forceMount mode toggles content via {#if}.
+            expect(container.textContent).not.toContain('FM_MARKER')
+        })
+    })
 })

--- a/src/lib/Accordion/accordion.types.ts
+++ b/src/lib/Accordion/accordion.types.ts
@@ -1,6 +1,6 @@
 import type { Snippet } from 'svelte'
 import type { ClassNameValue } from 'tailwind-merge'
-import type { BaseAccordionRootPropsWithoutHTML, AccordionContentPropsWithoutHTML } from 'bits-ui'
+import type { BaseAccordionRootPropsWithoutHTML } from 'bits-ui'
 import type { AccordionSlots } from './accordion.variants.js'
 
 // ============================================================================
@@ -122,10 +122,7 @@ export interface AccordionSlotProps {
  *
  * @see https://bits-ui.com/docs/components/accordion
  */
-export interface AccordionProps
-    extends
-        Omit<BaseAccordionRootPropsWithoutHTML, 'loop'>,
-        Pick<AccordionContentPropsWithoutHTML, 'forceMount'> {
+export interface AccordionProps extends Omit<BaseAccordionRootPropsWithoutHTML, 'loop'> {
     // -------------------------------------------------------------------------
     // Content
     // -------------------------------------------------------------------------
@@ -177,6 +174,18 @@ export interface AccordionProps
      * @default false
      */
     loop?: boolean
+
+    /**
+     * Use a JavaScript slide transition (enter/leave) for expanding and
+     * collapsing instead of the default CSS animation.
+     *
+     * Note: despite the name, this does **not** keep closed content mounted.
+     * When `true`, an item's content is unmounted while it is closed (required
+     * for the slide transition). The default (`false`) leaves bits-ui's CSS
+     * animation in place, which keeps closed content in the DOM (collapsed).
+     * @default false
+     */
+    forceMount?: boolean
 
     // -------------------------------------------------------------------------
     // Styling


### PR DESCRIPTION
## Summary

`Accordion`'s `forceMount` prop inherited a misleading doc (via a `Pick`) from the underlying primitive, implying it keeps content always-mounted (SEO). In reality:

- `forceMount=true` → **unmounts** an item's content while closed (to drive a JS slide transition).
- `forceMount=false` (default) → keeps closed content in the DOM (collapsed, CSS animation).

Verified with a probe before fixing. The name is kept (no breaking change); only the JSDoc is corrected and the prop is declared explicitly instead of `Pick`-ed.

## Changes

- `accordion.types.ts` — drop the `Pick<…, 'forceMount'>`; declare `forceMount` with an accurate JSDoc.
- `Accordion.svelte.spec.ts` — regression test (forceMount=true unmounts closed content).
- `CHANGELOG.md` — entry.

## Also reviewed (no change — see #70)

Defaults match docs, no `as` gap, rich slot props, items keyed by `value ?? index`, a11y via the primitive.

## Checklist

- [x] `pnpm check` (0/0) · `pnpm lint` (0 errors) · `pnpm test` (2378)
- [x] Regression test added

Closes #70