### PR TITLE
feat(command): export group/item types and type-check id + data-* on root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Command** — Exported the `CommandGroup` and `CommandItem` types from the package entry, so consumers can type the `groups` data with full type-checking without importing from internal paths.
+- **Command** — `CommandProps` now type-checks `id` and `data-*` attributes on the root element (useful as a scoping/anchor target and for test/analytics hooks); previously these were rejected by the type even though `restProps` already reached the root.
+
 ## [2.0.0] - 2026-06-01
 
 ### Added

--- a/src/lib/Command/Command.svelte.spec.ts
+++ b/src/lib/Command/Command.svelte.spec.ts
@@ -231,6 +231,21 @@ describe('Command', () => {
         })
     })
 
+    // ==================== ROOT ATTRIBUTES ====================
+
+    describe('root html attributes', () => {
+        it('should forward id and data-* attributes to the root element', () => {
+            render(CommandTestWrapper, {
+                groups: sampleGroups,
+                id: 'my-command',
+                'data-foo': 'bar'
+            })
+            const root = getRoot()!
+            expect(root.id).toBe('my-command')
+            expect(root.getAttribute('data-foo')).toBe('bar')
+        })
+    })
+
     // ==================== COMBINED ====================
 
     describe('combined', () => {

--- a/src/lib/Command/command.types.ts
+++ b/src/lib/Command/command.types.ts
@@ -1,6 +1,6 @@
 import type { Snippet } from 'svelte'
 import type { ClassNameValue } from 'tailwind-merge'
-import type { CommandRootPropsWithoutHTML } from 'bits-ui'
+import type { CommandRootProps, CommandRootPropsWithoutHTML } from 'bits-ui'
 import type { CommandSlots, CommandVariantProps } from './command.variants.js'
 
 // ============================================================================
@@ -73,10 +73,16 @@ export interface CommandItemSlotProps {
  *
  * @see https://bits-ui.com/docs/components/command
  */
-export interface CommandProps extends Pick<
-    CommandRootPropsWithoutHTML,
-    'value' | 'onValueChange' | 'filter' | 'shouldFilter' | 'loop' | 'vimBindings' | 'label'
-> {
+export interface CommandProps
+    extends
+        Pick<
+            CommandRootPropsWithoutHTML,
+            'value' | 'onValueChange' | 'filter' | 'shouldFilter' | 'loop' | 'vimBindings' | 'label'
+        >,
+        Pick<CommandRootProps, 'id'> {
+    /** Custom data attributes are forwarded to the root element. */
+    [key: `data-${string}`]: unknown
+
     // -------------------------------------------------------------------------
     // Refs
     // -------------------------------------------------------------------------

--- a/src/lib/Command/index.ts
+++ b/src/lib/Command/index.ts
@@ -1,2 +1,2 @@
 export { default as Command } from './Command.svelte'
-export type { CommandProps } from './command.types.js'
+export type { CommandProps, CommandGroup, CommandItem } from './command.types.js'

--- a/src/routes/command/+page.svelte
+++ b/src/routes/command/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { Command, Separator, Badge, Kbd, Button, Popover, Modal, Drawer } from '$lib/index.js'
-    import type { CommandGroup } from '$lib/Command/command.types.js'
+    import type { CommandGroup } from '$lib/index.js'
 
     // --- Basic groups ---
     const basicGroups: CommandGroup[] = [


### PR DESCRIPTION
## Summary

Two additive, non-breaking improvements to `Command`:

1. **Export `CommandGroup` and `CommandItem`** from the package entry. These are the core data-shaping types for the `groups` prop; previously consumers (and the library's own demo) had to import them from an internal path. Now consistent with `Select`/`SelectMenu`/`Tabs`/`Breadcrumb`.
2. **Type-check `id` and `data-*` on the root element.** These already reached `Command.Root` via `restProps` at runtime but were rejected by the type. Scope kept intentionally minimal (`id` for scoping/anchor, `data-*` for test/analytics hooks) — no `style`/`role`/`tabindex`/`aria-*`/event-handler padding.

Closes #95

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature / component
- [ ] 📖 Documentation
- [ ] ♻️ Refactor / chore
- [ ] ⚠️ Breaking change

## Changes

- `index.ts`: export `CommandGroup` + `CommandItem`.
- `command.types.ts`: `CommandProps` now picks `id` from the root props and adds a `data-${string}` index signature.
- Demo: import `CommandGroup` from the package entry instead of an internal path.
- Regression test: assert `id` and `data-*` are forwarded to `[data-command-root]`.
- `CHANGELOG.md`: two `Added` entries.

## Checklist

- [x] Linked the related issue (`Closes #…`)
- [x] `pnpm check` passes (0 errors, 0 warnings)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added or updated tests for the change
- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] Followed component conventions (no comments outside `*.types.ts`, Material 3 design tokens, common library parity)

## Notes

A performance investigation (Modal + Command jank) is documented in #95: the component's reactivity is clean; the cost is the inherent O(n) eager rendering of all items, and empty-list lag traces to the host page — not a defect here. No code change needed for that.
