### PR TITLE
perf(editor): lazy-load extensions, dedup serialize, harden image src, a11y popups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Editor** — Halved the serialization work per keystroke: the value-sync effect no longer re-serializes the document to compare it against a value the editor itself just emitted (it short-circuits on its own echo). Previously every edit serialized twice — once to push `value`, then again in the sync effect to compare. Most noticeable for `output="markdown"` and large documents. No API or behavior change.
 - **Editor** — The heavy optional extensions are now lazy-loaded via dynamic `import()`: `tiptap-markdown` (only when `output="markdown"`) and the table packages (only when `tables` is enabled). Editors that don't use them no longer pull `markdown-it` (~80 KB gzip) or `prosemirror-tables` (~25 KB gzip) into the bundle — the consumer's bundler now code-splits them into separate chunks loaded on demand. Editors that enable neither still mount **synchronously** (no behavior change); only `markdown`/`tables` editors initialize asynchronously while their chunk loads (toolbar actions are briefly disabled and `bind:api` methods are no-ops until then).
 
+### Security
+
+- **Editor** — Image URLs returned by `onImageUpload` are now validated before insertion: relative URLs, `http(s)`, and raster `data:image/*` URIs are allowed, while `javascript:`, `data:text/*`, and `data:image/svg+xml` (an SVG script vector) are rejected (the image is not inserted and a warning is logged). The `value` docs now state that the HTML output is schema-validated but not sanitizer-clean — consumers must sanitize (e.g. with DOMPurify) before rendering it as raw markup elsewhere.
+
 ## [2.0.0] - 2026-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Editor** — Halved the serialization work per keystroke: the value-sync effect no longer re-serializes the document to compare it against a value the editor itself just emitted (it short-circuits on its own echo). Previously every edit serialized twice — once to push `value`, then again in the sync effect to compare. Most noticeable for `output="markdown"` and large documents. No API or behavior change.
 - **Editor** — The heavy optional extensions are now lazy-loaded via dynamic `import()`: `tiptap-markdown` (only when `output="markdown"`) and the table packages (only when `tables` is enabled). Editors that don't use them no longer pull `markdown-it` (~80 KB gzip) or `prosemirror-tables` (~25 KB gzip) into the bundle — the consumer's bundler now code-splits them into separate chunks loaded on demand. Editors that enable neither still mount **synchronously** (no behavior change); only `markdown`/`tables` editors initialize asynchronously while their chunk loads (toolbar actions are briefly disabled and `bind:api` methods are no-ops until then).
 
+### Fixed
+
+- **Editor** — The mention (`@`) and slash (`/`) autocomplete popups are now proper ARIA listboxes: each item exposes `role="option"` + `aria-selected`, the listbox has an accessible name, and while a popup is open the editor's contenteditable exposes `aria-controls`, `aria-expanded`, and `aria-activedescendant` (cleared on close) so screen readers announce the highlighted option as the user navigates.
+
 ### Security
 
 - **Editor** — Image URLs returned by `onImageUpload` are now validated before insertion: relative URLs, `http(s)`, and raster `data:image/*` URIs are allowed, while `javascript:`, `data:text/*`, and `data:image/svg+xml` (an SVG script vector) are rejected (the image is not inserted and a warning is logged). The `value` docs now state that the HTML output is schema-validated but not sanitizer-clean — consumers must sanitize (e.g. with DOMPurify) before rendering it as raw markup elsewhere.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Editor** — The heavy optional extensions are now lazy-loaded via dynamic `import()`: `tiptap-markdown` (only when `output="markdown"`) and the table packages (only when `tables` is enabled). Editors that don't use them no longer pull `markdown-it` (~80 KB gzip) or `prosemirror-tables` (~25 KB gzip) into the bundle — the consumer's bundler now code-splits them into separate chunks loaded on demand. Editors that enable neither still mount **synchronously** (no behavior change); only `markdown`/`tables` editors initialize asynchronously while their chunk loads (toolbar actions are briefly disabled and `bind:api` methods are no-ops until then).
+
 ## [2.0.0] - 2026-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Editor** — `onImageUploadError` prop, called when `onImageUpload` rejects (previously upload failures were only logged to the console). Use it to surface errors to the user.
+
 ### Changed
 
 - **Editor** — Halved the serialization work per keystroke: the value-sync effect no longer re-serializes the document to compare it against a value the editor itself just emitted (it short-circuits on its own echo). Previously every edit serialized twice — once to push `value`, then again in the sync effect to compare. Most noticeable for `output="markdown"` and large documents. No API or behavior change.
 - **Editor** — The heavy optional extensions are now lazy-loaded via dynamic `import()`: `tiptap-markdown` (only when `output="markdown"`) and the table packages (only when `tables` is enabled). Editors that don't use them no longer pull `markdown-it` (~80 KB gzip) or `prosemirror-tables` (~25 KB gzip) into the bundle — the consumer's bundler now code-splits them into separate chunks loaded on demand. Editors that enable neither still mount **synchronously** (no behavior change); only `markdown`/`tables` editors initialize asynchronously while their chunk loads (toolbar actions are briefly disabled and `bind:api` methods are no-ops until then).
 
+### Removed
+
+- **Editor** — Removed the unused `toolbarGroup` key from the `ui` slot type; it was computed but never rendered, so setting it had no effect.
+
 ### Fixed
 
+- **Editor** — Changing the `output` prop on an already-mounted editor no longer corrupts the content. `output` is read once at mount (it also decides whether the Markdown extension is loaded); it is now applied consistently to serialization, so a runtime change is simply ignored instead of producing a format/extension mismatch. Re-key the component (`{#key output}`) to switch formats.
 - **Editor** — The mention (`@`) and slash (`/`) autocomplete popups are now proper ARIA listboxes: each item exposes `role="option"` + `aria-selected`, the listbox has an accessible name, and while a popup is open the editor's contenteditable exposes `aria-controls`, `aria-expanded`, and `aria-activedescendant` (cleared on close) so screen readers announce the highlighted option as the user navigates.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Editor** — Halved the serialization work per keystroke: the value-sync effect no longer re-serializes the document to compare it against a value the editor itself just emitted (it short-circuits on its own echo). Previously every edit serialized twice — once to push `value`, then again in the sync effect to compare. Most noticeable for `output="markdown"` and large documents. No API or behavior change.
 - **Editor** — The heavy optional extensions are now lazy-loaded via dynamic `import()`: `tiptap-markdown` (only when `output="markdown"`) and the table packages (only when `tables` is enabled). Editors that don't use them no longer pull `markdown-it` (~80 KB gzip) or `prosemirror-tables` (~25 KB gzip) into the bundle — the consumer's bundler now code-splits them into separate chunks loaded on demand. Editors that enable neither still mount **synchronously** (no behavior change); only `markdown`/`tables` editors initialize asynchronously while their chunk loads (toolbar actions are briefly disabled and `bind:api` methods are no-ops until then).
 
 ## [2.0.0] - 2026-06-01

--- a/src/lib/Editor/Editor.svelte
+++ b/src/lib/Editor/Editor.svelte
@@ -245,10 +245,6 @@
     $effect(() => {
         if (!contentElement) return
 
-        // Untrack: these props would otherwise cause editor recreation on every
-        // keystroke (value changes via onUpdate → effect re-runs → destroy + rebuild
-        // → cursor lost → can only type 1 char). value sync is handled by a
-        // dedicated effect below; disabled/readonly toggle via setEditable.
         const initialContent = untrack(() => value ?? '')
         const initialEditable = untrack(() => !disabled && !readonly)
         const initialAutofocus = untrack(() => autofocus)
@@ -321,9 +317,6 @@
         }
     })
 
