### PR TITLE
fix(select): forward trigger HTML attrs, drop dead defaultValue; fix SelectMenu FormField search field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Separator** — `position` prop (`'start' | 'center' | 'end'`, default `'center'`) controls where the label/icon/avatar/content sits along the separator.
 - **Tabs** — `TabsProps` now type-checks root HTML attributes (`id`, `style`, `title`, `role`, `tabindex`, `aria-*`, common event handlers, and `data-*`) and forwards them to the root element; previously these were rejected by the type and no `restProps` were spread.
 - **Pagination** — `PaginationProps` now type-checks root HTML attributes (`id`, `style`, `title`, `role`, `tabindex`, `aria-*`, common event handlers, and `data-*`) and forwards them to the root element; previously these were rejected by the type and no `restProps` were spread.
+- **Select** — `SelectProps` now type-checks trigger HTML attributes (`style`, `title`, `role`, `tabindex`, `aria-label`, `aria-labelledby`, common event handlers, and `data-*`) and forwards them to the `Select.Trigger`; previously these were rejected by the type and no `restProps` were spread.
+- **SelectMenu** — `SelectMenuProps` now type-checks trigger HTML attributes (`style`, `title`, `role`, `tabindex`, `aria-label`, `aria-labelledby`, common event handlers, and `data-*`) and forwards them to the `Combobox.Trigger`; previously these were rejected by the type and no `restProps` were spread.
 
 ### Changed
 
@@ -39,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **DropdownMenu** — Removed the unused `name` field from `DropdownMenuRadioGroup`; it was accepted by the type but never read at runtime (radio grouping is keyed by the single `radioGroups[0]` entry).
 - **Tabs** — Removed the unused `slot` field from `TabsItem`; it was accepted by the type and documented as enabling dynamic per-item slots, but was never wired to any rendering (setting it had no effect).
+- **Select** — Removed the unused `defaultValue` prop; it was accepted by the type but never wired (the component is controlled via `value`), so setting it had no effect.
 
 ### Fixed
 
@@ -54,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Pagination** — Removed the dead `firstIcon`/`prevIcon`/`nextIcon`/`lastIcon` keys from the `ui` slot type; they were accepted by the type but silently ignored (navigation icon sizing is handled by the underlying button). The same-named icon-name props (e.g. `prevIcon="lucide:arrow-left"`) are unaffected.
 - **Input** — Loading state no longer renders a duplicate, non-spinning loader: when a `trailingIcon` (or both a leading and trailing icon) is present, the spinner now appears only on the side selected by `trailing`, and the opposite side keeps its own icon glyph instead of showing a second static loader.
 - **Input** — `avatar` now takes precedence over `leadingIcon` when both are provided, matching the documented behavior; previously the leading icon was shown and the avatar was hidden.
+- **SelectMenu** — The in-dropdown search field no longer inherits the surrounding `FormField` context. Previously, when a `SelectMenu` was used inside a `<FormField>`, the search input duplicated the field's `id` (invalid HTML, broke label association) and fired spurious `FormField` validation events while typing.
 
 ## [1.8.0] - 2026-05-28
 

--- a/src/lib/Select/Select.svelte
+++ b/src/lib/Select/Select.svelte
@@ -67,7 +67,8 @@
         itemLabel: itemLabelSlot,
         itemTrailing,
         selected: selectedSlot,
-        content: contentSlot
+        content: contentSlot,
+        ...restProps
     }: Props = $props()
 
     // ---- Form context ----
@@ -371,6 +372,7 @@
         {/if}
 
         <Select.Trigger
+            {...restProps}
             id={resolvedId}
             name={resolvedName}
             aria-describedby={ariaDescribedBy}

--- a/src/lib/Select/Select.svelte.spec.ts
+++ b/src/lib/Select/Select.svelte.spec.ts
@@ -587,4 +587,22 @@ describe('Select', () => {
             })
         })
     })
+
+    // ==================== NATIVE ATTRIBUTES ====================
+
+    describe('native attributes', () => {
+        it('should forward id, aria-label and data-* to the trigger', () => {
+            render(Select, {
+                items: defaultItems,
+                id: 'fruit-select',
+                'aria-label': 'Fruit',
+                'data-testid': 'fruit-trigger'
+            })
+            const trigger = getTrigger()
+            expect(trigger).not.toBeNull()
+            expect(trigger!.id).toBe('fruit-select')
+            expect(trigger!.getAttribute('aria-label')).toBe('Fruit')
+            expect(trigger!.getAttribute('data-testid')).toBe('fruit-trigger')
+        })
+    })
 })

--- a/src/lib/Select/select.types.ts
+++ b/src/lib/Select/select.types.ts
@@ -2,7 +2,11 @@ import type { Snippet } from 'svelte'
 import type { ClassNameValue } from 'tailwind-merge'
 import type { SelectVariantProps, SelectSlots } from './select.variants.js'
 import type { AvatarProps } from '../Avatar/avatar.types.js'
