### PR TITLE
fix(input): correct loading spinner placement and avatar precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **AvatarGroup** — Avatars now render in array order left-to-right (the first avatar leftmost and on top). Previously the `flex-row-reverse` layout combined with an un-reversed list displayed them right-to-left (e.g. `[1,2,3]` rendered as `3 2 1`).
 - **Alert** — Corrected the `variant` prop's documented default from `'soft'` to `'solid'` to match the actual runtime default.
 - **Drawer** — Forward the remaining typed vaul-svelte props that were silently dropped (`setBackgroundColorOnScale`, `fixed`, `defaultOpen`, `disablePreventScroll`, `repositionInputs`, `snapToSequentialPoint`, `container`, `onAnimationEnd`, `preventScrollRestoration`, `autoFocus`). They were accepted by the type but never reached the underlying drawer.
+- **Input** — Loading state no longer renders a duplicate, non-spinning loader: when a `trailingIcon` (or both a leading and trailing icon) is present, the spinner now appears only on the side selected by `trailing`, and the opposite side keeps its own icon glyph instead of showing a second static loader.
+- **Input** — `avatar` now takes precedence over `leadingIcon` when both are provided, matching the documented behavior; previously the leading icon was shown and the avatar was hidden.
 
 ## [1.8.0] - 2026-05-28
 

--- a/src/lib/Input/Input.svelte
+++ b/src/lib/Input/Input.svelte
@@ -94,19 +94,14 @@
     const resolvedId = $derived(id ?? formFieldContext?.ariaId)
     const resolvedName = $derived(name ?? formFieldContext?.name)
 
-    const isLeading = $derived(
-        (!!icon && !trailing) || (loading && !trailing) || !!leadingIcon || !!avatar
-    )
-    const isTrailing = $derived((!!icon && trailing) || (loading && trailing) || !!trailingIcon)
+    const loadingLeading = $derived(loading && !trailing)
+    const loadingTrailing = $derived(loading && trailing)
 
-    const leadingIconName = $derived(
-        loading && isLeading
-            ? loadingIcon
-            : leadingIcon || (isLeading && !trailing && !avatar ? icon : undefined)
-    )
-    const trailingIconName = $derived(
-        loading && isTrailing ? loadingIcon : trailingIcon || (trailing ? icon : undefined)
-    )
+    const isLeading = $derived((!!icon && !trailing) || !!leadingIcon || !!avatar || loadingLeading)
+    const isTrailing = $derived((!!icon && trailing) || !!trailingIcon || loadingTrailing)
+
+    const leadingIconName = $derived(leadingIcon || (!!icon && !trailing ? icon : undefined))
+    const trailingIconName = $derived(trailingIcon || (!!icon && trailing ? icon : undefined))
 
     const ariaDescribedBy = $derived(
         !formFieldContext
@@ -123,7 +118,6 @@
             size: resolvedSize,
             leading: isLeading,
             trailing: isTrailing,
-            loading,
             highlight: resolvedHighlight
         })
     )
@@ -154,13 +148,19 @@
         <span class={classes.leading}>
             {@render leadingSlot()}
         </span>
-    {:else if isLeading && leadingIconName}
+    {:else if loadingLeading}
         <span class={classes.leading}>
-            <Icon name={leadingIconName} class={classes.leadingIcon} />
+            <span class="inline-flex animate-spin">
+                <Icon name={loadingIcon} class={classes.leadingIcon} />
+            </span>
         </span>
     {:else if avatar}
         <span class={classes.leading}>
             <Avatar {...avatar} size={classes.leadingAvatarSize} class={classes.leadingAvatar} />
+        </span>
+    {:else if leadingIconName}
+        <span class={classes.leading}>
+            <Icon name={leadingIconName} class={classes.leadingIcon} />
         </span>
     {/if}
 
@@ -185,7 +185,13 @@
         <span class={classes.trailing}>
             {@render trailingSlot()}
         </span>
-    {:else if isTrailing && trailingIconName}
+    {:else if loadingTrailing}
+        <span class={classes.trailing}>
+            <span class="inline-flex animate-spin">
+                <Icon name={loadingIcon} class={classes.trailingIcon} />
+            </span>
+        </span>
+    {:else if trailingIconName}
         <span class={classes.trailing}>
             <Icon name={trailingIconName} class={classes.trailingIcon} />
         </span>