-    // Sync aria attributes on the ProseMirror element when error/id state changes.
-    // Tiptap's editorProps.attributes is read once at init, so toggling needs
-    // direct DOM access. Run on every state change.
     $effect(() => {
         if (!contentElement) return
         const pm = contentElement.querySelector('.ProseMirror') as HTMLElement | null
@@ -421,7 +414,6 @@
         }
     })
 
-    // ----- URL prompt modal (shared by YouTube/Image/Link toolbar + slash) -----
     interface UrlPromptState {
         open: boolean
         title: string
@@ -465,7 +457,6 @@
         }
     }
 
-    // ----- Image upload via hidden file input -----
     let fileInput: HTMLInputElement | null = $state(null)
 
     async function handleFileSelected(event: Event): Promise<void> {
@@ -537,7 +528,6 @@
         })
     }
 
-    // ----- Table dimension picker -----
     let tableMenuOpen = $state(false)
     let tablePickerRows = $state(0)
     let tablePickerCols = $state(0)

--- a/src/lib/Editor/Editor.svelte
+++ b/src/lib/Editor/Editor.svelte
@@ -228,6 +228,7 @@
     }
 
     let suppressUpdate = false
+    let lastEmitted: string | EditorJSON | undefined
 
     $effect(() => {
         if (!contentElement) return
@@ -267,6 +268,7 @@
                     syncState(e)
                     if (suppressUpdate) return
                     const serialized = serialize(e)
+                    lastEmitted = serialized
                     value = serialized
                     emit.onInput()
                     onValueChange?.(serialized)
@@ -324,6 +326,7 @@
     $effect(() => {
         if (!editor) return
         if (value === undefined) return
+        if (typeof value === 'string' && value === lastEmitted) return
         const current = serialize(editor)
         if (isContentEqual(current, value)) return
         suppressUpdate = true

--- a/src/lib/Editor/Editor.svelte
+++ b/src/lib/Editor/Editor.svelte
@@ -58,6 +58,7 @@
         markdownAllowHtml = false,
         image = false,
         onImageUpload,
+        onImageUploadError,
         tables = false,
         onMention,
         mentionTrigger = '@',
@@ -81,6 +82,14 @@
 
     const formFieldContext = useFormField()
     const emit = useFormFieldEmit()
+
+    const resolvedOutput = untrack(() => output)
+
+    function getMarkdownStorage(ed: Editor): { getMarkdown?: () => string } | undefined {
+        return (ed.storage as unknown as Record<string, unknown>).markdown as
+            | { getMarkdown?: () => string }
+            | undefined
+    }
 
     const hasError = $derived(
         formFieldContext?.error !== undefined && formFieldContext?.error !== false
@@ -148,11 +157,9 @@
     }
 
     function serialize(ed: Editor): string | EditorJSON {
-        if (output === 'json') return ed.getJSON() as EditorJSON
-        if (output === 'markdown') {
-            const md = (ed.storage as unknown as Record<string, unknown>).markdown as
-                | { getMarkdown?: () => string }
-                | undefined
+        if (resolvedOutput === 'json') return ed.getJSON() as EditorJSON
+        if (resolvedOutput === 'markdown') {
+            const md = getMarkdownStorage(ed)
             if (md && typeof md.getMarkdown === 'function') {
                 return md.getMarkdown()
             }
@@ -208,7 +215,7 @@
             tables,
             youtube,
             dragHandle,
-            markdown: output === 'markdown',
+            markdown: resolvedOutput === 'markdown',
             markdownAllowHtml,
             mentionTrigger,
             mentionSuggestion: onMention
@@ -355,13 +362,11 @@
             TOOLBAR_ACTIONS[action].run(editor)
         },
         getValue(format) {
-            if (!editor) return output === 'json' ? ({} as EditorJSON) : ''
-            const fmt = format ?? output
+            if (!editor) return resolvedOutput === 'json' ? ({} as EditorJSON) : ''
+            const fmt = format ?? resolvedOutput
             if (fmt === 'json') return editor.getJSON() as EditorJSON
             if (fmt === 'markdown') {
-                const md = (editor.storage as unknown as Record<string, unknown>).markdown as
-                    | { getMarkdown?: () => string }
-                    | undefined
+                const md = getMarkdownStorage(editor)
                 if (md && typeof md.getMarkdown === 'function') return md.getMarkdown()
                 return editor.getHTML()
             }
@@ -405,7 +410,6 @@
         return {
             root: slots.root({ class: [c.root, className, u.root] }),
             toolbar: slots.toolbar({ class: [c.toolbar, u.toolbar] }),
-            toolbarGroup: slots.toolbarGroup({ class: [c.toolbarGroup, u.toolbarGroup] }),
             toolbarButton: slots.toolbarButton({ class: [c.toolbarButton, u.toolbarButton] }),
             toolbarSeparator: slots.toolbarSeparator({
                 class: [c.toolbarSeparator, u.toolbarSeparator]
@@ -480,8 +484,12 @@
             }
             editor.chain().focus().setImage({ src: url }).run()
         } catch (err) {
-            // eslint-disable-next-line no-console
-            console.error('[Editor] image upload failed', err)
+            if (onImageUploadError) {
+                onImageUploadError(err)
+            } else {
+                // eslint-disable-next-line no-console
+                console.error('[Editor] image upload failed', err)
+            }
         }
     }
 

--- a/src/lib/Editor/Editor.svelte
+++ b/src/lib/Editor/Editor.svelte
@@ -24,7 +24,12 @@
     import Icon from '../Icon/Icon.svelte'
     import Tooltip from '../Tooltip/Tooltip.svelte'
     import EditorUrlPrompt from './EditorUrlPrompt.svelte'
-    import { httpUrlSchema, youtubeUrlSchema, type UrlSchema } from './editor.schemas.js'
+    import {
+        httpUrlSchema,
+        youtubeUrlSchema,
+        isSafeImageSrc,
+        type UrlSchema
+    } from './editor.schemas.js'
 
     const config = getComponentConfig('editor', editorDefaults)
 
@@ -468,6 +473,11 @@
         if (!onImageUpload) return
         try {
             const url = await onImageUpload(file)
+            if (!isSafeImageSrc(url)) {
+                // eslint-disable-next-line no-console
+                console.warn('[Editor] blocked unsafe image src from onImageUpload:', url)
+                return
+            }
             editor.chain().focus().setImage({ src: url }).run()
         } catch (err) {
             // eslint-disable-next-line no-console

--- a/src/lib/Editor/Editor.svelte
+++ b/src/lib/Editor/Editor.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <script lang="ts">
-    import { Editor } from '@tiptap/core'
+    import { Editor, type AnyExtension } from '@tiptap/core'
     import BubbleMenuExt from '@tiptap/extension-bubble-menu'
     import { untrack } from 'svelte'
     import { editorVariants, editorDefaults } from './editor.variants.js'
@@ -191,7 +191,7 @@
         })
     }
 
-    function resolveExtensions() {
+    function resolveExtensions(): AnyExtension[] | Promise<AnyExtension[]> {
         if (extensionsOverride) return extensionsOverride
         return buildExtensions({
             headingLevels,
@@ -245,43 +245,56 @@
             ...(ariaDescribedBy ? { 'aria-describedby': ariaDescribedBy } : {}),
             ...(hasError ? { 'aria-invalid': 'true' } : {})
         }))
-        const exts = untrack(() => resolveExtensions())
+        const el = contentElement
+        const result = untrack(() => resolveExtensions())
 
-        const ed = new Editor({
-            element: contentElement,
-            extensions: exts,
-            content: initialContent,
-            editable: initialEditable,
-            autofocus: initialAutofocus,
-            editorProps: {
-                attributes: initialAttrs as Record<string, string>
-            },
-            onCreate: ({ editor: e }) => syncState(e),
-            onUpdate: ({ editor: e }) => {
-                syncState(e)
-                if (suppressUpdate) return
-                const serialized = serialize(e)
-                value = serialized
-                emit.onInput()
-                onValueChange?.(serialized)
-            },
-            onSelectionUpdate: ({ editor: e }) => syncState(e),
-            onFocus: ({ editor: e }) => {
-                syncState(e)
-                emit.onFocus()
-                onFocus?.()
-            },
-            onBlur: ({ editor: e }) => {
-                syncState(e)
-                emit.onBlur()
-                onBlur?.()
-            }
-        })
+        let ed: Editor | null = null
+        let cancelled = false
 
-        editor = ed
+        const create = (exts: AnyExtension[]) => {
+            if (cancelled) return
+            ed = new Editor({
+                element: el,
+                extensions: exts,
+                content: initialContent,
+                editable: initialEditable,
+                autofocus: initialAutofocus,
+                editorProps: {
+                    attributes: initialAttrs as Record<string, string>
+                },
+                onCreate: ({ editor: e }) => syncState(e),
+                onUpdate: ({ editor: e }) => {
+                    syncState(e)
+                    if (suppressUpdate) return
+                    const serialized = serialize(e)
+                    value = serialized
+                    emit.onInput()
+                    onValueChange?.(serialized)
+                },
+                onSelectionUpdate: ({ editor: e }) => syncState(e),
+                onFocus: ({ editor: e }) => {
+                    syncState(e)
+                    emit.onFocus()
+                    onFocus?.()
+                },
+                onBlur: ({ editor: e }) => {
+                    syncState(e)
+                    emit.onBlur()
+                    onBlur?.()
+                }
+            })
+            editor = ed
+        }
+
+        if (result instanceof Promise) {
+            result.then(create)
+        } else {
+            create(result)
+        }
 
         return () => {
-            ed.destroy()
+            cancelled = true
+            ed?.destroy()
             editor = null
         }
     })

--- a/src/lib/Editor/Editor.svelte.spec.ts
+++ b/src/lib/Editor/Editor.svelte.spec.ts
@@ -795,4 +795,96 @@ describe('Editor', () => {
             })
         })
     })
