### PR TITLE
fix(tabs): expose root HTML attributes, drop dead slot field, hide indicator from AT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Icon** — `IconProps` now type-checks SVG HTML attributes — `role`, `tabindex`, `aria-*` (`aria-label`, `aria-labelledby`, `aria-describedby`, `aria-hidden`), common event handlers, and `data-*` — which previously raised a type error despite reaching the rendered `<svg>` at runtime. This unblocks typed meaningful (non-decorative) icons and test/data hooks.
 - **Collapsible** — `CollapsibleProps` now type-checks root HTML attributes (`id`, `style`, `title`, `role`, `tabindex`, `aria-*`, common event handlers, and `data-*`); they are forwarded to the root element (previously rejected by the type while `restProps` was effectively dead).
 - **Separator** — `position` prop (`'start' | 'center' | 'end'`, default `'center'`) controls where the label/icon/avatar/content sits along the separator.
+- **Tabs** — `TabsProps` now type-checks root HTML attributes (`id`, `style`, `title`, `role`, `tabindex`, `aria-*`, common event handlers, and `data-*`) and forwards them to the root element; previously these were rejected by the type and no `restProps` were spread.
 
 ### Changed
 
@@ -36,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - **DropdownMenu** — Removed the unused `name` field from `DropdownMenuRadioGroup`; it was accepted by the type but never read at runtime (radio grouping is keyed by the single `radioGroups[0]` entry).
+- **Tabs** — Removed the unused `slot` field from `TabsItem`; it was accepted by the type and documented as enabling dynamic per-item slots, but was never wired to any rendering (setting it had no effect).
 
 ### Fixed
 
@@ -46,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **AvatarGroup** — Avatars now render in array order left-to-right (the first avatar leftmost and on top). Previously the `flex-row-reverse` layout combined with an un-reversed list displayed them right-to-left (e.g. `[1,2,3]` rendered as `3 2 1`).
 - **Alert** — Corrected the `variant` prop's documented default from `'soft'` to `'solid'` to match the actual runtime default.
 - **Drawer** — Forward the remaining typed vaul-svelte props that were silently dropped (`setBackgroundColorOnScale`, `fixed`, `defaultOpen`, `disablePreventScroll`, `repositionInputs`, `snapToSequentialPoint`, `container`, `onAnimationEnd`, `preventScrollRestoration`, `autoFocus`). They were accepted by the type but never reached the underlying drawer.
+- **Tabs** — The decorative sliding indicator is now marked `aria-hidden="true"` so assistive technologies ignore the empty visual element inside the tablist.
 
 ## [1.8.0] - 2026-05-28
 

--- a/src/lib/Tabs/Tabs.svelte
+++ b/src/lib/Tabs/Tabs.svelte
@@ -32,7 +32,8 @@
         leading,
         label: labelSlot,
         trailing,
-        body: bodySlot
+        body: bodySlot,
+        ...restProps
     }: Props = $props()
 
     // Initialize value if not provided (intentionally reads initial values only)
@@ -131,6 +132,7 @@
 </script>
 
 <Tabs.Root
+    {...restProps}
     bind:ref
     bind:value
     {onValueChange}
@@ -141,7 +143,7 @@
     class={classes.root}
 >
     <Tabs.List bind:ref={listEl} class={classes.list}>
-        <div class={classes.indicator} style={indicatorStyle}></div>
+        <div class={classes.indicator} style={indicatorStyle} aria-hidden="true"></div>
 
         {#each items as item, index (item.value ?? index)}
             {@const itemValue = getItemValue(item, index)}

--- a/src/lib/Tabs/tabs.svelte.spec.ts
+++ b/src/lib/Tabs/tabs.svelte.spec.ts
@@ -472,4 +472,45 @@ describe('Tabs', () => {
             })
         })
     })
