### PR TITLE
fix(pagination): name prev/next buttons, expose root HTML attrs, drop dead ui icon slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Icon** — `IconProps` now type-checks SVG HTML attributes — `role`, `tabindex`, `aria-*` (`aria-label`, `aria-labelledby`, `aria-describedby`, `aria-hidden`), common event handlers, and `data-*` — which previously raised a type error despite reaching the rendered `<svg>` at runtime. This unblocks typed meaningful (non-decorative) icons and test/data hooks.
 - **Collapsible** — `CollapsibleProps` now type-checks root HTML attributes (`id`, `style`, `title`, `role`, `tabindex`, `aria-*`, common event handlers, and `data-*`); they are forwarded to the root element (previously rejected by the type while `restProps` was effectively dead).
 - **Separator** — `position` prop (`'start' | 'center' | 'end'`, default `'center'`) controls where the label/icon/avatar/content sits along the separator.
+- **Pagination** — `PaginationProps` now type-checks root HTML attributes (`id`, `style`, `title`, `role`, `tabindex`, `aria-*`, common event handlers, and `data-*`) and forwards them to the root element; previously these were rejected by the type and no `restProps` were spread.
 
 ### Changed
 
@@ -46,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **AvatarGroup** — Avatars now render in array order left-to-right (the first avatar leftmost and on top). Previously the `flex-row-reverse` layout combined with an un-reversed list displayed them right-to-left (e.g. `[1,2,3]` rendered as `3 2 1`).
 - **Alert** — Corrected the `variant` prop's documented default from `'soft'` to `'solid'` to match the actual runtime default.
 - **Drawer** — Forward the remaining typed vaul-svelte props that were silently dropped (`setBackgroundColorOnScale`, `fixed`, `defaultOpen`, `disablePreventScroll`, `repositionInputs`, `snapToSequentialPoint`, `container`, `onAnimationEnd`, `preventScrollRestoration`, `autoFocus`). They were accepted by the type but never reached the underlying drawer.
+- **Pagination** — The previous/next navigation buttons now have an accessible name (`aria-label` "Previous page" / "Next page"); they were icon-only with no label, so assistive tech announced nothing (the first/last buttons already had names).
+- **Pagination** — Removed the dead `firstIcon`/`prevIcon`/`nextIcon`/`lastIcon` keys from the `ui` slot type; they were accepted by the type but silently ignored (navigation icon sizing is handled by the underlying button). The same-named icon-name props (e.g. `prevIcon="lucide:arrow-left"`) are unaffected.
 
 ## [1.8.0] - 2026-05-28
 

--- a/src/lib/Pagination/Pagination.svelte
+++ b/src/lib/Pagination/Pagination.svelte
@@ -47,7 +47,8 @@
         nextSlot,
         lastSlot,
         ellipsisSlot,
-        itemSlot
+        itemSlot,
+        ...restProps
     }: Props = $props()
 
     if (page === undefined) {
@@ -94,6 +95,7 @@
 </script>
 
 <Pagination.Root
+    {...restProps}
     bind:ref
     count={total}
     perPage={itemsPerPage}
@@ -144,6 +146,7 @@
                                 square
                                 {size}
                                 class={classes.prev}
+                                aria-label="Previous page"
                             >
                                 {@render prevSlot({ page: page!, disabled: prevDisabled })}
                             </ButtonComponent>
@@ -156,6 +159,7 @@
                                 {size}
                                 icon={prevIcon}
                                 class={classes.prev}
+                                aria-label="Previous page"
                             />
                         {/if}
                     {/snippet}
@@ -196,6 +200,7 @@
                                 square
                                 {size}
                                 class={classes.next}
+                                aria-label="Next page"
                             >
                                 {@render nextSlot({ page: page!, disabled: nextDisabled })}
                             </ButtonComponent>
@@ -208,6 +213,7 @@
                                 {size}
                                 icon={nextIcon}
                                 class={classes.next}
+                                aria-label="Next page"
                             />
                         {/if}
                     {/snippet}

--- a/src/lib/Pagination/Pagination.svelte.spec.ts
+++ b/src/lib/Pagination/Pagination.svelte.spec.ts
@@ -318,4 +318,47 @@ describe('Pagination', () => {
             })
         })
     })
+
+    // ==================== NAVIGATION ACCESSIBLE NAMES ====================
+
+    describe('navigation accessible names', () => {
+        it('should give the prev and next buttons an accessible name', async () => {
+            render(Pagination, defaultProps)
+            await vi.waitFor(() => {
+                expect(getPrevButton()).not.toBeNull()
+                expect(getNextButton()).not.toBeNull()
+            })
+            expect(getPrevButton()!.getAttribute('aria-label')).toBe('Previous page')
+            expect(getNextButton()!.getAttribute('aria-label')).toBe('Next page')
+        })
+
+        it('should keep accessible names when custom prev/next icons are used', async () => {
+            render(Pagination, {
+                ...defaultProps,
+                prevIcon: 'lucide:arrow-left',
+                nextIcon: 'lucide:arrow-right'
+            })
+            await vi.waitFor(() => expect(getPrevButton()).not.toBeNull())
+            expect(getPrevButton()!.getAttribute('aria-label')).toBe('Previous page')
+            expect(getNextButton()!.getAttribute('aria-label')).toBe('Next page')
+        })
+    })
+
+    // ==================== NATIVE ATTRIBUTES ====================
+
+    describe('native attributes', () => {
+        it('should forward id, aria-label and data-* to the root element', async () => {
+            render(Pagination, {
+                ...defaultProps,
+                id: 'pager',
+                'aria-label': 'Page navigation',
+                'data-testid': 'pager-root'
+            })
+            await vi.waitFor(() => expect(getRoot()).not.toBeNull())
+            const root = getRoot()!
+            expect(root.id).toBe('pager')
+            expect(root.getAttribute('aria-label')).toBe('Page navigation')
+            expect(root.getAttribute('data-testid')).toBe('pager-root')
+        })
+    })
 })