+
+    // ==================== POPUP ACCESSIBILITY ====================
+
+    describe('popup accessibility', () => {
+        it('slash popup exposes role=option, aria-selected, and editor aria-activedescendant', async () => {
+            let api: EditorApi | undefined
+            const { container } = render(Editor, {
+                slash: true,
+                get api() {
+                    return api
+                },
+                set api(v: EditorApi | undefined) {
+                    api = v
+                }
+            })
+            await vi.waitFor(() => expect(api?.editor).not.toBeNull())
+
+            api!.editor!.chain().focus().insertContent('/').run()
+
+            const popup = await vi.waitFor(() => {
+                const el = document.querySelector('[data-editor-slash-popup]')
+                expect(el).not.toBeNull()
+                return el as HTMLElement
+            })
+
+            const options = popup.querySelectorAll('[role="option"]')
+            expect(options.length).toBeGreaterThan(0)
+
+            const selected = popup.querySelectorAll('[role="option"][aria-selected="true"]')
+            expect(selected.length).toBe(1)
+
+            expect(popup.getAttribute('aria-label')).toBe('Slash commands')
+            expect(popup.id).not.toBe('')
+
+            const pm = getProseMirror(container)!
+            expect(pm.getAttribute('aria-controls')).toBe(popup.id)
+            expect(pm.getAttribute('aria-expanded')).toBe('true')
+
+            const activeId = pm.getAttribute('aria-activedescendant')
+            expect(activeId).toBeTruthy()
+            expect(popup.querySelector(`#${activeId}`)).not.toBeNull()
+            expect(popup.querySelector(`#${activeId}`)?.getAttribute('aria-selected')).toBe('true')
+        })
+
+        it('mention popup exposes role=option, aria-selected, and editor aria-activedescendant', async () => {
+            let api: EditorApi | undefined
+            const { container } = render(Editor, {
+                onMention: async () => [
+                    { id: 'alice', label: 'Alice' },
+                    { id: 'bob', label: 'Bob' }
+                ],
+                get api() {
+                    return api
+                },
+                set api(v: EditorApi | undefined) {
+                    api = v
+                }
+            })
+            await vi.waitFor(() => expect(api?.editor).not.toBeNull())
+
+            api!.editor!.chain().focus().insertContent('@').run()
+
+            const popup = await vi.waitFor(() => {
+                const el = document.querySelector('[data-editor-mention-popup]')
+                expect(el).not.toBeNull()
+                const list = (el as HTMLElement).querySelector('[role="listbox"]')
+                expect(list?.querySelectorAll('[role="option"]').length).toBeGreaterThan(0)
+                return el as HTMLElement
+            })
+
+            const listbox = popup.querySelector('[role="listbox"]') as HTMLElement
+            expect(listbox.getAttribute('aria-label')).toBe('Mentions')
+            expect(listbox.id).not.toBe('')
+
+            const options = listbox.querySelectorAll('[role="option"]')
+            expect(options.length).toBe(2)
+
+            const selected = listbox.querySelectorAll('[role="option"][aria-selected="true"]')
+            expect(selected.length).toBe(1)
+
+            const pm = getProseMirror(container)!
+            expect(pm.getAttribute('aria-controls')).toBe(listbox.id)
+            expect(pm.getAttribute('aria-expanded')).toBe('true')
+
+            const activeId = pm.getAttribute('aria-activedescendant')
+            expect(activeId).toBeTruthy()
+            expect(listbox.querySelector(`#${activeId}`)).not.toBeNull()
+            expect(listbox.querySelector(`#${activeId}`)?.getAttribute('aria-selected')).toBe(
+                'true'
+            )
+        })
+    })
 })

--- a/src/lib/Editor/Editor.svelte.spec.ts
+++ b/src/lib/Editor/Editor.svelte.spec.ts
@@ -463,6 +463,39 @@ describe('Editor', () => {
                 expect(btn).not.toBeNull()
             })
         })
+
+        const selectFile = (container: Element) => {
+            const input = container.querySelector('[data-editor-image-input]') as HTMLInputElement
+            const dt = new DataTransfer()
+            dt.items.add(new File(['x'], 'x.png', { type: 'image/png' }))
+            input.files = dt.files
+            input.dispatchEvent(new Event('change', { bubbles: true }))
+        }
+
+        it('blocks an unsafe image src returned by onImageUpload', async () => {
+            const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+            const { container } = render(Editor, {
+                image: true,
+                onImageUpload: async () => 'javascript:alert(1)'
+            })
+            await vi.waitFor(() => expect(container.querySelector('.ProseMirror')).not.toBeNull())
+            selectFile(container)
+            await vi.waitFor(() => expect(warn).toHaveBeenCalled())
+            expect(container.querySelector('img')).toBeNull()
+            warn.mockRestore()
+        })
+
+        it('inserts an image for a safe https src from onImageUpload', async () => {
+            const { container } = render(Editor, {
+                image: true,
+                onImageUpload: async () => 'https://example.com/a.png'
+            })
+            await vi.waitFor(() => expect(container.querySelector('.ProseMirror')).not.toBeNull())
+            selectFile(container)
+            await vi.waitFor(() => {
+                expect(container.querySelector('img')).not.toBeNull()
+            })
+        })
     })
 
     // ==================== PHASE 2: TABLES ====================

