### PR TITLE
fix(drawer): forward all typed vaul props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Button** — Removed the internal `leadingAvatarSize` key from the `ui` prop type; it was accepted by the type but silently ignored at runtime.
 - **Link** — Caller-passed attributes no longer override the component's disabled-state safety attributes (`role`, `aria-disabled`, `tabindex`) or the computed `target`/`rel`/`aria-current`; `{...restProps}` is now spread before the component's own attributes.
 - **Link** — `raw` mode now resolves an array `class` value correctly (via `tailwind-merge`) instead of mis-joining it into comma-separated invalid tokens.
+- **Drawer** — Forward the remaining typed vaul-svelte props that were silently dropped (`setBackgroundColorOnScale`, `fixed`, `defaultOpen`, `disablePreventScroll`, `repositionInputs`, `snapToSequentialPoint`, `container`, `onAnimationEnd`, `preventScrollRestoration`, `autoFocus`). They were accepted by the type but never reached the underlying drawer.
 
 ## [1.8.0] - 2026-05-28
 

--- a/src/lib/Drawer/Drawer.svelte
+++ b/src/lib/Drawer/Drawer.svelte
@@ -44,7 +44,8 @@
         titleSlot,
         descriptionSlot,
         body: bodySlot,
-        footer: footerSlot
+        footer: footerSlot,
+        ...rest
     }: Props = $props()
 
     const hasTitle = $derived(!!title || !!titleSlot)
@@ -81,6 +82,7 @@
 
     const rootProps = $derived.by(() => {
         const base = {
+            ...rest,
             open,
             onOpenChange: handleOpenChange,
             direction,

--- a/src/lib/Drawer/Drawer.svelte.spec.ts
+++ b/src/lib/Drawer/Drawer.svelte.spec.ts
@@ -708,4 +708,23 @@ describe('Drawer', () => {
             })
         })
     })
+
+    // ==================== FORWARDED VAUL PROPS ====================
+
+    describe('forwarded vaul props', () => {
+        it('forwards container so content portals into the given element', async () => {
+            const el = document.createElement('div')
+            el.setAttribute('data-drawer-container', '')
+            document.body.appendChild(el)
+            try {
+                render(Drawer, { open: true, title: 'Test', container: el })
+                // Before the fix `container` was dropped → content went to <body>, not `el`.
+                await vi.waitFor(() => {
+                    expect(el.querySelector('[data-vaul-drawer]')).not.toBeNull()
+                })
+            } finally {
+                el.remove()
+            }
+        })
+    })
 })


### PR DESCRIPTION
## Summary

`DrawerProps` `Pick`s ~28 vaul-svelte root props, but the component had no `...restProps` and `rootProps` forwarded only a subset. As a result ~10 props were **accepted by the type yet silently dropped** (never reached vaul):

`setBackgroundColorOnScale`, `fixed`, `defaultOpen`, `disablePreventScroll`, `repositionInputs`, `snapToSequentialPoint`, `container`, `onAnimationEnd`, `preventScrollRestoration`, `autoFocus`.

Verified before fixing: a type probe showed all 10 type-check; the existing Lifecycle-Callbacks demo never logged `onAnimationEnd` despite passing one. Fix: collect `...rest` and spread into the root props (`rest` is empty unless one of these props is passed, so default behavior is unchanged).

## Changes

- `Drawer.svelte` — add `...rest` to props and spread it into `rootProps`.
- `Drawer.svelte.spec.ts` — regression test (`container` forwards → content portals into the given element).
- `CHANGELOG.md` — Fixed entry.

## Also reviewed (no change — see #72)

- Title-less drawer → no `Drawer.Title` → by-design (consumer responsibility, like Modal).
- `className as string` cast on Trigger → won't-fix (negligible, like Modal).

## Checklist

- [x] `pnpm check` (0/0) · `pnpm lint` (0 errors) · `pnpm test` (2378)
- [x] Regression test added

Closes #72