### PR TITLE
fix(types): tighten public component type safety

### DIFF
--- a/src/lib/Badge/badge.types.ts
+++ b/src/lib/Badge/badge.types.ts
@@ -20,7 +20,7 @@ export type BadgeProps = Omit<HTMLAttributes<HTMLSpanElement>, 'class'> & {
      * Override styles for specific badge slots.
      * Available slots: base, label, leadingIcon, trailingIcon, leadingAvatar.
      */
-    ui?: Partial<Record<BadgeSlots, ClassNameValue>>
+    ui?: Partial<Record<Exclude<BadgeSlots, 'leadingAvatarSize'>, ClassNameValue>>
 
     /**
      * Sets the text content displayed inside the badge.

--- a/src/lib/Collapsible/collapsible.types.ts
+++ b/src/lib/Collapsible/collapsible.types.ts
@@ -46,7 +46,7 @@ export interface CollapsibleProps
             | 'onblur'
         > {
     /** Custom data attributes are forwarded to the root element. */
-    [key: `data-${string}`]: unknown
+    [key: `data-${string}`]: string | number | boolean | null | undefined
 
     // -------------------------------------------------------------------------
     // Refs

--- a/src/lib/Command/command.types.ts
+++ b/src/lib/Command/command.types.ts
@@ -81,7 +81,7 @@ export interface CommandProps
         >,
         Pick<CommandRootProps, 'id'> {
     /** Custom data attributes are forwarded to the root element. */
-    [key: `data-${string}`]: unknown
+    [key: `data-${string}`]: string | number | boolean | null | undefined
 
     // -------------------------------------------------------------------------
     // Refs

--- a/src/lib/Icon/icon.types.ts
+++ b/src/lib/Icon/icon.types.ts
@@ -21,7 +21,7 @@ export interface IconProps
             | 'onblur'
         > {
     /** Custom data attributes are forwarded to the rendered `<svg>`. */
-    [key: `data-${string}`]: unknown
+    [key: `data-${string}`]: string | number | boolean | null | undefined
     /**
      * Icon name in Iconify format: "collection:icon-name"
      * @example "lucide:home", "mdi:account", "heroicons:star"

--- a/src/lib/Input/index.ts
+++ b/src/lib/Input/index.ts
@@ -1,2 +1,2 @@
 export { default as Input } from './Input.svelte'
-export type { InputProps } from './input.types.js'
+export type { InputProps, InputValue } from './input.types.js'

--- a/src/lib/Pagination/pagination.types.ts
+++ b/src/lib/Pagination/pagination.types.ts
@@ -68,7 +68,7 @@ export interface PaginationProps extends Pick<
     | 'onblur'
 > {
     /** Custom data attributes are forwarded to the root element. */
-    [key: `data-${string}`]: unknown
+    [key: `data-${string}`]: string | number | boolean | null | undefined
 
     /**
      * Bindable reference to the root DOM element.

--- a/src/lib/Popover/popover.types.ts
+++ b/src/lib/Popover/popover.types.ts
@@ -30,6 +30,9 @@ type ContentProps = Pick<
 >
 
 export interface PopoverProps extends RootProps, ContentProps {
+    /** Custom data attributes are forwarded to the content element. */
+    [key: `data-${string}`]: string | number | boolean | null | undefined
+
     /**
      * Bindable reference to the content DOM element.
      */

--- a/src/lib/Select/select.types.ts
+++ b/src/lib/Select/select.types.ts
@@ -170,7 +170,7 @@ type TriggerHTMLProps = Pick<
 
 export interface SelectProps extends RootProps, ContentProps, TriggerHTMLProps {
     /** Custom data attributes are forwarded to the trigger element. */
-    [key: `data-${string}`]: unknown
+    [key: `data-${string}`]: string | number | boolean | null | undefined
 
     // -------------------------------------------------------------------------
     // Ref

--- a/src/lib/SelectMenu/select-menu.types.ts
+++ b/src/lib/SelectMenu/select-menu.types.ts
@@ -143,7 +143,7 @@ type TriggerHTMLProps = Pick<
 
 export interface SelectMenuProps extends ContentProps, TriggerHTMLProps {
     /** Custom data attributes are forwarded to the trigger element. */
-    [key: `data-${string}`]: unknown
+    [key: `data-${string}`]: string | number | boolean | null | undefined
 
     // -------------------------------------------------------------------------
     // Ref

--- a/src/lib/Separator/separator.types.ts
+++ b/src/lib/Separator/separator.types.ts
@@ -4,7 +4,7 @@ import type { Separator } from 'bits-ui'
 import type { SeparatorVariantProps, SeparatorSlots } from './separator.variants.js'
 import type { AvatarProps } from '../Avatar/avatar.types.js'
 
-export type SeparatorProps = Separator.RootProps & {
+export type SeparatorProps = Omit<Separator.RootProps, 'class'> & {
     /**
      * Sets the color scheme applied to the separator.
      * @default 'surface'

--- a/src/lib/Tabs/tabs.types.ts
+++ b/src/lib/Tabs/tabs.types.ts
@@ -121,7 +121,7 @@ export interface TabsProps extends Pick<
     | 'onblur'
 > {
     /** Custom data attributes are forwarded to the root element. */
-    [key: `data-${string}`]: unknown
+    [key: `data-${string}`]: string | number | boolean | null | undefined
 
     /**
      * Bindable reference to the root DOM element.

--- a/src/lib/Tooltip/tooltip.types.ts
+++ b/src/lib/Tooltip/tooltip.types.ts
@@ -37,6 +37,9 @@ type ContentProps = Pick<
 >
 
 export interface TooltipProps extends ProviderProps, RootProps, ContentProps {
+    /** Custom data attributes are forwarded to the content element. */
+    [key: `data-${string}`]: string | number | boolean | null | undefined
+
     /**
      * Bindable reference to the content DOM element.
      */


### PR DESCRIPTION
Closes #100

Tightens public component types without changing runtime behavior.

- Narrow the `data-*` index signatures from `unknown` to `string | number | boolean | null | undefined` (Icon, Tabs, Pagination, Command, Select, SelectMenu, Collapsible).
- `Separator`: `Omit<Separator.RootProps, 'class'>` to avoid the `ClassValue & ClassNameValue` intersection on `class`.
- `Badge`: exclude the non-class `leadingAvatarSize` slot from `ui`.
- `Input`: export `InputValue` (referenced by the public `InputProps` generic).

**Verification:** `svelte-check` clean; affected component specs pass. Type-only changes.