--- a/src/lib/Editor/Editor.svelte.spec.ts
+++ b/src/lib/Editor/Editor.svelte.spec.ts
@@ -116,6 +116,28 @@ describe('Editor', () => {
                 expect(getProseMirror(container)?.textContent).toContain('From JSON')
             })
         })
+
+        it('applies an external value change after the editor has emitted (echo-dedup stays correct)', async () => {
+            let api: EditorApi | undefined
+            const screen = render(Editor, {
+                value: '<p>start</p>',
+                get api() {
+                    return api
+                },
+                set api(v: EditorApi | undefined) {
+                    api = v
+                }
+            })
+            await vi.waitFor(() => expect(api?.editor).not.toBeNull())
+            api!.insert(' edited')
+            await vi.waitFor(() => {
+                expect(getProseMirror(screen.container)?.textContent).toContain('edited')
+            })
+            await screen.rerender({ value: '<p>external</p>' })
+            await vi.waitFor(() => {
+                expect(getProseMirror(screen.container)?.textContent).toContain('external')
+            })
+        })
     })
 
     // ==================== EDITABILITY ====================

--- a/src/lib/Editor/Editor.svelte.spec.ts
+++ b/src/lib/Editor/Editor.svelte.spec.ts
@@ -138,6 +138,24 @@ describe('Editor', () => {
                 expect(getProseMirror(screen.container)?.textContent).toContain('external')
             })
         })
+
+        it('treats output as fixed at mount (changing the prop later has no effect)', async () => {
+            let api: EditorApi | undefined
+            const screen = render(Editor, {
+                output: 'html',
+                value: '<p>hi</p>',
+                get api() {
+                    return api
+                },
+                set api(v: EditorApi | undefined) {
+                    api = v
+                }
+            })
+            await vi.waitFor(() => expect(api?.editor).not.toBeNull())
+            expect(typeof api!.getValue()).toBe('string')
+            await screen.rerender({ output: 'json', value: '<p>hi</p>' })
+            expect(typeof api!.getValue()).toBe('string')
+        })
     })
 
     // ==================== EDITABILITY ====================
@@ -495,6 +513,20 @@ describe('Editor', () => {
             await vi.waitFor(() => {
                 expect(container.querySelector('img')).not.toBeNull()
             })
+        })
+
+        it('calls onImageUploadError when the upload rejects', async () => {
+            const onImageUploadError = vi.fn()
+            const { container } = render(Editor, {
+                image: true,
+                onImageUpload: async () => {
+                    throw new Error('upload failed')
+                },
+                onImageUploadError
+            })
+            await vi.waitFor(() => expect(container.querySelector('.ProseMirror')).not.toBeNull())
+            selectFile(container)
+            await vi.waitFor(() => expect(onImageUploadError).toHaveBeenCalled())
         })
     })
 

