### PR TITLE
chore(ci): bump GitHub Actions to v6 (Node 24 runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,13 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@v6
               with:
                   version: 10
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: pnpm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,13 @@ jobs:
             id-token: write
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@v6
               with:
                   version: 10
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: pnpm


### PR DESCRIPTION
## Summary

Bumps the GitHub Actions pinned in our workflows from v4 (Node.js 20 runtime, deprecated) to v6 (Node.js 24), resolving the deprecation warning before the forced cutover (2026-06-16).

Closes #98

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature / component
- [ ] 📖 Documentation
- [x] ♻️ Refactor / chore
- [ ] ⚠️ Breaking change

## Changes

- `ci.yml` and `publish.yml`: `actions/checkout`, `actions/setup-node`, `pnpm/action-setup` → `@v6`.
- All inputs unchanged (`version: 10`, `cache: pnpm`, `node-version: 22`, `registry-url`) — drop-in.

## Checklist

- [x] Linked the related issue (`Closes #…`)
- [x] CI tooling only — no package code change
