### PR TITLE
fix(dropdown-menu)!: route trigger ARIA onto caller element via child snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Icon** — `IconProps` now type-checks SVG HTML attributes — `role`, `tabindex`, `aria-*` (`aria-label`, `aria-labelledby`, `aria-describedby`, `aria-hidden`), common event handlers, and `data-*` — which previously raised a type error despite reaching the rendered `<svg>` at runtime. This unblocks typed meaningful (non-decorative) icons and test/data hooks.
 - **Separator** — `position` prop (`'start' | 'center' | 'end'`, default `'center'`) controls where the label/icon/avatar/content sits along the separator.
 
+### Changed
+
+- **DropdownMenu** — **BREAKING:** the trigger `children` snippet is no longer auto-wrapped in a `<span>`. It now receives `{ open, props }` and you must spread `props` onto your own focusable trigger element so the menu's ARIA (`aria-haspopup`, `aria-expanded`, `id`) and event handlers land on the real control instead of a non-semantic wrapper. Migration:
+
+    ```svelte
+    <!-- Before -->
+    <DropdownMenu {items}>
+        <Button>Open</Button>
+    </DropdownMenu>
+
+    <!-- After -->
+    <DropdownMenu {items}>
+        {#snippet children({ props })}
+            <Button {...props}>Open</Button>
+        {/snippet}
+    </DropdownMenu>
+    ```
+
+### Removed
+
+- **DropdownMenu** — Removed the unused `name` field from `DropdownMenuRadioGroup`; it was accepted by the type but never read at runtime (radio grouping is keyed by the single `radioGroups[0]` entry).
+
 ### Fixed
 
 - **Button** — Loading state with both `leadingIcon` and `trailingIcon` no longer renders a static (non-spinning) loader on the opposite side. The spinner now appears only on the side selected by `trailing`, and the other icon keeps its original glyph.