--- a/src/lib/Editor/Editor.svelte.spec.ts
+++ b/src/lib/Editor/Editor.svelte.spec.ts
@@ -457,7 +457,12 @@ describe('Editor', () => {
         it('clicking table button opens dimension picker', async () => {
             const { container } = render(Editor, { tables: true, toolbar: ['table'] })
             await vi.waitFor(() => {
-                expect(container.querySelector('button[data-action="table"]')).not.toBeNull()
+                expect(container.querySelector('.ProseMirror')).not.toBeNull()
+                const btn = container.querySelector(
+                    'button[data-action="table"]'
+                ) as HTMLButtonElement | null
+                expect(btn).not.toBeNull()
+                expect(btn!.disabled).toBe(false)
             })
             const btn = container.querySelector('button[data-action="table"]') as HTMLButtonElement
             await btn.click()
@@ -469,7 +474,12 @@ describe('Editor', () => {
         it('clicking a dimension cell button inserts a table (UI flow)', async () => {
             const { container } = render(Editor, { tables: true, toolbar: ['table'] })
             await vi.waitFor(() => {
-                expect(container.querySelector('button[data-action="table"]')).not.toBeNull()
+                expect(container.querySelector('.ProseMirror')).not.toBeNull()
+                const btn = container.querySelector(
+                    'button[data-action="table"]'
+                ) as HTMLButtonElement | null
+                expect(btn).not.toBeNull()
+                expect(btn!.disabled).toBe(false)
             })
             const tableBtn = container.querySelector(
                 'button[data-action="table"]'
@@ -702,6 +712,31 @@ describe('Editor', () => {
             })
             await vi.waitFor(() => {
                 expect(getContent(container)?.className).toContain('custom-content-cls')
+            })
+        })
+    })
+
+    // ==================== LAZY EXTENSION LOADING ====================
+
+    describe('lazy extension loading', () => {
+        it('mounts synchronously when no lazy feature (markdown/tables) is enabled', () => {
+            const { container } = render(Editor, { toolbar: ['bold'] })
+            expect(container.querySelector('.ProseMirror')).not.toBeNull()
+        })
+
+        it('mounts asynchronously when tables are enabled (lazy chunk)', async () => {
+            const { container } = render(Editor, { tables: true })
+            expect(container.querySelector('.ProseMirror')).toBeNull()
+            await vi.waitFor(() => {
+                expect(container.querySelector('.ProseMirror')).not.toBeNull()
+            })
+        })
+
+        it('mounts asynchronously for markdown output (lazy chunk)', async () => {
+            const { container } = render(Editor, { output: 'markdown' })
+            expect(container.querySelector('.ProseMirror')).toBeNull()
+            await vi.waitFor(() => {
+                expect(container.querySelector('.ProseMirror')).not.toBeNull()
             })
         })
     })

--- a/src/lib/Editor/SlashPopup.svelte
+++ b/src/lib/Editor/SlashPopup.svelte
@@ -6,9 +6,11 @@
         items: SlashCommand[]
         selectedIndex: number
         onPick: (index: number) => void
+        listboxId: string
+        optionIdPrefix: string
     }
 
-    let { items, selectedIndex, onPick }: Props = $props()
+    let { items, selectedIndex, onPick, listboxId, optionIdPrefix }: Props = $props()
 
     let listEl: HTMLDivElement | null = $state(null)
 
@@ -24,7 +26,9 @@
 
 <div
     bind:this={listEl}
+    id={listboxId}
     role="listbox"
+    aria-label="Slash commands"
     data-editor-slash-popup
     class="max-h-72 max-w-80 min-w-64 overflow-y-auto rounded-lg border border-outline-variant bg-surface py-1 shadow-lg"
 >
@@ -35,6 +39,9 @@
             {@const active = i === selectedIndex}
             <button
                 type="button"
+                role="option"
+                id={`${optionIdPrefix}${i}`}
+                aria-selected={active}
                 data-slash-item
                 data-id={cmd.id}
                 data-index={i}

--- a/src/lib/Editor/editor.extensions.ts
+++ b/src/lib/Editor/editor.extensions.ts
@@ -6,11 +6,6 @@ import Typography from '@tiptap/extension-typography'
 import CharacterCount from '@tiptap/extension-character-count'
 import Image from '@tiptap/extension-image'
 import Mention from '@tiptap/extension-mention'
-import { Table } from '@tiptap/extension-table'
-import { TableRow } from '@tiptap/extension-table-row'
-import { TableCell } from '@tiptap/extension-table-cell'
-import { TableHeader } from '@tiptap/extension-table-header'
-import { Markdown } from 'tiptap-markdown'
 import Youtube from '@tiptap/extension-youtube'
 import { DragHandle } from '@tiptap/extension-drag-handle'
 import type { SuggestionOptions } from '@tiptap/suggestion'
@@ -68,7 +63,13 @@ function buildImageExt(): AnyExtension {
     })
 }
 
-function buildTableExts(): AnyExtension[] {
+async function buildTableExts(): Promise<AnyExtension[]> {
+    const [{ Table }, { TableRow }, { TableCell }, { TableHeader }] = await Promise.all([
+        import('@tiptap/extension-table'),
+        import('@tiptap/extension-table-row'),
+        import('@tiptap/extension-table-cell'),
+        import('@tiptap/extension-table-header')
+    ])
     return [
         Table.configure({
             resizable: true,
@@ -80,7 +81,8 @@ function buildTableExts(): AnyExtension[] {
     ]
 }
 
-function buildMarkdownExt(allowHtml: boolean): AnyExtension {
+async function buildMarkdownExt(allowHtml: boolean): Promise<AnyExtension> {
+    const { Markdown } = await import('tiptap-markdown')
     return Markdown.configure({
         html: allowHtml,
         tightLists: true,
@@ -133,7 +135,8 @@ function buildDragHandleExt(): AnyExtension {
     })
 }
 
-type OptionalBuilder = (o: BuildExtensionsOptions) => AnyExtension | AnyExtension[] | null
+type OptionalBuilderResult = AnyExtension | AnyExtension[] | Promise<AnyExtension | AnyExtension[]>
+type OptionalBuilder = (o: BuildExtensionsOptions) => OptionalBuilderResult | null
 
 const OPTIONAL_BUILDERS: OptionalBuilder[] = [
     (o) => (o.placeholder ? Placeholder.configure({ placeholder: o.placeholder }) : null),
@@ -150,17 +153,28 @@ const OPTIONAL_BUILDERS: OptionalBuilder[] = [
     (o) => (o.dragHandle ? buildDragHandleExt() : null)
 ]
 
-function collectOptionalExts(options: BuildExtensionsOptions): AnyExtension[] {
-    const acc: AnyExtension[] = []
+function collectOptionalExts(
+    options: BuildExtensionsOptions
+): AnyExtension[] | Promise<AnyExtension[]> {
+    const sync: AnyExtension[] = []
+    const lazy: Promise<AnyExtension | AnyExtension[]>[] = []
     for (const build of OPTIONAL_BUILDERS) {
         const result = build(options)
-        if (result === null) continue
-        if (Array.isArray(result)) acc.push(...result)
-        else acc.push(result)
+        if (result === null || result === undefined) continue
+        if (result instanceof Promise) lazy.push(result)
+        else if (Array.isArray(result)) sync.push(...result)
+        else sync.push(result)
     }
-    return acc
+    if (lazy.length === 0) return sync
+    return Promise.all(lazy).then((resolved) => [...sync, ...resolved.flat()])
 }
 
-export function buildExtensions(options: BuildExtensionsOptions = {}): AnyExtension[] {
-    return [...buildCore(options), ...collectOptionalExts(options), ...(options.extra ?? [])]
+export function buildExtensions(
+    options: BuildExtensionsOptions = {}
+): AnyExtension[] | Promise<AnyExtension[]> {
+    const optional = collectOptionalExts(options)
+    if (optional instanceof Promise) {
+        return optional.then((opt) => [...buildCore(options), ...opt, ...(options.extra ?? [])])
+    }
+    return [...buildCore(options), ...optional, ...(options.extra ?? [])]
 }

--- a/src/lib/Editor/editor.extensions.ts
+++ b/src/lib/Editor/editor.extensions.ts
@@ -112,8 +112,6 @@ function buildYoutubeExt(): AnyExtension {
     })
 }
 
-// lucide:grip-vertical inline SVG. Used directly because @iconify/svelte
-// component would need to be mounted via Svelte; this is a vanilla DOM helper.
 const GRIP_VERTICAL_SVG =
     '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="9" cy="5" r="1"/><circle cx="9" cy="12" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="19" r="1"/></svg>'
 

--- a/src/lib/Editor/editor.schemas.spec.ts
+++ b/src/lib/Editor/editor.schemas.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { isSafeImageSrc } from './editor.schemas.js'
+
+describe('isSafeImageSrc', () => {
+    it('allows http(s) and relative/protocol-relative urls', () => {
+        expect(isSafeImageSrc('https://example.com/a.png')).toBe(true)
+        expect(isSafeImageSrc('http://example.com/a.png')).toBe(true)
+        expect(isSafeImageSrc('/uploads/a.png')).toBe(true)
+        expect(isSafeImageSrc('./a.png')).toBe(true)
+        expect(isSafeImageSrc('../a.png')).toBe(true)
+        expect(isSafeImageSrc('a.png')).toBe(true)
+        expect(isSafeImageSrc('//cdn.example.com/a.png')).toBe(true)
+    })
+
+    it('allows raster data:image URIs', () => {
+        expect(isSafeImageSrc('data:image/png;base64,iVBORw0KGgo=')).toBe(true)
+        expect(isSafeImageSrc('data:image/jpeg;base64,/9j/4AAQ')).toBe(true)
+        expect(isSafeImageSrc('data:image/gif;base64,R0lGOD')).toBe(true)
+        expect(isSafeImageSrc('data:image/webp;base64,UklGR')).toBe(true)
+    })
+
+    it('blocks dangerous schemes (case/space-insensitive)', () => {
+        expect(isSafeImageSrc('javascript:alert(1)')).toBe(false)
+        expect(isSafeImageSrc('  JavaScript:alert(1)')).toBe(false)
+        expect(isSafeImageSrc('vbscript:msgbox(1)')).toBe(false)
+        expect(isSafeImageSrc('file:///etc/passwd')).toBe(false)
+    })
+
+    it('blocks svg and non-image data: URIs', () => {
+        expect(isSafeImageSrc('data:image/svg+xml,<svg onload=alert(1)>')).toBe(false)
+        expect(isSafeImageSrc('data:image/svg+xml;base64,PHN2Zz4=')).toBe(false)
+        expect(isSafeImageSrc('data:text/html,<script>alert(1)</script>')).toBe(false)
+    })
+
+    it('rejects empty input', () => {
+        expect(isSafeImageSrc('')).toBe(false)
+        expect(isSafeImageSrc('   ')).toBe(false)
+    })
+
+    it('resists control-character and embedded-newline scheme bypasses', () => {
+        const ctrl = String.fromCharCode(1)
+        expect(isSafeImageSrc(ctrl + 'javascript:alert(1)')).toBe(false)
+        expect(isSafeImageSrc(ctrl + 'data:image/svg+xml,<svg onload=alert(1)>')).toBe(false)
+        expect(isSafeImageSrc('java\nscript:alert(1)')).toBe(false)
+        expect(isSafeImageSrc('\tvbscript:x')).toBe(false)
+        expect(isSafeImageSrc('  https://example.com/a.png  ')).toBe(true)
+    })
+})

--- a/src/lib/Editor/editor.schemas.ts
+++ b/src/lib/Editor/editor.schemas.ts
@@ -11,17 +11,6 @@ export const httpUrlSchema: UrlSchema = v.pipe(
     v.regex(/^https?:\/\//i, 'URL must start with http:// or https://')
 )
 
-/**
- * Whether a string is safe to use as an `<img src>`. Allows relative URLs,
- * `http`/`https`, and raster `data:image/*` URIs; blocks `javascript:`,
- * `vbscript:`, `data:text/*`, and `data:image/svg+xml` (SVG can execute script).
- *
- * The input is first normalized the way the WHATWG URL parser does — tab/CR/LF
- * are removed and leading/trailing control characters and spaces (code point
- * <= 0x20) are stripped — so prefixed/embedded-control bypasses (a leading
- * control byte before `javascript:`, or `java\nscript:`) cannot slip past the
- * scheme check.
- */
 function normalizeUrl(src: string): string {
     const s = src.replace(/[\t\n\r]/g, '')
     let start = 0

--- a/src/lib/Editor/editor.schemas.ts
+++ b/src/lib/Editor/editor.schemas.ts
@@ -11,6 +11,40 @@ export const httpUrlSchema: UrlSchema = v.pipe(
     v.regex(/^https?:\/\//i, 'URL must start with http:// or https://')
 )
 
+/**
+ * Whether a string is safe to use as an `<img src>`. Allows relative URLs,
+ * `http`/`https`, and raster `data:image/*` URIs; blocks `javascript:`,
+ * `vbscript:`, `data:text/*`, and `data:image/svg+xml` (SVG can execute script).
+ *
+ * The input is first normalized the way the WHATWG URL parser does — tab/CR/LF
+ * are removed and leading/trailing control characters and spaces (code point
+ * <= 0x20) are stripped — so prefixed/embedded-control bypasses (a leading
+ * control byte before `javascript:`, or `java\nscript:`) cannot slip past the
+ * scheme check.
+ */
+function normalizeUrl(src: string): string {
+    const s = src.replace(/[\t\n\r]/g, '')
+    let start = 0
+    let end = s.length
+    while (start < end && s.charCodeAt(start) <= 0x20) start++
+    while (end > start && s.charCodeAt(end - 1) <= 0x20) end--
+    return s.slice(start, end)
+}
+
+export function isSafeImageSrc(src: string): boolean {
+    const s = normalizeUrl(src)
+    if (!s) return false
+    const scheme = /^([a-z][a-z0-9+.-]*):/i.exec(s)?.[1]?.toLowerCase()
+    if (!scheme) return true
+    if (scheme === 'http' || scheme === 'https') return true
+    if (scheme === 'data') {
+        return /^data:image\/(?:png|jpe?g|gif|webp|avif|bmp|x-icon|vnd\.microsoft\.icon)[;,]/i.test(
+            s
+        )
+    }
+    return false
+}
+
 export const youtubeUrlSchema: UrlSchema = v.pipe(
     v.string(),
     v.trim(),

--- a/src/lib/Editor/editor.slash.svelte.ts
+++ b/src/lib/Editor/editor.slash.svelte.ts
@@ -20,11 +20,6 @@ interface SlashCommandsContext {
     image?: boolean
     tables?: boolean
     youtube?: boolean
-    /**
-     * Override for the URL prompt used by image/youtube commands. Pass an
-     * async function that resolves to a URL string, or `null`/empty string
-     * to cancel. When omitted, falls back to `window.prompt`.
-     */
     promptUrl?: (opts: UrlPromptOptions) => Promise<string | null>
 }
 
@@ -33,10 +28,6 @@ function defaultPromptUrl(opts: UrlPromptOptions): Promise<string | null> {
     return Promise.resolve(window.prompt(opts.title, opts.initialValue ?? opts.placeholder ?? ''))
 }
 
-/**
- * Returns the built-in slash command list, optionally including media
- * commands based on which features are enabled in the host Editor.
- */
 export function buildDefaultSlashCommands(ctx: SlashCommandsContext = {}): SlashCommand[] {
     const commands: SlashCommand[] = [
         {
@@ -170,11 +161,6 @@ export function buildDefaultSlashCommands(ctx: SlashCommandsContext = {}): Slash
 
     return commands
 }
-
-// ----------------------------------------------------------------------------
-// Suggestion popup — mounts the SlashPopup Svelte component imperatively
-// (Tiptap's Suggestion render API expects DOM-level lifecycle hooks).
-// ----------------------------------------------------------------------------
 
 type MountedComponent = ReturnType<typeof mount>
 
@@ -326,10 +312,6 @@ function buildSuggestionRender() {
     }
 }
 
-// ----------------------------------------------------------------------------
-// Tiptap extension
-// ----------------------------------------------------------------------------
-
 interface SlashExtensionOptions {
     suggestion: Partial<SuggestionOptions>
 }
@@ -369,8 +351,6 @@ export function buildSlashExtension(commands: SlashCommand[], trigger: string = 
             allowSpaces: false,
             items: ({ query }: { query: string }) => substringFilter(commands, query),
             render: buildSuggestionRender as unknown as SuggestionOptions['render'],
-            // Tiptap merges `suggestion` shallowly when an extension is .configure()'d,
-            // so the command default in addOptions gets overwritten. Include it here.
             command: ({ editor, range, props }) => {
                 editor.chain().focus().deleteRange(range).run()
                 ;(props as SlashCommand).run({ editor })

--- a/src/lib/Editor/editor.slash.svelte.ts
+++ b/src/lib/Editor/editor.slash.svelte.ts
@@ -178,11 +178,21 @@ export function buildDefaultSlashCommands(ctx: SlashCommandsContext = {}): Slash
 
 type MountedComponent = ReturnType<typeof mount>
 
+let slashSeq = 0
+
 interface PopupHandle {
     container: HTMLElement
     component: MountedComponent
-    state: { items: SlashCommand[]; selectedIndex: number; onPick: (i: number) => void }
+    state: {
+        items: SlashCommand[]
+        selectedIndex: number
+        onPick: (i: number) => void
+        listboxId: string
+        optionIdPrefix: string
+    }
     cleanup: (() => void) | null
+    editorDom: HTMLElement | null
+    stopActiveDescendant: (() => void) | null
 }
 
 function substringFilter(commands: SlashCommand[], query: string): SlashCommand[] {
@@ -209,6 +219,11 @@ function buildSuggestionRender() {
         }) => {
             if (typeof document === 'undefined') return
 
+            const seq = ++slashSeq
+            const listboxId = `sv5ui-slash-listbox-${seq}`
+            const optionIdPrefix = `sv5ui-slash-${seq}-`
+            const editorDom = props.editor.view.dom as HTMLElement
+
             const container = document.createElement('div')
             container.setAttribute('data-editor-slash-container', '')
             container.style.cssText = 'position:absolute;top:0;left:0;z-index:50;'
@@ -217,6 +232,8 @@ function buildSuggestionRender() {
             const state = $state({
                 items: props.items,
                 selectedIndex: 0,
+                listboxId,
+                optionIdPrefix,
                 onPick: (i: number) => {
                     const cmd = state.items[i]
                     if (!cmd) return
@@ -229,7 +246,30 @@ function buildSuggestionRender() {
                 props: state
             })
 
-            handle = { container, component, state, cleanup: null }
+            editorDom.setAttribute('aria-controls', listboxId)
+            editorDom.setAttribute('aria-expanded', 'true')
+
+            const stopActiveDescendant = $effect.root(() => {
+                $effect(() => {
+                    if (state.items.length > 0) {
+                        editorDom.setAttribute(
+                            'aria-activedescendant',
+                            `${optionIdPrefix}${state.selectedIndex}`
+                        )
+                    } else {
+                        editorDom.removeAttribute('aria-activedescendant')
+                    }
+                })
+            })
+
+            handle = {
+                container,
+                component,
+                state,
+                cleanup: null,
+                editorDom,
+                stopActiveDescendant
+            }
 
             const rect = props.clientRect?.()
             if (rect) {
@@ -273,6 +313,12 @@ function buildSuggestionRender() {
         onExit: () => {
             if (!handle) return
             handle.cleanup?.()
+            handle.stopActiveDescendant?.()
+            if (handle.editorDom) {
+                handle.editorDom.removeAttribute('aria-controls')
+                handle.editorDom.removeAttribute('aria-expanded')
+                handle.editorDom.removeAttribute('aria-activedescendant')
+            }
             unmount(handle.component)
             handle.container.remove()
             handle = null

--- a/src/lib/Editor/editor.suggestion.ts
+++ b/src/lib/Editor/editor.suggestion.ts
@@ -7,6 +7,8 @@ interface BuildMentionSuggestionOptions {
     onQuery: (query: string) => Promise<MentionItem[]>
 }
 
+let mentionSeq = 0
+
 interface SuggestionRef {
     items: MentionItem[]
     selectedIndex: number
@@ -14,6 +16,9 @@ interface SuggestionRef {
     listEl: HTMLElement | null
     cleanup: (() => void) | null
     pickItem: (index: number) => void
+    editorDom: HTMLElement | null
+    listboxId: string
+    optionIdPrefix: string
 }
 
 function createPopup(): HTMLElement {
@@ -42,6 +47,9 @@ function renderItems(state: SuggestionRef): void {
         row.type = 'button'
         row.setAttribute('data-mention-item', '')
         row.setAttribute('data-index', String(i))
+        row.setAttribute('role', 'option')
+        row.id = `${state.optionIdPrefix}${i}`
+        row.setAttribute('aria-selected', i === state.selectedIndex ? 'true' : 'false')
         row.className = [
             'flex w-full items-center gap-2 px-3 py-1.5 text-sm text-start',
             'hover:bg-surface-container-high',
@@ -69,6 +77,13 @@ function renderItems(state: SuggestionRef): void {
         })
         state.listEl?.appendChild(row)
     })
+
+    if (state.editorDom && state.items.length > 0) {
+        state.editorDom.setAttribute(
+            'aria-activedescendant',
+            `${state.optionIdPrefix}${state.selectedIndex}`
+        )
+    }
 }
 
 export function buildMentionSuggestion(
@@ -89,11 +104,21 @@ export function buildMentionSuggestion(
                 onStart: (props: SuggestionProps) => {
                     if (typeof document === 'undefined') return
 
+                    const seq = ++mentionSeq
+                    const listboxId = `sv5ui-mention-listbox-${seq}`
+                    const optionIdPrefix = `sv5ui-mention-${seq}-`
+                    const editorDom = props.editor.view.dom as HTMLElement
+
                     const popupEl = createPopup()
                     const listEl = document.createElement('div')
                     listEl.setAttribute('role', 'listbox')
+                    listEl.id = listboxId
+                    listEl.setAttribute('aria-label', 'Mentions')
                     popupEl.appendChild(listEl)
                     document.body.appendChild(popupEl)
+
+                    editorDom.setAttribute('aria-controls', listboxId)
+                    editorDom.setAttribute('aria-expanded', 'true')
 
                     state = {
                         items: props.items as MentionItem[],
@@ -101,6 +126,9 @@ export function buildMentionSuggestion(
                         popupEl,
                         listEl,
                         cleanup: null,
+                        editorDom,
+                        listboxId,
+                        optionIdPrefix,
                         pickItem: (i: number) => {
                             const it = state?.items[i]
                             if (!it) return
@@ -160,6 +188,11 @@ export function buildMentionSuggestion(
                 onExit: () => {
                     state?.cleanup?.()
                     state?.popupEl?.remove()
+                    if (state?.editorDom) {
+                        state.editorDom.removeAttribute('aria-controls')
+                        state.editorDom.removeAttribute('aria-expanded')
+                        state.editorDom.removeAttribute('aria-activedescendant')
+                    }
                     state = null
                 }
             }

--- a/src/lib/Editor/editor.toolbar.ts
+++ b/src/lib/Editor/editor.toolbar.ts
@@ -9,14 +9,6 @@ export interface ToolbarActionDef {
     run: (editor: Editor) => void
 }
 
-// ---------------------------------------------------------------------------
-// Fallback `run` handlers below (link/image/youtube) use window.prompt because
-// they need to gather a URL. Editor.svelte intercepts these actions and routes
-// them through the EditorUrlPrompt modal instead. The fallbacks only execute
-// when a consumer calls `api.run('link'|'image'|'youtube')` directly — at
-// which point we have no modal mount point, so window.prompt is the simplest
-// non-UI fallback.
-// ---------------------------------------------------------------------------
 function promptForLink(editor: Editor): void {
     const previous = (editor.getAttributes('link').href as string | undefined) ?? 'https://'
     const url = typeof window === 'undefined' ? null : window.prompt('URL', previous)

--- a/src/lib/Editor/editor.types.ts
+++ b/src/lib/Editor/editor.types.ts
@@ -272,6 +272,10 @@ export interface EditorProps extends Omit<
 
     /**
      * Serialization format used for `value` and `onValueChange`.
+     *
+     * Read once when the editor mounts (it also decides whether the Markdown
+     * extension is loaded). Changing it on an existing editor has no effect —
+     * re-key the component (e.g. `{#key output}`) to switch formats.
      * @default 'html'
      */
     output?: EditorOutput
@@ -368,6 +372,12 @@ export interface EditorProps extends Omit<
      * inserted and a warning is logged).
      */
     onImageUpload?: (file: File) => Promise<string>
+
+    /**
+     * Called when `onImageUpload` rejects. When omitted, the error is logged to
+     * the console. Use this to surface upload failures to the user.
+     */
+    onImageUploadError?: (error: unknown) => void
 
     // ------------------------------------------------------------------------
     // Tables (Phase 2)

--- a/src/lib/Editor/editor.types.ts
+++ b/src/lib/Editor/editor.types.ts
@@ -261,6 +261,12 @@ export interface EditorProps extends Omit<
      * Bindable content. The runtime type depends on `output`:
      * - `output: 'html'` (default) → `string` of HTML
      * - `output: 'json'` → `EditorJSON` document
+     *
+     * Security: the serialized value is structurally validated by the editor
+     * schema (unknown tags, attributes, and event handlers are dropped), but it
+     * is NOT sanitizer-clean. It can still contain arbitrary image `src` values
+     * (including `data:` URIs from pasted content). Sanitize the HTML output
+     * (e.g. with DOMPurify) before rendering it as raw markup elsewhere.
      */
     value?: string | EditorJSON
 
@@ -355,6 +361,11 @@ export interface EditorProps extends Omit<
      * must return the resolved URL to insert as `<img src=...>`. When
      * omitted and `image` is `true`, images can only be inserted via URL
      * prompt (toolbar).
+     *
+     * The returned URL is validated before insertion: relative URLs,
+     * `http(s)`, and raster `data:image/*` URIs are allowed; `javascript:`,
+     * `data:text/*`, and `data:image/svg+xml` are rejected (the image is not
+     * inserted and a warning is logged).
      */
     onImageUpload?: (file: File) => Promise<string>
 

--- a/src/lib/Editor/editor.variants.ts
+++ b/src/lib/Editor/editor.variants.ts
@@ -14,7 +14,6 @@ export const editorVariants = tv({
             'bg-surface-container-low',
             'rounded-t-lg p-1.5'
         ],
-        toolbarGroup: 'flex items-center gap-0.5',
         toolbarButton: [
             'inline-flex items-center justify-center rounded text-on-surface-variant',
             'hover:bg-surface-container-high hover:text-on-surface',

--- a/src/lib/Editor/editor.variants.ts
+++ b/src/lib/Editor/editor.variants.ts
@@ -25,7 +25,6 @@ export const editorVariants = tv({
         toolbarSeparator: 'mx-1 h-5 w-px shrink-0 bg-outline-variant',
         content: [
             'text-on-surface',
-            // ----- Inner ProseMirror element (the actual contenteditable) -----
             '[&_.ProseMirror]:outline-none',
             '[&_.ProseMirror]:focus:outline-none',
             '[&_.ProseMirror]:focus-visible:outline-none',
@@ -33,13 +32,11 @@ export const editorVariants = tv({
             '[&_.ProseMirror]:min-h-32',
             '[&_.ProseMirror]:whitespace-pre-wrap',
             '[&_.ProseMirror]:break-words',
-            // ----- Placeholder (when editor is empty) -----
             '[&_.is-editor-empty]:before:content-[attr(data-placeholder)]',
             '[&_.is-editor-empty]:before:text-on-surface-variant/60',
             '[&_.is-editor-empty]:before:pointer-events-none',
             '[&_.is-editor-empty]:before:float-left',
             '[&_.is-editor-empty]:before:h-0',
-            // ----- Content typography (lightweight in-house prose) -----
             '[&_p]:my-2 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0',
             '[&_h1]:text-2xl [&_h1]:font-bold [&_h1]:my-3',
             '[&_h2]:text-xl [&_h2]:font-bold [&_h2]:my-3',
@@ -56,17 +53,13 @@ export const editorVariants = tv({
             '[&_hr]:border-outline-variant [&_hr]:my-4',
             '[&_strong]:font-semibold',
             '[&_em]:italic',
-            // ----- Image -----
             '[&_img]:max-w-full [&_img]:h-auto [&_img]:rounded-md [&_img]:my-2',
-            // ----- YouTube embed (responsive 16:9) -----
             '[&_iframe[src*="youtube"]]:aspect-video [&_iframe[src*="youtube"]]:w-full [&_iframe[src*="youtube"]]:rounded-md [&_iframe[src*="youtube"]]:my-3 [&_iframe[src*="youtube"]]:border-0',
-            // ----- Mention chip -----
             '[&_.sv5ui-editor-mention]:inline-flex [&_.sv5ui-editor-mention]:items-center',
             '[&_.sv5ui-editor-mention]:rounded [&_.sv5ui-editor-mention]:bg-primary-container/60',
             '[&_.sv5ui-editor-mention]:text-on-primary-container',
             '[&_.sv5ui-editor-mention]:px-1.5 [&_.sv5ui-editor-mention]:py-0.5',
             '[&_.sv5ui-editor-mention]:text-sm [&_.sv5ui-editor-mention]:font-medium',
-            // ----- Table -----
             '[&_.tableWrapper]:my-3 [&_.tableWrapper]:overflow-x-auto',
             '[&_table]:w-full [&_table]:border-collapse [&_table]:table-fixed',
             '[&_table]:border [&_table]:border-outline-variant [&_table]:rounded-md',
@@ -77,12 +70,10 @@ export const editorVariants = tv({
             '[&_td]:border [&_td]:border-outline-variant',
             '[&_td]:px-2 [&_td]:py-1.5 [&_td]:align-top',
             '[&_td]:relative [&_td]:min-w-16',
-            // Tiptap selectedCell highlight + column resize handle
             '[&_.selectedCell]:bg-primary/10',
             '[&_.column-resize-handle]:absolute [&_.column-resize-handle]:top-0 [&_.column-resize-handle]:bottom-[-2px]',
             '[&_.column-resize-handle]:-right-0.5 [&_.column-resize-handle]:w-1',
             '[&_.column-resize-handle]:bg-primary/40 [&_.column-resize-handle]:pointer-events-none',
-            // ----- Selection styling -----
             '[&_::selection]:bg-primary/20'
         ],
         footer: [
@@ -94,11 +85,6 @@ export const editorVariants = tv({
         ],
         countLabel: 'tabular-nums',
         bubbleMenu: [
-            // ⚠️ Tiptap's BubbleMenu only sets `visibility:hidden` initially,
-            // leaving the element in normal flow (taking up space below the editor)
-            // until the user first selects text. Setting `position:absolute` upfront
-            // keeps it out of flow from mount — extension's Floating UI positioning
-            // then overrides left/top inline on selection.
             'absolute top-0 left-0 z-50 invisible',
             'flex items-center gap-0.5 p-1',
             'rounded-lg border border-outline-variant bg-surface',

--- a/src/lib/Editor/index.ts
+++ b/src/lib/Editor/index.ts
@@ -29,10 +29,12 @@
  *
  * (`npm add` / `yarn add` work equally well.)
  *
- * All 18 packages are required, even if you only enable a subset of
- * features. Editor imports every extension at module load so toggling
- * `image`, `tables`, `youtube`, etc. via props doesn't trigger a dynamic
- * import. Missing peers fail at runtime with module-resolution errors.
+ * All 18 packages must be installed even if you only enable a subset of
+ * features — missing peers fail at runtime with module-resolution errors.
+ * Most extensions are imported eagerly, but the heaviest optional ones load
+ * on demand: `tiptap-markdown` (only with `output="markdown"`) and the table
+ * packages (only with `tables`) are pulled in via dynamic `import()`, so your
+ * bundler code-splits them out of the base editor chunk when unused.
  *
  * ## Usage
  *


### PR DESCRIPTION
## Summary

Full Editor review — performance, security, accessibility, and cleanup. Each finding was verified (probes + adversarial/regression tests) before fixing.

Closes #91

## Changes (7 commits)

- **perf/bundle** — `tiptap-markdown` (only `output="markdown"`) and the table packages (only `tables`) are lazy-loaded via dynamic `import()`, code-split out of the base chunk (~80 KB + ~25 KB gzip saved when unused). Hybrid: editors that enable neither still mount **synchronously** (no behavior change); only markdown/tables editors init asynchronously.
- **perf** — Halved per-keystroke serialization by short-circuiting the value-sync effect on the editor's own echo (string outputs).
- **security** — Validate image `src` from `onImageUpload` (`isSafeImageSrc`): allows relative/`http(s)`/raster `data:image/*`; blocks `javascript:`/`data:text`/`data:image/svg+xml`. WHATWG-normalized to resist control-char/embedded-newline scheme bypasses. Documented that HTML output must be sanitized downstream.
- **a11y** — Mention and slash popups are now proper ARIA listboxes (`role=option` + `aria-selected` + ids); the editor exposes `aria-controls`/`aria-expanded`/`aria-activedescendant` (cleared on close).
- **bug** — `output` is read once at mount (changing it on a live editor no longer corrupts content; documented). Added `onImageUploadError`. Removed dead `toolbarGroup` ui slot. Deduplicated the markdown-storage cast.
- **chore/docs** — Removed prose implementation comments (kept eslint-disable directives); corrected a stale `index.ts` install note about dynamic imports.

## Checklist

- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm lint`
- [x] `pnpm test` — full suite 2450/2450 (new regression, security-bypass, and a11y tests)
- [x] CHANGELOG updated (Added / Changed / Removed / Fixed / Security)
- [x] dist verified: `editor.extensions.js` uses dynamic `import()` for markdown/tables

## Deferred (tracked in #91)
P3 (syncState cost), B2 (caret reset on external value — by-design), B3 (bubble-menu timing), A3 (textbox aria nesting), S3 (mention avatar src), T2 (`Record<unknown>` public types).