### PR TITLE
fix(modal,slideover,drawer): render trigger via child snippet to avoid nested button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Modal / Slideover / Drawer** — **BREAKING.** The trigger is no longer wrapped in an extra `<button>`. Previously the `children` snippet was rendered inside the component's own trigger button, so passing a `<Button>`/`<Link>` produced an invalid nested `<button>` inside `<button>` (an SSR `node_invalid_placement_ssr` hydration error that can escalate to a hard `The deferred DOM Node could not be resolved` failure). The `children` snippet now receives a `props` argument that you must spread onto your own focusable element, so the trigger ARIA and event handlers land on the real control. Migration:
+
+    ```svelte
+    <!-- Before -->
+    <Modal title="…">
+        <Button>Open</Button>
+    </Modal>
+
+    <!-- After -->
+    <Modal title="…">
+        {#snippet children({ props })}
+            <Button {...props}>Open</Button>
+        {/snippet}
+    </Modal>
+    ```
+
 ## [2.0.0] - 2026-06-01
 
 ### Added

--- a/src/lib/Drawer/Drawer.svelte
+++ b/src/lib/Drawer/Drawer.svelte
@@ -177,8 +177,10 @@
 
 {#snippet drawerBody()}
     {#if children}
-        <Drawer.Trigger class={className as string}>
-            {@render children()}
+        <Drawer.Trigger>
+            {#snippet child({ props })}
+                {@render children({ props })}
+            {/snippet}
         </Drawer.Trigger>
     {/if}
 

--- a/src/lib/Drawer/Drawer.svelte.spec.ts
+++ b/src/lib/Drawer/Drawer.svelte.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-svelte'
 import { page } from 'vitest/browser'
 import Drawer from './Drawer.svelte'
+import DrawerTriggerTestWrapper from './DrawerTriggerTestWrapper.svelte'
 
 describe('Drawer', () => {
     // Helper: query inside the portal (document.body) since Drawer portals its content
@@ -725,6 +726,21 @@ describe('Drawer', () => {
             } finally {
                 el.remove()
             }
+        })
+    })
+
+    describe('trigger', () => {
+        it('forwards trigger props to the caller element without nesting a button', async () => {
+            const { container } = render(DrawerTriggerTestWrapper)
+            const btn = container.querySelector('[data-testid="trigger"]') as HTMLButtonElement
+            expect(btn).not.toBeNull()
+            expect(btn.tagName).toBe('BUTTON')
+            expect(btn.querySelector('button')).toBeNull()
+            expect(btn.getAttribute('data-state')).toBe('closed')
+            btn.click()
+            await vi.waitFor(() => {
+                expect(btn.getAttribute('data-state')).toBe('open')
+            })
         })
     })
 })