-import type { SelectRootPropsWithoutHTML, SelectContentPropsWithoutHTML } from 'bits-ui'
+import type {
+    SelectRootPropsWithoutHTML,
+    SelectContentPropsWithoutHTML,
+    SelectTriggerProps
+} from 'bits-ui'
 
 /**
  * The value shape for the Select.
@@ -148,7 +152,26 @@ type ContentProps = Pick<
  *
  * @see https://bits-ui.com/docs/components/select
  */
-export interface SelectProps extends RootProps, ContentProps {
+type TriggerHTMLProps = Pick<
+    SelectTriggerProps,
+    | 'style'
+    | 'title'
+    | 'role'
+    | 'tabindex'
+    | 'aria-label'
+    | 'aria-labelledby'
+    | 'onclick'
+    | 'onkeydown'
+    | 'onmouseenter'
+    | 'onmouseleave'
+    | 'onfocus'
+    | 'onblur'
+>
+
+export interface SelectProps extends RootProps, ContentProps, TriggerHTMLProps {
+    /** Custom data attributes are forwarded to the trigger element. */
+    [key: `data-${string}`]: unknown
+
     // -------------------------------------------------------------------------
     // Ref
     // -------------------------------------------------------------------------
@@ -169,14 +192,6 @@ export interface SelectProps extends RootProps, ContentProps {
      * - When `multiple` is `true`, this is a `string[]`.
      */
     value?: string | string[]
-
-    /**
-     * The default selected value when uncontrolled.
-     *
-     * - When `multiple` is `false`/omitted, this is a `string`.
-     * - When `multiple` is `true`, this is a `string[]`.
-     */
-    defaultValue?: string | string[]
 
     /**
      * Whether multiple items can be selected at once.

--- a/src/lib/SelectMenu/SelectMenu.svelte
+++ b/src/lib/SelectMenu/SelectMenu.svelte
@@ -21,7 +21,6 @@
     } from '../FieldGroup/field-group.variants.js'
     import Icon from '../Icon/Icon.svelte'
     import Avatar from '../Avatar/Avatar.svelte'
-    import Input from '../Input/Input.svelte'
     import type { AvatarSize } from '../Avatar/avatar.types.js'
     import { useFormField, useFormFieldEmit } from '../hooks/useFormField.svelte.js'
 
@@ -82,7 +81,8 @@
         itemTrailing,
         selected: selectedSlot,
         empty: emptySlot,
-        content: contentSlot
+        content: contentSlot,
+        ...restProps
     }: Props = $props()
 
     // ---- Form context ----
@@ -444,7 +444,9 @@
         {forceMount}
         class={contentClass}
     >
-        <Input
+        <!-- svelte-ignore a11y_autofocus -->
+        <input
+            type="text"
             autofocus
             placeholder={searchPlaceholder}
             value={searchTerm}
@@ -455,8 +457,6 @@
                 e.preventDefault()
                 handleCreate()
             }}
-            variant="none"
-            size={resolvedSize}
             class={inputClass}
         />
 
@@ -539,6 +539,7 @@
         />
 
         <Combobox.Trigger
+            {...restProps}
             id={resolvedId}
             aria-describedby={ariaDescribedBy}
             aria-invalid={resolvedHighlight ? true : undefined}

--- a/src/lib/SelectMenu/SelectMenu.svelte.spec.ts
+++ b/src/lib/SelectMenu/SelectMenu.svelte.spec.ts
@@ -2,6 +2,7 @@ import { page } from 'vitest/browser'
 import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-svelte'
 import SelectMenu from './SelectMenu.svelte'
+import SelectMenuFormFieldTestWrapper from './SelectMenuFormFieldTestWrapper.svelte'
 import type { SelectMenuItem, SelectMenuItemType } from './select-menu.types.js'
 
 const defaultItems: SelectMenuItem[] = [
@@ -804,6 +805,26 @@ describe('SelectMenu', () => {
             await page.getByRole('option', { name: /Create "react"/ }).click()
             await new Promise((r) => setTimeout(r, 50))
             expect(onCreate).not.toHaveBeenCalled()
+        })
+    })
+
+    // ==================== FORMFIELD INTEGRATION ====================
+
+    describe('FormField integration', () => {
+        it('should not share the FormField id between the trigger and the search input', async () => {
+            render(SelectMenuFormFieldTestWrapper, {
+                items: [{ value: 'apple', label: 'Apple' }]
+            })
+            await vi.waitFor(() => {
+                expect(document.querySelector('input[placeholder="Search..."]')).not.toBeNull()
+            })
+            const withFieldId = document.querySelectorAll('[id="form-field-fruit"]')
+            expect(withFieldId.length).toBe(1)
+            expect((withFieldId[0] as HTMLElement).tagName).toBe('BUTTON')
+            const search = document.querySelector(
+                'input[placeholder="Search..."]'
+            ) as HTMLInputElement
+            expect(search.id).not.toBe('form-field-fruit')
         })
     })
 })

--- a/src/lib/SelectMenu/SelectMenuFormFieldTestWrapper.svelte
+++ b/src/lib/SelectMenu/SelectMenuFormFieldTestWrapper.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+    import FormField from '../FormField/FormField.svelte'
+    import SelectMenu from './SelectMenu.svelte'
+    import type { SelectMenuItemType } from './select-menu.types.js'
+
+    let { items = [] }: { items?: SelectMenuItemType[] } = $props()
+</script>
+
+<FormField name="fruit" label="Fruit">
+    <SelectMenu open {items} placeholder="Pick" />
+</FormField>

--- a/src/lib/SelectMenu/select-menu.types.ts
+++ b/src/lib/SelectMenu/select-menu.types.ts
@@ -2,7 +2,7 @@ import type { Snippet } from 'svelte'
 import type { ClassNameValue } from 'tailwind-merge'
 import type { SelectMenuVariantProps, SelectMenuSlots } from './select-menu.variants.js'
 import type { AvatarProps } from '../Avatar/avatar.types.js'
-import type { ComboboxContentPropsWithoutHTML } from 'bits-ui'
+import type { ComboboxContentPropsWithoutHTML, ComboboxTriggerProps } from 'bits-ui'
 
 // ============================================================================
 // Item Types (reuse from Select)
@@ -125,7 +125,26 @@ type ContentProps = Pick<
  *
  * @see https://bits-ui.com/docs/components/combobox
  */
-export interface SelectMenuProps extends ContentProps {
+type TriggerHTMLProps = Pick<
+    ComboboxTriggerProps,
+    | 'style'
+    | 'title'
+    | 'role'
+    | 'tabindex'
+    | 'aria-label'
+    | 'aria-labelledby'
+    | 'onclick'
+    | 'onkeydown'
+    | 'onmouseenter'
+    | 'onmouseleave'
+    | 'onfocus'
+    | 'onblur'
+>
+
+export interface SelectMenuProps extends ContentProps, TriggerHTMLProps {
+    /** Custom data attributes are forwarded to the trigger element. */
+    [key: `data-${string}`]: unknown
+
     // -------------------------------------------------------------------------
     // Ref
     // -------------------------------------------------------------------------

--- a/src/lib/SelectMenu/select-menu.variants.ts
+++ b/src/lib/SelectMenu/select-menu.variants.ts
@@ -14,7 +14,11 @@ export const selectMenuVariants = tv({
             'overflow-hidden',
             'flex flex-col'
         ],
-        input: 'border-b border-outline-variant',
+        input: [
+            'w-full border-0 border-b border-outline-variant bg-transparent',
+            'text-on-surface placeholder:text-on-surface-variant/50',
+            'focus:outline-none focus:ring-0'
+        ],
         viewport: 'p-1 flex-1 overflow-y-auto scrollbar-thin',
         empty: 'text-center text-on-surface-variant',
         createItem: [
@@ -29,26 +33,31 @@ export const selectMenuVariants = tv({
     variants: {
         size: {
             xs: {
+                input: 'px-2 py-1 text-xs',
                 empty: 'p-2 text-xs',
                 createItem: 'py-1 text-xs',
                 createItemIcon: 'size-3'
             },
             sm: {
+                input: 'px-2.5 py-1.5 text-xs',
                 empty: 'p-2.5 text-xs',
                 createItem: 'py-1.5 text-xs',
                 createItemIcon: 'size-3.5'
             },
             md: {
+                input: 'px-3 py-2 text-sm',
                 empty: 'p-2.5 text-sm',
                 createItem: 'py-1.5 text-sm',
                 createItemIcon: 'size-4'
             },
             lg: {
+                input: 'px-4 py-2.5 text-sm',
                 empty: 'p-3 text-sm',
                 createItem: 'py-2 text-sm',
                 createItemIcon: 'size-5'
             },
             xl: {
+                input: 'px-5 py-3 text-base',
                 empty: 'p-3 text-base',
                 createItem: 'py-2.5 text-base',
                 createItemIcon: 'size-5'


### PR DESCRIPTION
## Summary

Select & SelectMenu review fixes (low-risk type/a11y). The deeper SelectMenu screen-reader ARIA issue is deferred to #84 (a spike showed the canonical fix breaks dropdown anchoring).

Closes #85

## Changes

- **Select — types:** `SelectProps` now type-checks and forwards native trigger HTML attributes (`style`, `title`, `role`, `tabindex`, `aria-label`/`-labelledby`, common event handlers, `data-*`) onto `Select.Trigger` via a `Pick` + `data-*` index + `...restProps` spread.
- **Select — types:** removed the unused `defaultValue` prop (never wired; the component is controlled via `value`).
- **SelectMenu — types:** same trigger-attribute forwarding onto `Combobox.Trigger`.
- **SelectMenu — bug/a11y:** the in-dropdown search field is now a plain `<input>` instead of the `Input` component, so it no longer inherits the surrounding `FormField` context (which duplicated the field `id` and fired spurious validation events while typing). Its styling moved to the `input` variant slot (sized xs–xl).

## Checklist

- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm lint`
- [x] `pnpm test` — full suite 2400/2400 (added Select native-attrs test + SelectMenu FormField-id regression test)
- [x] CHANGELOG updated (Added / Removed / Fixed)

## Deferred
- #84 — SelectMenu combobox ARIA on hidden input (screen-reader). Keyboard works via event bubbling; full fix needs a combobox restructure that the spike showed risks anchoring.