### PR TITLE
fix(calendar): initialize placeholder so year navigation works on first render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Calendar** — The Previous/Next year navigation buttons did nothing on initial render. They advanced an internal `placeholder` that stayed `undefined` until the first month navigation, so the first year click was a no-op. The placeholder is now initialized (from `value` when provided, otherwise today) so year navigation works immediately.
+
 ## [2.0.0] - 2026-06-01
 
 ### Added

--- a/src/lib/Calendar/Calendar.svelte
+++ b/src/lib/Calendar/Calendar.svelte
@@ -14,7 +14,7 @@
     import { calendarVariants, calendarDefaults } from './calendar.variants.js'
     import { getComponentConfig } from '../config.js'
     import Icon from '../Icon/Icon.svelte'
-    import type { DateValue } from '@internationalized/date'
+    import { type DateValue, today, getLocalTimeZone } from '@internationalized/date'
     import type { Month } from 'bits-ui'
     import { useFormField, useFormFieldEmit } from '../hooks/useFormField.svelte.js'
 
@@ -62,6 +62,19 @@
         weekDay: weekDaySlot,
         ...restProps
     }: Props = $props()
+
+    function firstDateOf(val: unknown): DateValue | undefined {
+        if (!val) return undefined
+        if (Array.isArray(val)) return val[0] as DateValue | undefined
+        if (typeof val === 'object' && 'start' in val) {
+            return (val as { start?: DateValue }).start
+        }
+        return val as DateValue
+    }
+
+    if (placeholder === undefined) {
+        placeholder = firstDateOf(value) ?? today(getLocalTimeZone())
+    }
 
     const formFieldContext = useFormField()
     const emit = useFormFieldEmit()

--- a/src/lib/Calendar/Calendar.svelte.spec.ts
+++ b/src/lib/Calendar/Calendar.svelte.spec.ts
@@ -222,6 +222,66 @@ describe('Calendar', () => {
                 expect(buttons.length).toBeGreaterThanOrEqual(4)
             })
         })
+
+        it('should advance the year when Next year is clicked (no placeholder provided)', async () => {
+            render(Calendar)
+            await vi.waitFor(() => expect(getHeading()).not.toBeNull())
+            const before = getHeading()!.textContent ?? ''
+            const yearBefore = Number(before.match(/\d{4}/)?.[0])
+            const nextYear = document.querySelector('[aria-label="Next year"]') as HTMLButtonElement
+            expect(nextYear).not.toBeNull()
+            nextYear.click()
+            await vi.waitFor(() => {
+                const yearAfter = Number((getHeading()!.textContent ?? '').match(/\d{4}/)?.[0])
+                expect(yearAfter).toBe(yearBefore + 1)
+            })
+        })
+
+        it('should go back a year when Previous year is clicked (no placeholder provided)', async () => {
+            render(Calendar)
+            await vi.waitFor(() => expect(getHeading()).not.toBeNull())
+            const yearBefore = Number((getHeading()!.textContent ?? '').match(/\d{4}/)?.[0])
+            const prevYear = document.querySelector(
+                '[aria-label="Previous year"]'
+            ) as HTMLButtonElement
+            expect(prevYear).not.toBeNull()
+            prevYear.click()
+            await vi.waitFor(() => {
+                const yearAfter = Number((getHeading()!.textContent ?? '').match(/\d{4}/)?.[0])
+                expect(yearAfter).toBe(yearBefore - 1)
+            })
+        })
+
+        it('should open on the value month when a value is provided without a placeholder', async () => {
+            render(Calendar, { value: new CalendarDate(2020, 1, 15) })
+            await vi.waitFor(() => {
+                const heading = getHeading()
+                expect(heading).not.toBeNull()
+                expect(heading!.textContent).toContain('January')
+                expect(heading!.textContent).toContain('2020')
+            })
+        })
+
+        it('should still navigate months when no placeholder is provided', async () => {
+            render(Calendar)
+            await vi.waitFor(() => expect(getHeading()).not.toBeNull())
+            const before = getHeading()!.textContent ?? ''
+            getNextButton()!.click()
+            await vi.waitFor(() => {
+                expect((getHeading()!.textContent ?? '') !== before).toBe(true)
+            })
+        })
+
+        it('should move to the value month when value is set after mount', async () => {
+            const screen = render(Calendar, {})
+            await vi.waitFor(() => expect(getHeading()).not.toBeNull())
+            await screen.rerender({ value: new CalendarDate(2019, 7, 4) })
+            await vi.waitFor(() => {
+                const heading = getHeading()!
+                expect(heading.textContent).toContain('July')
+                expect(heading.textContent).toContain('2019')
+            })
+        })
     })
 
     // ==================== DISABLED STATE ====================


### PR DESCRIPTION
## Summary

The Previous/Next year buttons did nothing on the first click when no `placeholder` was provided (the common default). They mutated a `placeholder` that stayed `undefined` until the first month navigation, so the first year click was a no-op.

Closes #90

## Changes

- **Calendar** — `placeholder` is now seeded at init when undefined: from `value` (single/range/multiple) if present, otherwise `today(getLocalTimeZone())` — matching what bits-ui already displays, so there's no visual change on load. Year navigation works immediately.
- Added regression tests: Next/Previous year change the heading year without a `placeholder`; month navigation still works without a `placeholder`; opening on a `value`'s month; following a `value` set after mount.

## Evidence (prove-before-fix)
Before: render with no `placeholder` → heading `"June 2026"` → click Next year → still `"June 2026"`. After: → `"June 2027"`.

## Checklist

- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm lint`
- [x] `pnpm test` — Calendar 63/63 (incl. 6 new tests)
- [x] CHANGELOG updated (Fixed)