--- a/src/lib/Input/Input.svelte.spec.ts
+++ b/src/lib/Input/Input.svelte.spec.ts
@@ -94,6 +94,37 @@ describe('Input', () => {
             const spans = container.querySelectorAll('span')
             expect(spans.length).toBeGreaterThanOrEqual(1)
         })
+
+        it('should spin the leading loader and keep the trailing icon static (both icons)', () => {
+            const { container } = render(Input, {
+                loading: true,
+                leadingIcon: 'lucide:mail',
+                trailingIcon: 'lucide:check'
+            })
+            expect(container.querySelector('.start-0 .animate-spin')).not.toBeNull()
+            expect(container.querySelector('.end-0 .animate-spin')).toBeNull()
+            expect(container.querySelector('.end-0')).not.toBeNull()
+        })
+
+        it('should keep a trailing-only icon static and not duplicate the loader there', () => {
+            const { container } = render(Input, {
+                loading: true,
+                trailingIcon: 'lucide:eye'
+            })
+            expect(container.querySelector('.end-0 .animate-spin')).toBeNull()
+            expect(container.querySelector('.start-0 .animate-spin')).not.toBeNull()
+        })
+
+        it('should spin the trailing loader and keep the leading icon static when trailing', () => {
+            const { container } = render(Input, {
+                loading: true,
+                trailing: true,
+                leadingIcon: 'lucide:mail',
+                trailingIcon: 'lucide:check'
+            })
+            expect(container.querySelector('.end-0 .animate-spin')).not.toBeNull()
+            expect(container.querySelector('.start-0 .animate-spin')).toBeNull()
+        })
     })
 
     // ==================== VARIANTS ====================
@@ -302,12 +333,12 @@ describe('Input', () => {
             await expect.element(input).toHaveClass(/ps-9/)
         })
 
-        it('should not render avatar when leadingIcon is provided', () => {
+        it('should render avatar over leadingIcon when both are provided (avatar takes precedence)', () => {
             const { container } = render(Input, {
                 leadingIcon: 'lucide:user',
                 avatar: { alt: 'John Doe' }
             })
-            expect(container.textContent).not.toContain('JD')
+            expect(container.textContent).toContain('JD')
         })
 
         it('should not render avatar when loading', () => {

--- a/src/lib/Input/input.variants.ts
+++ b/src/lib/Input/input.variants.ts
@@ -82,9 +82,6 @@ export const inputVariants = tv({
         trailing: {
             true: ''
         },
-        loading: {
-            true: ''
-        },
         highlight: {
             true: ''
         }
@@ -384,24 +381,7 @@ export const inputVariants = tv({
         { trailing: true, size: 'sm', class: { base: 'pe-8' } },
         { trailing: true, size: 'md', class: { base: 'pe-9' } },
         { trailing: true, size: 'lg', class: { base: 'pe-10' } },
-        { trailing: true, size: 'xl', class: { base: 'pe-12' } },
-
-        // ========== LOADING ICON ANIMATION ==========
-        {
-            loading: true,
-            leading: true,
-            class: {
-                leadingIcon: 'animate-spin'
-            }
-        },
-        {
-            loading: true,
-            leading: false,
-            trailing: true,
-            class: {
-                trailingIcon: 'animate-spin'
-            }
-        }
+        { trailing: true, size: 'xl', class: { base: 'pe-12' } }
     ],
     defaultVariants: {
         variant: 'outline',


### PR DESCRIPTION
## Summary

Input review fixes: the loading state rendered a duplicate, non-spinning loader, and `avatar`/`leadingIcon` precedence contradicted the docs.

Closes #80

## Changes

- **bug (loading):** the spinner now appears only on the side selected by `trailing`; the opposite side keeps its own icon glyph. Previously a `trailingIcon` (or both a leading and trailing icon) plus `loading` produced a static (non-spinning) loader on the other side and overrode the caller's icon. The `animate-spin` compound variants and the now-unused `loading` variant were removed in favor of applying the spin on the rendered loader element.
- **bug/docs (avatar):** `avatar` now renders over `leadingIcon` when both are provided, matching the documented "avatar takes precedence" behavior (previously the leading icon won and the avatar was hidden).

## Checklist

- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm lint`
- [x] `pnpm test` — 68/68 (updated the avatar-precedence test; added 3 loading regression tests)
- [x] CHANGELOG updated (Fixed)