--- a/src/lib/DropdownMenu/DropdownMenu.svelte
+++ b/src/lib/DropdownMenu/DropdownMenu.svelte
@@ -348,9 +348,7 @@
     {#if children}
         <DropdownMenu.Trigger>
             {#snippet child({ props })}
-                <span {...props} class={className as string}>
-                    {@render children({ open })}
-                </span>
+                {@render children({ open, props })}
             {/snippet}
         </DropdownMenu.Trigger>
     {/if}

--- a/src/lib/DropdownMenu/DropdownMenu.svelte.spec.ts
+++ b/src/lib/DropdownMenu/DropdownMenu.svelte.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-svelte'
 import { page } from 'vitest/browser'
 import DropdownMenu from './DropdownMenu.svelte'
+import DropdownMenuTriggerTestWrapper from './DropdownMenuTriggerTestWrapper.svelte'
 import type { DropdownMenuItem, DropdownMenuRadioGroup } from './dropdown-menu.types.js'
 
 describe('DropdownMenu', () => {
@@ -295,7 +296,7 @@ describe('DropdownMenu', () => {
                     { type: 'radio', label: 'Option 1', value: 'opt1' },
                     { type: 'radio', label: 'Option 2', value: 'opt2' }
                 ]
-                const radioGroups: DropdownMenuRadioGroup[] = [{ name: 'options', value: 'opt1' }]
+                const radioGroups: DropdownMenuRadioGroup[] = [{ value: 'opt1' }]
                 render(DropdownMenu, { open: true, items, radioGroups })
                 await vi.waitFor(() => {
                     expect(getRadioItems().length).toBe(2)
@@ -307,7 +308,7 @@ describe('DropdownMenu', () => {
                     { type: 'radio', label: 'Option 1', value: 'opt1' },
                     { type: 'radio', label: 'Option 2', value: 'opt2' }
                 ]
-                const radioGroups: DropdownMenuRadioGroup[] = [{ name: 'options', value: 'opt1' }]
+                const radioGroups: DropdownMenuRadioGroup[] = [{ value: 'opt1' }]
                 render(DropdownMenu, { open: true, items, radioGroups })
                 await vi.waitFor(() => {
                     const radioItems = getRadioItems()
@@ -323,9 +324,7 @@ describe('DropdownMenu', () => {
                     { type: 'radio', label: 'Option 1', value: 'opt1', closeOnSelect: false },
                     { type: 'radio', label: 'Option 2', value: 'opt2', closeOnSelect: false }
                 ]
-                const radioGroups: DropdownMenuRadioGroup[] = [
-                    { name: 'options', value: 'opt1', onValueChange }
-                ]
+                const radioGroups: DropdownMenuRadioGroup[] = [{ value: 'opt1', onValueChange }]
                 render(DropdownMenu, { open: true, items, radioGroups })
                 await vi.waitFor(() => {
                     expect(getRadioItems().length).toBe(2)
@@ -653,7 +652,7 @@ describe('DropdownMenu', () => {
                     items: [{ label: 'Sub Item' }]
                 }
             ]
-            const radioGroups: DropdownMenuRadioGroup[] = [{ name: 'theme', value: 'light' }]
+            const radioGroups: DropdownMenuRadioGroup[] = [{ value: 'light' }]
             render(DropdownMenu, { open: true, items, radioGroups })
 
             await vi.waitFor(() => {
@@ -686,6 +685,46 @@ describe('DropdownMenu', () => {
 
                 const items = getItems()
                 expect((items[0] as HTMLElement).className).toContain('item-custom')
+            })
+        })
+    })
+
+    // ==================== TRIGGER (children props) ====================
+
+    describe('trigger', () => {
+        const getTrigger = () =>
+            document.querySelector('[data-testid="trigger"]') as HTMLElement | null
+
+        it('should wire trigger props onto the caller element, not a wrapper', () => {
+            render(DropdownMenuTriggerTestWrapper, { items: basicItems })
+            const trigger = getTrigger()
+            expect(trigger).not.toBeNull()
+            expect(trigger!.tagName).toBe('BUTTON')
+            expect(trigger!.getAttribute('aria-haspopup')).toBe('menu')
+            expect(trigger!.hasAttribute('data-dropdown-menu-trigger')).toBe(true)
+        })
+
+        it('should not insert an extra span wrapper around the trigger', () => {
+            render(DropdownMenuTriggerTestWrapper, { items: basicItems })
+            const trigger = getTrigger()
+            expect(trigger!.parentElement?.tagName).not.toBe('SPAN')
+        })
+
+        it('should open the menu when the trigger is clicked', async () => {
+            render(DropdownMenuTriggerTestWrapper, { items: basicItems })
+            expect(getContent()).toBeNull()
+            getTrigger()!.click()
+            await vi.waitFor(() => {
+                expect(getContent()).not.toBeNull()
+            })
+        })
+
+        it('should expose open state to the children snippet', async () => {
+            render(DropdownMenuTriggerTestWrapper, { items: basicItems })
+            expect(getTrigger()!.getAttribute('data-open')).toBe('false')
+            getTrigger()!.click()
+            await vi.waitFor(() => {
+                expect(getTrigger()!.getAttribute('data-open')).toBe('true')
             })
         })
     })

--- a/src/lib/DropdownMenu/DropdownMenuTriggerTestWrapper.svelte
+++ b/src/lib/DropdownMenu/DropdownMenuTriggerTestWrapper.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+    import DropdownMenu from './DropdownMenu.svelte'
+    import type { DropdownMenuItem } from './dropdown-menu.types.js'
+
+    let { items = [] }: { items?: DropdownMenuItem[] } = $props()
+</script>
+
+<DropdownMenu {items}>
+    {#snippet children({ open, props })}
+        <button data-testid="trigger" data-open={open} {...props}>Open</button>
+    {/snippet}
+</DropdownMenu>

--- a/src/lib/DropdownMenu/dropdown-menu.types.ts
+++ b/src/lib/DropdownMenu/dropdown-menu.types.ts
@@ -170,11 +170,6 @@ export type DropdownMenuItem =
  */
 export interface DropdownMenuRadioGroup {
     /**
-     * Unique identifier for the radio group.
-     */
-    name: string
-
-    /**
      * Currently selected value in the group.
      */
     value?: string
@@ -254,8 +249,9 @@ export interface DropdownMenuProps extends RootProps, ContentProps {
     items?: DropdownMenuItem[]
 
     /**
-     * Radio groups configuration for managing radio item selections.
-     * @example [{ name: 'theme', value: 'dark', onValueChange: (v) => theme = v }]
+     * Radio group configuration for managing radio item selections.
+     * Only the first entry is used — all `type: 'radio'` items belong to it.
+     * @example [{ value: 'dark', onValueChange: (v) => theme = v }]
      */
     radioGroups?: DropdownMenuRadioGroup[]
 
@@ -305,7 +301,9 @@ export interface DropdownMenuProps extends RootProps, ContentProps {
     // -------------------------------------------------------------------------
 
     /**
-     * Additional CSS class for the trigger wrapper.
+     * Additional CSS class for the dropdown content.
+     * Applied only when no trigger `children` are provided (style your own
+     * trigger element directly otherwise).
      */
     class?: ClassNameValue
 
@@ -319,10 +317,18 @@ export interface DropdownMenuProps extends RootProps, ContentProps {
     // -------------------------------------------------------------------------
 
     /**
-     * Default slot content used as the trigger element.
-     * When provided, clicking this element opens the dropdown.
+     * Trigger content. Spread the provided `props` onto your own focusable
+     * element (e.g. a `<Button>`) so the trigger's ARIA and event handlers land
+     * on the real control.
+     *
+     * @example
+     * ```svelte
+     * {#snippet children({ open, props })}
+     *   <Button {...props}>{open ? 'Close' : 'Open'}</Button>
+     * {/snippet}
+     * ```
      */
-    children?: Snippet<[{ open: boolean }]>
+    children?: Snippet<[{ open: boolean; props: Record<string, unknown> }]>
 
     /**
      * Custom content to render at the top of the dropdown menu.

--- a/src/routes/dropdown-menu/+page.svelte
+++ b/src/routes/dropdown-menu/+page.svelte
@@ -179,10 +179,12 @@
         <h2 class="text-lg font-semibold">Basic</h2>
         <div class="rounded-lg bg-surface-container-high p-4">
             <DropdownMenu items={basicItems}>
-                <Button variant="outline">
-                    File
-                    <span class="ml-2 text-xs opacity-60">Alt+F</span>
-                </Button>
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline">
+                        File
+                        <span class="ml-2 text-xs opacity-60">Alt+F</span>
+                    </Button>
+                {/snippet}
             </DropdownMenu>
         </div>
     </section>
@@ -200,7 +202,9 @@
         >
             {#each [{ side: 'top' as const, label: 'Top' }, { side: 'right' as const, label: 'Right' }, { side: 'bottom' as const, label: 'Bottom' }, { side: 'left' as const, label: 'Left' }] as item (item.side)}
                 <DropdownMenu items={basicItems.slice(0, 4)} side={item.side}>
-                    <Button variant="soft">{item.label}</Button>
+                    {#snippet children({ props })}
+                        <Button {...props} variant="soft">{item.label}</Button>
+                    {/snippet}
                 </DropdownMenu>
             {/each}
         </div>
@@ -212,7 +216,9 @@
         <div class="flex flex-wrap items-center gap-4 rounded-lg bg-surface-container-high p-4">
             {#each [{ size: 'xs' as const, label: 'XS' }, { size: 'sm' as const, label: 'SM' }, { size: 'md' as const, label: 'MD' }, { size: 'lg' as const, label: 'LG' }, { size: 'xl' as const, label: 'XL' }] as item (item.size)}
                 <DropdownMenu items={basicItems.slice(0, 4)} size={item.size}>
-                    <Button size={item.size} variant="outline">{item.label}</Button>
+                    {#snippet children({ props })}
+                        <Button {...props} size={item.size} variant="outline">{item.label}</Button>
+                    {/snippet}
                 </DropdownMenu>
             {/each}
         </div>
@@ -228,7 +234,11 @@
         </p>
         <div class="rounded-lg bg-surface-container-high p-4">
             <DropdownMenu items={coloredItems}>
-                <Button variant="outline" icon="lucide:more-horizontal">Actions</Button>
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" icon="lucide:more-horizontal"
+                        >Actions</Button
+                    >
+                {/snippet}
             </DropdownMenu>
         </div>
     </section>
@@ -239,7 +249,9 @@
         <p class="text-sm text-on-surface-variant">Toggle boolean states with checkbox items.</p>
         <div class="flex flex-wrap items-center gap-4 rounded-lg bg-surface-container-high p-4">
             <DropdownMenu items={checkboxItems}>
-                <Button variant="outline" icon="lucide:layout">View</Button>
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" icon="lucide:layout">View</Button>
+                {/snippet}
             </DropdownMenu>
             <div class="text-sm text-on-surface-variant">
                 <p>Status Bar: <code class="text-primary">{showStatusBar}</code></p>
@@ -255,7 +267,9 @@
         <p class="text-sm text-on-surface-variant">Single selection with radio items and groups.</p>
         <div class="flex flex-wrap items-center gap-4 rounded-lg bg-surface-container-high p-4">
             <DropdownMenu items={radioItems} {radioGroups}>
-                <Button variant="outline" icon="lucide:sun-moon">Theme</Button>
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" icon="lucide:sun-moon">Theme</Button>
+                {/snippet}
             </DropdownMenu>
             <div class="text-sm text-on-surface-variant">
                 Selected: <code class="text-primary">{selectedTheme}</code>
@@ -268,7 +282,9 @@
         <h2 class="text-lg font-semibold">Submenus</h2>
         <div class="rounded-lg bg-surface-container-high p-4">
             <DropdownMenu items={submenuItems}>
-                <Button variant="outline" icon="lucide:menu">Navigate</Button>
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" icon="lucide:menu">Navigate</Button>
+                {/snippet}
             </DropdownMenu>
         </div>
     </section>
@@ -285,10 +301,18 @@
         </p>
         <div class="flex flex-wrap items-center gap-4 rounded-lg bg-surface-container-high p-4">
             <DropdownMenu items={closeOnSelectItems}>
-                <Button variant="outline" icon="lucide:mouse-pointer-click">Actions</Button>
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" icon="lucide:mouse-pointer-click"
+                        >Actions</Button
+                    >
+                {/snippet}
             </DropdownMenu>
             <DropdownMenu items={checkboxCloseOnSelectItems}>
-                <Button variant="outline" icon="lucide:check-square">Multi-Select</Button>
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" icon="lucide:check-square"
+                        >Multi-Select</Button
+                    >
+                {/snippet}
             </DropdownMenu>
             <div class="text-sm text-on-surface-variant">
                 <p>Click count: <code class="text-primary">{clickCount}</code></p>
@@ -310,7 +334,11 @@
                 <p class="text-sm font-medium text-on-surface-variant">Observe click state</p>
                 <div class="flex items-center gap-4 rounded-lg bg-surface-container-high p-4">
                     <DropdownMenu items={basicItems.slice(0, 4)} bind:open={controlledOpen}>
-                        <Button variant={controlledOpen ? 'solid' : 'outline'}>Click me</Button>
+                        {#snippet children({ props })}
+                            <Button {...props} variant={controlledOpen ? 'solid' : 'outline'}>
+                                Click me
+                            </Button>
+                        {/snippet}
                     </DropdownMenu>
                     <span class="text-sm text-on-surface-variant">
                         open: <code class="text-primary">{controlledOpen}</code>
@@ -321,7 +349,9 @@
                 <p class="text-sm font-medium text-on-surface-variant">Toggle programmatically</p>
                 <div class="flex items-center gap-4 rounded-lg bg-surface-container-high p-4">
                     <DropdownMenu items={basicItems.slice(0, 4)} open={controlledOpen}>
-                        <Button variant="outline">Target</Button>
+                        {#snippet children({ props })}
+                            <Button {...props} variant="outline">Target</Button>
+                        {/snippet}
                     </DropdownMenu>
                     <Button variant="soft" onclick={() => (controlledOpen = !controlledOpen)}>
                         {controlledOpen ? 'Close' : 'Open'}
@@ -336,7 +366,9 @@
         <h2 class="text-lg font-semibold">Custom Header/Footer</h2>
         <div class="rounded-lg bg-surface-container-high p-4">
             <DropdownMenu items={basicItems.slice(0, 4)}>
-                <Button variant="outline" icon="lucide:user-circle">Account</Button>
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" icon="lucide:user-circle">Account</Button>
+                {/snippet}
                 {#snippet header()}
                     <div class="px-3 py-2">
                         <p class="text-sm font-medium">John Doe</p>
@@ -373,7 +405,9 @@
         </p>
         <div class="rounded-lg bg-surface-container-high p-4">
             <DropdownMenu>
-                <Button variant="outline" icon="lucide:palette">Colors</Button>
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" icon="lucide:palette">Colors</Button>
+                {/snippet}
                 {#snippet content({ close })}
                     <div class="p-4">
                         <p class="mb-3 text-sm font-medium">Choose a color</p>
@@ -409,7 +443,9 @@
                             separator: 'bg-on-primary/20'
                         }}
                     >
-                        <Button>Primary Style</Button>
+                        {#snippet children({ props })}
+                            <Button {...props}>Primary Style</Button>
+                        {/snippet}
                     </DropdownMenu>
                 </div>
             </div>
@@ -420,7 +456,9 @@
                         items={basicItems.slice(0, 4)}
                         ui={{ content: 'rounded-xl shadow-2xl' }}
                     >
-                        <Button variant="outline">Rounded</Button>
+                        {#snippet children({ props })}
+                            <Button {...props} variant="outline">Rounded</Button>
+                        {/snippet}
                     </DropdownMenu>
                 </div>
             </div>
@@ -441,16 +479,18 @@
                     class="flex items-center justify-center rounded-lg bg-surface-container-high p-6"
                 >
                     <DropdownMenu items={profileItems}>
-                        <Button icon="lucide:chevron-down" trailing>
-                            <span class="flex items-center gap-2">
-                                <span
-                                    class="flex size-6 items-center justify-center rounded-full bg-primary text-xs text-on-primary"
-                                >
-                                    JD
+                        {#snippet children({ props })}
+                            <Button {...props} icon="lucide:chevron-down" trailing>
+                                <span class="flex items-center gap-2">
+                                    <span
+                                        class="flex size-6 items-center justify-center rounded-full bg-primary text-xs text-on-primary"
+                                    >
+                                        JD
+                                    </span>
+                                    shadcn
                                 </span>
-                                shadcn
-                            </span>
-                        </Button>
+                            </Button>
+                        {/snippet}
                     </DropdownMenu>
                 </div>
             </div>
@@ -462,12 +502,15 @@
                     class="flex items-center justify-center rounded-lg bg-surface-container-high p-6"
                 >
                     <DropdownMenu items={coloredItems} arrow align="center">
-                        <Button
-                            variant="outline"
-                            icon="lucide:more-vertical"
-                            square
-                            aria-label="More options"
-                        />
+                        {#snippet children({ props })}
+                            <Button
+                                {...props}
+                                variant="outline"
+                                icon="lucide:more-vertical"
+                                square
+                                aria-label="More options"
+                            />
+                        {/snippet}
                     </DropdownMenu>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

The DropdownMenu trigger `children` snippet was auto-wrapped in a non-semantic `<span>`, so the menu's trigger semantics and keyboard/click handlers landed on that wrapper rather than the caller's real focusable control. This routes the trigger props to the caller's own element via the primitive's `child` snippet pattern, fixing keyboard/focus/screen-reader behavior. Also cleans up two minor type/doc issues.

Closes #76

## Changes

- **a11y (breaking):** `children` snippet now receives `{ open, props }`. Spread `props` onto your own trigger element so `aria-haspopup`/`aria-expanded`/`aria-controls`/`id` and event handlers land on the real control. Removed the auto-inserted `<span>` wrapper.
- **types:** removed the unused `name` field from `DropdownMenuRadioGroup`.
- **docs:** clarified that only the first `radioGroups` entry is used, and that `class` applies to the content when no trigger `children` are provided.
- Migrated all demo trigger usages and added regression tests (trigger ARIA on caller element, no span wrapper, click-to-open, `open` exposed to snippet).

### BREAKING CHANGE — migration

```svelte
<!-- Before -->
<DropdownMenu {items}>
    <Button>Open</Button>
</DropdownMenu>

<!-- After -->
<DropdownMenu {items}>
    {#snippet children({ props })}
        <Button {...props}>Open</Button>
    {/snippet}
</DropdownMenu>
```

## Checklist

- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm lint`
- [x] `pnpm test` — 58/58 (incl. 4 new trigger tests)
- [x] CHANGELOG updated (Changed + Removed)