--- a/src/lib/Pagination/pagination.types.ts
+++ b/src/lib/Pagination/pagination.types.ts
@@ -1,5 +1,6 @@
 import type { Snippet } from 'svelte'
 import type { ClassNameValue } from 'tailwind-merge'
+import type { PaginationRootProps } from 'bits-ui'
 import type { PaginationSlots, PaginationVariantProps } from './pagination.variants.js'
 import type { ButtonProps } from '../Button/button.types.js'
 
@@ -49,7 +50,26 @@ export interface PaginationItemSlotProps {
  *
  * @see https://bits-ui.com/docs/components/pagination
  */
-export interface PaginationProps {
+export interface PaginationProps extends Pick<
+    PaginationRootProps,
+    | 'id'
+    | 'style'
+    | 'title'
+    | 'role'
+    | 'tabindex'
+    | 'aria-label'
+    | 'aria-labelledby'
+    | 'aria-describedby'
+    | 'onclick'
+    | 'onkeydown'
+    | 'onmouseenter'
+    | 'onmouseleave'
+    | 'onfocus'
+    | 'onblur'
+> {
+    /** Custom data attributes are forwarded to the root element. */
+    [key: `data-${string}`]: unknown
+
     /**
      * Bindable reference to the root DOM element.
      */

--- a/src/lib/Pagination/pagination.variants.ts
+++ b/src/lib/Pagination/pagination.variants.ts
@@ -97,11 +97,7 @@ export const paginationVariants = tv({
         prev: '',
         next: '',
         last: '',
-        ellipsisIcon: navIcon,
-        firstIcon: navIcon,
-        prevIcon: navIcon,
-        nextIcon: navIcon,
-        lastIcon: navIcon
+        ellipsisIcon: navIcon
     },
     variants: {
         size: {
@@ -109,51 +105,31 @@ export const paginationVariants = tv({
                 list: 'gap-0.5',
                 item: 'size-7 text-xs',
                 ellipsis: 'size-7 text-xs',
-                ellipsisIcon: 'size-3',
-                firstIcon: 'size-3',
-                prevIcon: 'size-3',
-                nextIcon: 'size-3',
-                lastIcon: 'size-3'
+                ellipsisIcon: 'size-3'
             },
             sm: {
                 list: 'gap-0.5',
                 item: 'size-8 text-xs',
                 ellipsis: 'size-8 text-xs',
-                ellipsisIcon: 'size-3.5',
-                firstIcon: 'size-3.5',
-                prevIcon: 'size-3.5',
-                nextIcon: 'size-3.5',
-                lastIcon: 'size-3.5'
+                ellipsisIcon: 'size-3.5'
             },
             md: {
                 list: 'gap-1',
                 item: 'size-9 text-sm',
                 ellipsis: 'size-9 text-sm',
-                ellipsisIcon: 'size-4',
-                firstIcon: 'size-4',
-                prevIcon: 'size-4',
-                nextIcon: 'size-4',
-                lastIcon: 'size-4'
+                ellipsisIcon: 'size-4'
             },
             lg: {
                 list: 'gap-1',
                 item: 'size-10 text-sm',
                 ellipsis: 'size-10 text-sm',
-                ellipsisIcon: 'size-5',
-                firstIcon: 'size-5',
-                prevIcon: 'size-5',
-                nextIcon: 'size-5',
-                lastIcon: 'size-5'
+                ellipsisIcon: 'size-5'
             },
             xl: {
                 list: 'gap-1.5',
                 item: 'size-11 text-base',
                 ellipsis: 'size-11 text-base',
-                ellipsisIcon: 'size-5',
-                firstIcon: 'size-5',
-                prevIcon: 'size-5',
-                nextIcon: 'size-5',
-                lastIcon: 'size-5'
+                ellipsisIcon: 'size-5'
             }
         },
         disabled: {


### PR DESCRIPTION
## Summary

Pagination review fixes: give the prev/next navigation buttons an accessible name, forward native root HTML attributes, and remove dead `ui` icon slot keys.

Closes #83

## Changes

- **a11y:** prev/next buttons now have `aria-label` ("Previous page" / "Next page"); they were icon-only with no accessible name (first/last already had names).
- **types:** `PaginationProps` now `Pick`s native root HTML attributes from the primitive root props + a `data-*` index signature, and `...restProps` is spread onto `Pagination.Root`.
- **types:** removed the dead `firstIcon`/`prevIcon`/`nextIcon`/`lastIcon` keys from the `ui` slot type (accepted but silently ignored). The same-named icon-name string props are unaffected.

## Checklist

- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm lint`
- [x] `pnpm test` — 29/29 (incl. 3 new)
- [x] CHANGELOG updated (Added / Fixed)