--- a/src/lib/Drawer/DrawerTriggerTestWrapper.svelte
+++ b/src/lib/Drawer/DrawerTriggerTestWrapper.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+    import Drawer from './Drawer.svelte'
+</script>
+
+<Drawer>
+    {#snippet children({ props })}
+        <button data-testid="trigger" {...props}>Open</button>
+    {/snippet}
+    {#snippet content()}<p>Body</p>{/snippet}
+</Drawer>

--- a/src/lib/Drawer/drawer.types.ts
+++ b/src/lib/Drawer/drawer.types.ts
@@ -86,9 +86,18 @@ export type DrawerProps = VaulRootProps & {
     class?: ClassNameValue
 
     /**
-     * Default slot renders the trigger element.
+     * Trigger content. Spread the provided `props` onto your own focusable
+     * element (e.g. a `<Button>`) so the drawer's trigger ARIA and event
+     * handlers land on the real control instead of a nested wrapper button.
+     *
+     * @example
+     * ```svelte
+     * {#snippet children({ props })}
+     *   <Button {...props}>Open</Button>
+     * {/snippet}
+     * ```
      */
-    children?: Snippet
+    children?: Snippet<[{ props: Record<string, unknown> }]>
 
     /**
      * Custom content slot (replaces default layout with header/body/footer).

--- a/src/lib/Modal/Modal.svelte
+++ b/src/lib/Modal/Modal.svelte
@@ -203,8 +203,10 @@
 
 <Dialog.Root bind:open onOpenChange={handleOpenChange} {onOpenChangeComplete}>
     {#if children}
-        <Dialog.Trigger class={className as string}>
-            {@render children()}
+        <Dialog.Trigger>
+            {#snippet child({ props })}
+                {@render children({ props })}
+            {/snippet}
         </Dialog.Trigger>
     {/if}
 

--- a/src/lib/Modal/Modal.svelte.spec.ts
+++ b/src/lib/Modal/Modal.svelte.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-svelte'
 import { page } from 'vitest/browser'
 import Modal from './Modal.svelte'
+import ModalTriggerTestWrapper from './ModalTriggerTestWrapper.svelte'
 
 describe('Modal', () => {
     const getOverlay = () => document.querySelector('[data-dialog-overlay]') as HTMLElement | null
@@ -544,6 +545,21 @@ describe('Modal', () => {
             await vi.waitFor(() => {
                 const content = getContent()
                 expect(content!.className).toMatch(/scale-in/)
+            })
+        })
+    })
+
+    describe('trigger', () => {
+        it('forwards trigger props to the caller element without nesting a button', async () => {
+            const { container } = render(ModalTriggerTestWrapper)
+            const btn = container.querySelector('[data-testid="trigger"]') as HTMLButtonElement
+            expect(btn).not.toBeNull()
+            expect(btn.tagName).toBe('BUTTON')
+            expect(btn.querySelector('button')).toBeNull()
+            expect(btn.getAttribute('data-state')).toBe('closed')
+            btn.click()
+            await vi.waitFor(() => {
+                expect(btn.getAttribute('data-state')).toBe('open')
             })
         })
     })

--- a/src/lib/Modal/ModalTriggerTestWrapper.svelte
+++ b/src/lib/Modal/ModalTriggerTestWrapper.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+    import Modal from './Modal.svelte'
+</script>
+
+<Modal title="Trigger test" description="D">
+    {#snippet children({ props })}
+        <button data-testid="trigger" {...props}>Open</button>
+    {/snippet}
+    {#snippet body()}<p>Body</p>{/snippet}
+</Modal>

--- a/src/lib/Modal/modal.types.ts
+++ b/src/lib/Modal/modal.types.ts
@@ -137,10 +137,18 @@ export interface ModalProps extends RootProps, ContentProps {
     // --- Slots ---
 
     /**
-     * Default slot content used as the trigger element.
-     * When provided, clicking this element opens the modal.
+     * Trigger content. Spread the provided `props` onto your own focusable
+     * element (e.g. a `<Button>`) so the dialog's trigger ARIA and event
+     * handlers land on the real control instead of a nested wrapper button.
+     *
+     * @example
+     * ```svelte
+     * {#snippet children({ props })}
+     *   <Button {...props}>Open</Button>
+     * {/snippet}
+     * ```
      */
-    children?: Snippet
+    children?: Snippet<[{ props: Record<string, unknown> }]>
 
     /**
      * Custom content slot that replaces the entire default layout

--- a/src/lib/Slideover/Slideover.svelte
+++ b/src/lib/Slideover/Slideover.svelte
@@ -197,8 +197,10 @@
 
 <Dialog.Root bind:open onOpenChange={handleOpenChange} {onOpenChangeComplete}>
     {#if children}
-        <Dialog.Trigger class={className as string}>
-            {@render children()}
+        <Dialog.Trigger>
+            {#snippet child({ props })}
+                {@render children({ props })}
+            {/snippet}
         </Dialog.Trigger>
     {/if}
 

--- a/src/lib/Slideover/Slideover.svelte.spec.ts
+++ b/src/lib/Slideover/Slideover.svelte.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-svelte'
 import { page } from 'vitest/browser'
 import Slideover from './Slideover.svelte'
+import SlideoverTriggerTestWrapper from './SlideoverTriggerTestWrapper.svelte'
 
 describe('Slideover', () => {
     const getOverlay = () => document.querySelector('[data-dialog-overlay]') as HTMLElement | null
@@ -613,6 +614,21 @@ describe('Slideover', () => {
             await vi.waitFor(() => {
                 const content = getContent()
                 expect(content!.className).toMatch(/slide-in-full-left/)
+            })
+        })
+    })
+
+    describe('trigger', () => {
+        it('forwards trigger props to the caller element without nesting a button', async () => {
+            const { container } = render(SlideoverTriggerTestWrapper)
+            const btn = container.querySelector('[data-testid="trigger"]') as HTMLButtonElement
+            expect(btn).not.toBeNull()
+            expect(btn.tagName).toBe('BUTTON')
+            expect(btn.querySelector('button')).toBeNull()
+            expect(btn.getAttribute('data-state')).toBe('closed')
+            btn.click()
+            await vi.waitFor(() => {
+                expect(btn.getAttribute('data-state')).toBe('open')
             })
         })
     })

--- a/src/lib/Slideover/SlideoverTriggerTestWrapper.svelte
+++ b/src/lib/Slideover/SlideoverTriggerTestWrapper.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+    import Slideover from './Slideover.svelte'
+</script>
+
+<Slideover title="Trigger test" description="D">
+    {#snippet children({ props })}
+        <button data-testid="trigger" {...props}>Open</button>
+    {/snippet}
+    {#snippet body()}<p>Body</p>{/snippet}
+</Slideover>

--- a/src/lib/Slideover/slideover.types.ts
+++ b/src/lib/Slideover/slideover.types.ts
@@ -136,10 +136,18 @@ export interface SlideoverProps extends RootProps, ContentProps {
     // --- Slots ---
 
     /**
-     * Default slot content used as the trigger element.
-     * When provided, clicking this element opens the slideover.
+     * Trigger content. Spread the provided `props` onto your own focusable
+     * element (e.g. a `<Button>`) so the dialog's trigger ARIA and event
+     * handlers land on the real control instead of a nested wrapper button.
+     *
+     * @example
+     * ```svelte
+     * {#snippet children({ props })}
+     *   <Button {...props}>Open</Button>
+     * {/snippet}
+     * ```
      */
-    children?: Snippet
+    children?: Snippet<[{ props: Record<string, unknown> }]>
 
     /**
      * Custom content slot that replaces the entire default layout

--- a/src/routes/drawer/+page.svelte
+++ b/src/routes/drawer/+page.svelte
@@ -61,7 +61,9 @@
                 title="Basic Drawer"
                 description="This is a basic drawer with title, description, body and footer."
             >
-                <Button variant="outline" label="Open Drawer" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open Drawer" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Slides up from the bottom by default. Swipe down or click the overlay to
@@ -86,7 +88,13 @@
                     title="{dir.charAt(0).toUpperCase() + dir.slice(1)} Drawer"
                     description="Opens from the {dir}."
                 >
-                    <Button variant="outline" label={dir.charAt(0).toUpperCase() + dir.slice(1)} />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            label={dir.charAt(0).toUpperCase() + dir.slice(1)}
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <p class="text-on-surface-variant">
                             Drawer from the <strong>{dir}</strong>. Swipe towards the edge to
@@ -120,11 +128,14 @@
                     title="Inset {dir.charAt(0).toUpperCase() + dir.slice(1)}"
                     description="Inset + {dir} direction."
                 >
-                    <Button
-                        variant="soft"
-                        size="sm"
-                        label="Inset {dir.charAt(0).toUpperCase() + dir.slice(1)}"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="soft"
+                            size="sm"
+                            label="Inset {dir.charAt(0).toUpperCase() + dir.slice(1)}"
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <p class="text-on-surface-variant">
                             Inset mode combined with <strong>{dir}</strong> direction.
@@ -152,7 +163,9 @@
                 title="No Handle"
                 description="Handle is hidden."
             >
-                <Button variant="outline" label="No Handle" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="No Handle" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">No drag handle visible. Still swipeable.</p>
                 {/snippet}
@@ -171,7 +184,9 @@
                 title="Handle Only"
                 description="Only the handle can be dragged."
             >
-                <Button variant="outline" label="Handle Only" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Handle Only" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Content area is not draggable — only the handle responds to drag.
@@ -199,7 +214,9 @@
                 title="Non-Modal"
                 description="No overlay, background is interactive."
             >
-                <Button variant="outline" label="Non-Modal" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Non-Modal" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         No overlay. You can still interact with the page behind.
@@ -220,7 +237,9 @@
                 title="Scale Background"
                 description="Background scales down when opened."
             >
-                <Button variant="outline" label="Scale Background" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Scale Background" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         The page content behind scales down, creating a layered depth effect.
@@ -247,7 +266,9 @@
                 title="Non-Dismissible"
                 description="You must use the close button."
             >
-                <Button variant="outline" label="Open (Non-Dismissible)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open (Non-Dismissible)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Try swiping or clicking outside — the drawer will not close.
@@ -276,7 +297,9 @@
                 title="Snap Points"
                 description="Snaps at 25%, 50%, 100%."
             >
-                <Button variant="outline" label="3 Snap Points" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="3 Snap Points" />
+                {/snippet}
                 {#snippet body()}
                     <div class="space-y-2">
                         <p class="text-on-surface-variant">
@@ -299,7 +322,9 @@
                 title="Controlled Snap"
                 description="Active: {activeSnap}"
             >
-                <Button variant="outline" label="Controlled Snap" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Controlled Snap" />
+                {/snippet}
                 {#snippet body()}
                     <div class="space-y-3">
                         <p class="text-on-surface-variant">
@@ -340,7 +365,9 @@
                 title="Outer Drawer"
                 description="This is the parent drawer."
             >
-                <Button variant="outline" label="Open Nested" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open Nested" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Click below to open a child drawer on top of this one.
@@ -352,7 +379,14 @@
                             title="Inner Drawer"
                             description="Nested child drawer."
                         >
-                            <Button variant="solid" color="primary" label="Open Inner Drawer" />
+                            {#snippet children({ props })}
+                                <Button
+                                    {...props}
+                                    variant="solid"
+                                    color="primary"
+                                    label="Open Inner Drawer"
+                                />
+                            {/snippet}
                             {#snippet body()}
                                 <p class="text-on-surface-variant">
                                     This is the nested drawer. Closing it returns to the outer
@@ -386,7 +420,9 @@
         <div class="flex flex-wrap gap-3 rounded-lg bg-surface-container-high p-4">
             <!-- Custom header -->
             <Drawer bind:open={slotsOpen}>
-                <Button variant="outline" label="Custom Header" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Custom Header" />
+                {/snippet}
                 {#snippet header()}
                     <div class="flex items-center gap-3">
                         <div
@@ -426,7 +462,9 @@
 
             <!-- Full content slot -->
             <Drawer bind:open={customContentOpen} title="Custom Content">
-                <Button variant="outline" label="Content Slot" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Content Slot" />
+                {/snippet}
                 {#snippet content()}
                     <div class="flex flex-col items-center gap-4 p-6">
                         <div
@@ -472,7 +510,9 @@
                 title="Callback Demo"
                 description="Check the log above."
             >
-                <Button variant="outline" label="Open (With Callbacks)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open (With Callbacks)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Open, close, and watch the callback log update.
@@ -535,7 +575,9 @@
                     container: 'gap-3'
                 }}
             >
-                <Button variant="outline" label="Open Styled Drawer" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open Styled Drawer" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-primary-container/80">
                         This drawer overrides content, title, description, handle, and container
@@ -563,12 +605,15 @@
             <div class="rounded-lg bg-surface-container-high p-4">
                 <p class="mb-3 text-sm font-medium">Mobile Settings Panel</p>
                 <Drawer bind:open={settingsOpen} title="Settings">
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:settings"
-                        label="Settings"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:settings"
+                            label="Settings"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <div class="space-y-4">
                             {#each [{ icon: 'lucide:user', label: 'Account', desc: 'Manage your profile' }, { icon: 'lucide:bell', label: 'Notifications', desc: 'Push, email, SMS' }, { icon: 'lucide:shield', label: 'Privacy', desc: 'Data and permissions' }, { icon: 'lucide:palette', label: 'Appearance', desc: 'Theme and display' }, { icon: 'lucide:globe', label: 'Language', desc: 'English (US)' }] as item (item.label)}
@@ -616,12 +661,15 @@
             <div class="rounded-lg bg-surface-container-high p-4">
                 <p class="mb-3 text-sm font-medium">Notifications Drawer</p>
                 <Drawer bind:open={notificationsOpen} direction="right">
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:bell"
-                        label="Notifications"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:bell"
+                            label="Notifications"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet header()}
                         <div class="flex items-center justify-between">
                             <h3 class="text-lg font-semibold text-on-surface">Notifications</h3>
@@ -674,12 +722,15 @@
                     title="Filters"
                     description="Refine your search results."
                 >
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:filter"
-                        label="Filters"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:filter"
+                            label="Filters"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <div class="space-y-4">
                             <div>
@@ -735,13 +786,16 @@
             <div class="rounded-lg bg-surface-container-high p-4">
                 <p class="mb-3 text-sm font-medium">Confirmation (Non-Dismissible)</p>
                 <Drawer bind:open={confirmOpen} dismissible={false} handle={false}>
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:trash-2"
-                        label="Delete Account"
-                        color="error"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:trash-2"
+                            label="Delete Account"
+                            color="error"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet content()}
                         <div class="flex flex-col items-center gap-4 p-6 text-center">
                             <div

--- a/src/routes/modal/+page.svelte
+++ b/src/routes/modal/+page.svelte
@@ -59,7 +59,9 @@
                 title="Basic Modal"
                 description="This is a basic modal with title, description, body and footer."
             >
-                <Button variant="outline" label="Open Modal" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open Modal" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         A centered modal dialog. Click the X, press Escape, or click outside to
@@ -89,7 +91,9 @@
                 title="Fullscreen Modal"
                 description="This modal takes up the entire screen."
             >
-                <Button variant="outline" label="Open Fullscreen" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open Fullscreen" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Covers the entire viewport. Useful for complex forms or media viewers.
@@ -116,7 +120,9 @@
                 title="Scrollable Modal"
                 description="The entire modal scrolls within the overlay."
             >
-                <Button variant="outline" label="Scrollable" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Scrollable" />
+                {/snippet}
                 {#snippet body()}
                     <div class="space-y-3">
                         {#each Array.from({ length: 20 }, (_, i) => i) as i (i)}
@@ -142,7 +148,9 @@
                 title="Scrollable + Fullscreen"
                 description="Full viewport with scrollable content."
             >
-                <Button variant="outline" label="Scrollable + Fullscreen" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Scrollable + Fullscreen" />
+                {/snippet}
                 {#snippet body()}
                     <div class="space-y-3">
                         {#each Array.from({ length: 30 }, (_, i) => i) as i (i)}
@@ -173,7 +181,9 @@
                 title="No Transition"
                 description="Appears instantly without animation."
             >
-                <Button variant="outline" label="No Transition" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="No Transition" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">Modal opens and closes without animation.</p>
                 {/snippet}
@@ -192,7 +202,9 @@
                 title="No Close Button"
                 description="Close button is hidden."
             >
-                <Button variant="outline" label="No Close Button" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="No Close Button" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">Use the footer button or Escape to close.</p>
                 {/snippet}
@@ -207,7 +219,9 @@
                 title="No Overlay"
                 description="Background is visible."
             >
-                <Button variant="outline" label="No Overlay" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="No Overlay" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">No backdrop overlay behind the modal.</p>
                 {/snippet}
@@ -232,7 +246,9 @@
                 title="Non-Dismissible"
                 description="Must use the close button."
             >
-                <Button variant="outline" label="Open (Non-Dismissible)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open (Non-Dismissible)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Clicking outside or pressing Escape won't close this modal.
@@ -256,7 +272,9 @@
         <div class="flex flex-wrap gap-3 rounded-lg bg-surface-container-high p-4">
             <!-- Custom header -->
             <Modal bind:open={slotsOpen}>
-                <Button variant="outline" label="Custom Header" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Custom Header" />
+                {/snippet}
                 {#snippet header()}
                     <div class="flex items-center gap-3 p-4 sm:px-6">
                         <div
@@ -298,7 +316,9 @@
                 title="User Profile"
                 description="Manage your account settings."
             >
-                <Button variant="outline" label="Actions Slot" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Actions Slot" />
+                {/snippet}
                 {#snippet actions()}
                     <Badge variant="soft" color="success" size="xs" label="Active" />
                     <Badge variant="soft" color="info" size="xs" label="Pro" />
@@ -315,7 +335,9 @@
 
             <!-- Full content slot -->
             <Modal bind:open={customContentOpen} title="Custom Content">
-                <Button variant="outline" label="Content Slot" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Content Slot" />
+                {/snippet}
                 {#snippet content()}
                     <div class="flex flex-col items-center gap-4 p-6">
                         <div
@@ -360,7 +382,9 @@
                 title="Callback Demo"
                 description="Check the log above."
             >
-                <Button variant="outline" label="Open (With Callbacks)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open (With Callbacks)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Open, close, and watch the callback log update.
@@ -422,7 +446,9 @@
                     header: 'border-on-primary-container/10'
                 }}
             >
-                <Button variant="outline" label="Open Styled Modal" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open Styled Modal" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-primary-container/80">
                         This modal overrides content, title, description, and header slot classes.
@@ -449,13 +475,16 @@
             <div class="rounded-lg bg-surface-container-high p-4">
                 <p class="mb-3 text-sm font-medium">Confirmation Dialog</p>
                 <Modal bind:open={confirmOpen} dismissible={false} close={false}>
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:trash-2"
-                        label="Delete Item"
-                        color="error"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:trash-2"
+                            label="Delete Item"
+                            color="error"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet content()}
                         <div class="flex flex-col items-center gap-4 p-6 text-center">
                             <div
@@ -495,12 +524,15 @@
                     title="Create Project"
                     description="Fill in the details to create a new project."
                 >
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:plus"
-                        label="New Project"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:plus"
+                            label="New Project"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <div class="space-y-4">
                             <div>
@@ -556,12 +588,15 @@
                     description="Your session has timed out due to inactivity."
                     dismissible={false}
                 >
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:clock"
-                        label="Session Alert"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:clock"
+                            label="Session Alert"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <p class="text-on-surface-variant">
                             Please sign in again to continue using the application.
@@ -583,12 +618,15 @@
             <div class="rounded-lg bg-surface-container-high p-4">
                 <p class="mb-3 text-sm font-medium">Image Preview</p>
                 <Modal bind:open={imageOpen} close={{ color: 'surface', size: 'md' }}>
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:image"
-                        label="View Image"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:image"
+                            label="View Image"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet content()}
                         <div class="p-2">
                             <img
@@ -624,7 +662,9 @@
                     title={`Size: ${s}`}
                     description="Resize your browser to see how the modal width scales."
                 >
-                    <Button variant="outline" label={`size="${s}"`} />
+                    {#snippet children({ props })}
+                        <Button {...props} variant="outline" label={`size="${s}"`} />
+                    {/snippet}
                     {#snippet body()}
                         <p class="text-sm text-on-surface-variant">
                             Current size is <code>{s}</code>.
@@ -652,7 +692,9 @@
                     title={`Transition: ${t}`}
                     description="Open and close to see the animation."
                 >
-                    <Button variant="outline" label={`transition="${t}"`} />
+                    {#snippet children({ props })}
+                        <Button {...props} variant="outline" label={`transition="${t}"`} />
+                    {/snippet}
                 </Modal>
             {/each}
         </div>

--- a/src/routes/slideover/+page.svelte
+++ b/src/routes/slideover/+page.svelte
@@ -72,7 +72,9 @@
                 title="Right Slideover"
                 description="Slides in from the right (default)."
             >
-                <Button variant="outline" label="Right" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Right" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         This panel slides in from the right side (default).
@@ -89,7 +91,9 @@
                 title="Left Slideover"
                 description="Slides in from the left."
             >
-                <Button variant="outline" label="Left" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Left" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">This panel slides in from the left side.</p>
                 {/snippet}
@@ -104,7 +108,9 @@
                 title="Top Slideover"
                 description="Slides down from the top."
             >
-                <Button variant="outline" label="Top" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Top" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">This panel slides down from the top.</p>
                 {/snippet}
@@ -119,7 +125,9 @@
                 title="Bottom Slideover"
                 description="Slides up from the bottom."
             >
-                <Button variant="outline" label="Bottom" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Bottom" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">This panel slides up from the bottom.</p>
                 {/snippet}
@@ -145,7 +153,9 @@
                 title="Inset Right"
                 description="Inset mode with rounded corners."
             >
-                <Button variant="outline" label="Inset (Right)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Inset (Right)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         This slideover has margins and rounded corners, giving it a floating
@@ -168,7 +178,9 @@
                 title="Inset Left"
                 description="Inset mode from the left side."
             >
-                <Button variant="outline" label="Inset (Left)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Inset (Left)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Inset mode from the left with floating panel appearance.
@@ -190,7 +202,9 @@
                 title="Inset Top"
                 description="Inset mode from the top."
             >
-                <Button variant="outline" label="Inset (Top)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Inset (Top)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Inset mode from the top with floating panel appearance.
@@ -212,7 +226,9 @@
                 title="Inset Bottom"
                 description="Inset mode from the bottom."
             >
-                <Button variant="outline" label="Inset (Bottom)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Inset (Bottom)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Inset mode from the bottom with floating panel appearance.
@@ -246,7 +262,9 @@
                 title="No Transition"
                 description="This slideover appears and disappears instantly."
             >
-                <Button variant="outline" label="No Transition" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="No Transition" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         No slide or fade animation — the slideover snaps open and closed.
@@ -279,7 +297,9 @@
                 title="No Close Button"
                 description="The X button is hidden."
             >
-                <Button variant="outline" label="No Close Button" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="No Close Button" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         There's no X button. Use the footer button or Escape key to close.
@@ -313,7 +333,9 @@
                 title="No Overlay"
                 description="The backdrop is hidden."
             >
-                <Button variant="outline" label="No Overlay" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="No Overlay" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         The slideover has no backdrop overlay. The page content behind is fully
@@ -348,7 +370,9 @@
                 title="Non-Dismissible"
                 description="You must use the button to close."
             >
-                <Button variant="outline" label="Open (Non-Dismissible)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open (Non-Dismissible)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Try clicking outside or pressing Escape — the slideover will not close.
@@ -387,7 +411,9 @@
         <div class="flex flex-wrap gap-3 rounded-lg bg-surface-container-high p-4">
             <!-- Custom header slot -->
             <Slideover bind:open={slotsOpen}>
-                <Button variant="outline" label="Custom Header" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Custom Header" />
+                {/snippet}
                 {#snippet header()}
                     <div class="flex items-center gap-3 p-4 sm:px-6">
                         <div
@@ -422,7 +448,9 @@
 
             <!-- Custom title/description slots -->
             <Slideover bind:open={titleSlotOpen}>
-                <Button variant="outline" label="Custom Title/Desc" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Custom Title/Desc" />
+                {/snippet}
                 {#snippet titleSlot()}
                     <span class="flex items-center gap-2">
                         <Icon name="lucide:sparkles" size="16" class="text-warning" />
@@ -467,7 +495,9 @@
                 title="User Profile"
                 description="Manage your account settings."
             >
-                <Button variant="outline" label="Actions Slot" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Actions Slot" />
+                {/snippet}
                 {#snippet actions()}
                     <Badge variant="soft" color="success" size="xs" label="Active" />
                     <Badge variant="soft" color="info" size="xs" label="Pro" />
@@ -487,7 +517,9 @@
 
             <!-- Full content slot -->
             <Slideover bind:open={customContentOpen} title="Custom Content">
-                <Button variant="outline" label="Content Slot" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Content Slot" />
+                {/snippet}
                 {#snippet content()}
                     <div class="flex h-full flex-col items-center justify-center gap-4 p-6">
                         <div
@@ -544,7 +576,9 @@
                 title="Callback Demo"
                 description="Check the log above."
             >
-                <Button variant="outline" label="Open (With Callbacks)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open (With Callbacks)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Open, close, and watch the callback log update in real-time.
@@ -578,7 +612,9 @@
                 title="No Portal"
                 description="Rendered inline, not in a portal."
             >
-                <Button variant="outline" label="Open (No Portal)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open (No Portal)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         This slideover is rendered inline in the DOM.
@@ -650,7 +686,9 @@
                     description: 'text-on-primary-container/70'
                 }}
             >
-                <Button variant="outline" label="Open Styled Slideover" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open Styled Slideover" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-primary-container/80">
                         This slideover overrides
@@ -695,12 +733,15 @@
                     title="Filters"
                     description="Refine your search results."
                 >
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:sliders-horizontal"
-                        label="Filters"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:sliders-horizontal"
+                            label="Filters"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <div class="space-y-6">
                             <div>
@@ -786,12 +827,15 @@
                     title="Settings"
                     description="Customize your experience."
                 >
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:settings"
-                        label="Settings"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:settings"
+                            label="Settings"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <div class="space-y-6">
                             <div class="flex items-center justify-between">
@@ -866,12 +910,15 @@
                     title="Shopping Cart"
                     description="3 items in your cart"
                 >
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:shopping-cart"
-                        label="Cart (3)"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:shopping-cart"
+                            label="Cart (3)"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <div class="space-y-4">
                             {#each [{ name: 'Wireless Headphones', price: '$199.99', qty: 1 }, { name: 'USB-C Cable', price: '$19.99', qty: 2 }, { name: 'Phone Case', price: '$29.99', qty: 1 }] as item (item.name)}
@@ -932,12 +979,15 @@
                     title="Notifications"
                     description="You have 5 unread notifications"
                 >
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:bell"
-                        label="Notifications"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:bell"
+                            label="Notifications"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <div class="space-y-3">
                             {#each [{ icon: 'lucide:package', title: 'Order shipped', desc: 'Your order #1234 has been shipped', time: '2m ago', color: 'text-info' }, { icon: 'lucide:user-plus', title: 'New follower', desc: 'John Doe started following you', time: '1h ago', color: 'text-primary' }, { icon: 'lucide:message-circle', title: 'New comment', desc: 'Sarah commented on your post', time: '3h ago', color: 'text-success' }, { icon: 'lucide:heart', title: 'Post liked', desc: 'Your post received 100 likes', time: '5h ago', color: 'text-error' }, { icon: 'lucide:calendar', title: 'Event reminder', desc: 'Team meeting in 30 minutes', time: '1d ago', color: 'text-warning' }] as notif (notif.title)}
@@ -991,7 +1041,9 @@
                     title={`Size: ${s}`}
                     description={`right side, size="${s}"`}
                 >
-                    <Button variant="outline" label={`size="${s}"`} />
+                    {#snippet children({ props })}
+                        <Button {...props} variant="outline" label={`size="${s}"`} />
+                    {/snippet}
                     {#snippet body()}
                         <p class="text-sm text-on-surface-variant">
                             Current size is <code>{s}</code>.
@@ -1019,7 +1071,9 @@
                     title={`Transition: ${t}`}
                     description="Open and close to see the animation."
                 >
-                    <Button variant="outline" label={`transition="${t}"`} />
+                    {#snippet children({ props })}
+                        <Button {...props} variant="outline" label={`transition="${t}"`} />
+                    {/snippet}
                 </Slideover>
             {/each}
         </div>


### PR DESCRIPTION
## Summary

The `Modal`, `Slideover`, and `Drawer` trigger rendered its `children` snippet **inside** the underlying primitive's own `<button>`. When the trigger is an interactive control (`<Button>`/`<Link>` — the documented, common case) this produced an invalid nested `<button>` inside `<button>`, which in SSR throws `node_invalid_placement_ssr` and can escalate to a hard hydration failure (`The deferred DOM Node could not be resolved`).

This uses the primitive's `child` snippet so the trigger props/ARIA/handlers are spread onto the consumer's own element — a single, correct trigger button.

Closes #94

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature / component
- [ ] 📖 Documentation
- [ ] ♻️ Refactor / chore
- [x] ⚠️ Breaking change

## Changes

- `Modal` / `Slideover` / `Drawer`: render the trigger via the `child` snippet; the `children` snippet now receives `{ props }` to spread onto your own focusable element.
- Types: `children` snippet typed as `Snippet<[{ props: Record<string, unknown> }]>` with a migration example.
- Migrated all demo trigger usages to the new `{#snippet children({ props })}` form.
- Added regression tests (Modal/Slideover/Drawer): assert a single, non-nested trigger button and `data-state` `closed → open` on click.
- `CHANGELOG.md`: BREAKING entry with migration note.

### Migration

```svelte
<!-- Before -->
<Modal title="…"><Button>Open</Button></Modal>

<!-- After -->
<Modal title="…">
    {#snippet children({ props })}
        <Button {...props}>Open</Button>
    {/snippet}
</Modal>
```

## Checklist

- [x] Linked the related issue (`Closes #…`)
- [x] `pnpm check` passes (0 errors, 0 warnings)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added or updated tests for the change
- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] Followed component conventions (no comments outside `*.types.ts`, Material 3 design tokens, common library parity)