+
+    // ==================== NATIVE ATTRIBUTES ====================
+
+    describe('native attributes', () => {
+        it('should forward id, aria-label and data-* to the root element', async () => {
+            render(Tabs, {
+                items: sampleItems,
+                id: 'settings-tabs',
+                'aria-label': 'Settings sections',
+                'data-testid': 'tabs-root'
+            })
+            await vi.waitFor(() => {
+                const root = getRoot()
+                expect(root).not.toBeNull()
+                expect(root!.id).toBe('settings-tabs')
+                expect(root!.getAttribute('aria-label')).toBe('Settings sections')
+                expect(root!.getAttribute('data-testid')).toBe('tabs-root')
+            })
+        })
+
+        it('should forward onclick handler to the root element', async () => {
+            const onclick = vi.fn()
+            render(Tabs, { items: sampleItems, onclick })
+            await vi.waitFor(() => expect(getRoot()).not.toBeNull())
+            getRoot()!.click()
+            expect(onclick).toHaveBeenCalled()
+        })
+    })
+
+    // ==================== INDICATOR ACCESSIBILITY ====================
+
+    describe('indicator accessibility', () => {
+        it('should mark the decorative indicator with aria-hidden', async () => {
+            render(Tabs, { items: sampleItems })
+            await vi.waitFor(() => {
+                const indicator = getList()!.querySelector('.transition-all')
+                expect(indicator).not.toBeNull()
+                expect(indicator!.getAttribute('aria-hidden')).toBe('true')
+            })
+        })
+    })
 })

--- a/src/lib/Tabs/tabs.types.ts
+++ b/src/lib/Tabs/tabs.types.ts
@@ -1,5 +1,6 @@
 import type { Snippet } from 'svelte'
 import type { ClassNameValue } from 'tailwind-merge'
+import type { TabsRootProps } from 'bits-ui'
 import type { TabsSlots, TabsVariantProps } from './tabs.variants.js'
 
 // ============================================================================
@@ -52,12 +53,6 @@ export interface TabsItem {
     content?: string
 
     /**
-     * Named slot identifier for custom content rendering.
-     * When provided, allows using dynamic snippet slots for this item.
-     */
-    slot?: string
-
-    /**
      * Additional CSS classes applied to this item's trigger element.
      */
     class?: ClassNameValue
@@ -108,7 +103,26 @@ export interface TabsSlotProps {
  *
  * @see https://bits-ui.com/docs/components/tabs
  */
-export interface TabsProps {
+export interface TabsProps extends Pick<
+    TabsRootProps,
+    | 'id'
+    | 'style'
+    | 'title'
+    | 'role'
+    | 'tabindex'
+    | 'aria-label'
+    | 'aria-labelledby'
+    | 'aria-describedby'
+    | 'onclick'
+    | 'onkeydown'
+    | 'onmouseenter'
+    | 'onmouseleave'
+    | 'onfocus'
+    | 'onblur'
+> {
+    /** Custom data attributes are forwarded to the root element. */
+    [key: `data-${string}`]: unknown
+
     /**
      * Bindable reference to the root DOM element.
      */


### PR DESCRIPTION
## Summary

Tabs review fixes: forward native root HTML attributes (previously rejected by the type and never spread), remove a dead `slot` field, and hide the decorative indicator from assistive tech.

Closes #78

## Changes

- **types:** `TabsProps` now `Pick`s native root HTML attributes from the primitive root props (`id`, `style`, `title`, `role`, `tabindex`, `aria-*`, common event handlers) plus a `data-*` index signature, and `...restProps` is spread onto `Tabs.Root`. Consumers can now attach `id`/`data-*`/`aria-label`/handlers to the root.
- **types:** removed the unused `slot` field from `TabsItem` (declared and documented but never wired to any rendering — setting it had no effect).
- **a11y:** the decorative sliding indicator `<div>` is now `aria-hidden="true"`.
- Added regression tests (root forwards `id`/`aria-label`/`data-*`, root forwards `onclick`, indicator `aria-hidden`).

## Checklist

- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm lint`
- [x] `pnpm test` — 41/41 (incl. 3 new)
- [x] CHANGELOG updated (Added / Removed / Fixed)