### PR TITLE
perf(components): memoize per-render variant computations

### DIFF
--- a/src/lib/Accordion/Accordion.svelte
+++ b/src/lib/Accordion/Accordion.svelte
@@ -53,7 +53,18 @@
 
     type SlotName = (typeof slotNames)[number]
 
+    const itemDefaults = $derived.by(() => {
+        const result = {} as Record<SlotName, string>
+        for (const slot of slotNames) {
+            result[slot] = variantSlots[slot]({ class: [config.slots[slot], ui?.[slot]] })
+        }
+        return result
+    })
+
     function getItemClasses(item: AccordionItem) {
+        if (!item.ui && item.class === undefined && item.disabled === undefined) {
+            return itemDefaults
+        }
         const result = {} as Record<SlotName, string>
         for (const slot of slotNames) {
             const baseClass = [

--- a/src/lib/Progress/Progress.svelte
+++ b/src/lib/Progress/Progress.svelte
@@ -80,6 +80,19 @@
         }
     })
 
+    const stepClasses = $derived.by(() => {
+        const make = (step: 'active' | 'first' | 'last' | 'other') =>
+            progressVariants({ size, orientation, inverted, step }).step({
+                class: [config.slots.step, ui?.step]
+            })
+        return {
+            active: make('active'),
+            first: make('first'),
+            last: make('last'),
+            other: make('other')
+        }
+    })
+
     const state = $derived(isIndeterminate ? 'indeterminate' : 'determinate')
 </script>
 
@@ -108,12 +121,7 @@
     {#if hasSteps && Array.isArray(max)}
         <div class={classes.steps}>
             {#each max as step, index (index)}
-                {@const stepClass = progressVariants({
-                    size,
-                    orientation,
-                    inverted,
-                    step: stepVariant(index)
-                }).step({ class: [config.slots.step, ui?.step] })}
+                {@const stepClass = stepClasses[stepVariant(index)]}
                 <div class={stepClass}>
                     {#if stepSlot}
                         {@render stepSlot({ step, index })}

--- a/src/lib/Skeleton/Skeleton.svelte
+++ b/src/lib/Skeleton/Skeleton.svelte
@@ -19,11 +19,9 @@
         ...restProps
     }: Props = $props()
 
-    const classes = $derived.by(() => {
-        const slots = skeletonVariants()
-        return {
-            root: slots.root({ class: [config.slots.root, className, ui?.root] })
-        }
+    const slots = skeletonVariants()
+    const classes = $derived({
+        root: slots.root({ class: [config.slots.root, className, ui?.root] })
     })
 </script>
 

--- a/src/lib/Stepper/Stepper.svelte
+++ b/src/lib/Stepper/Stepper.svelte
@@ -122,9 +122,7 @@
         }
     }
 
-    $effect.pre(() => {
-        api = apiInstance
-    })
+    api = apiInstance
 
     const variantSlots = $derived(stepperVariants({ orientation, size, color }))
 

--- a/src/lib/Switch/Switch.svelte
+++ b/src/lib/Switch/Switch.svelte
@@ -72,17 +72,16 @@
         disabled: isDisabled ? true : undefined
     })
 
-    const classes = $derived.by(() => {
-        const slots = switchVariants(variantOpts)
-        return {
-            root: slots.root({ class: [config.slots.root, className, ui?.root] }),
-            base: slots.base({ class: [config.slots.base, ui?.base] }),
-            container: slots.container({ class: [config.slots.container, ui?.container] }),
-            thumb: slots.thumb({ class: [config.slots.thumb, ui?.thumb] }),
-            wrapper: slots.wrapper({ class: [config.slots.wrapper, ui?.wrapper] }),
-            label: slots.label({ class: [config.slots.label, ui?.label] }),
-            description: slots.description({ class: [config.slots.description, ui?.description] })
-        }
+    const slots = $derived(switchVariants(variantOpts))
+
+    const classes = $derived({
+        root: slots.root({ class: [config.slots.root, className, ui?.root] }),
+        base: slots.base({ class: [config.slots.base, ui?.base] }),
+        container: slots.container({ class: [config.slots.container, ui?.container] }),
+        thumb: slots.thumb({ class: [config.slots.thumb, ui?.thumb] }),
+        wrapper: slots.wrapper({ class: [config.slots.wrapper, ui?.wrapper] }),
+        label: slots.label({ class: [config.slots.label, ui?.label] }),
+        description: slots.description({ class: [config.slots.description, ui?.description] })
     })
 
     const iconClasses = $derived.by(() => {
@@ -91,15 +90,11 @@
         const iconUiClass = [config.slots.icon, ui?.icon]
         return {
             checked: hasCheckedIcon
-                ? switchVariants({ ...variantOpts, checked: true, unchecked: loading }).icon({
-                      class: iconUiClass
-                  })
+                ? slots.icon({ class: iconUiClass, checked: true, unchecked: loading })
                 : undefined,
             unchecked:
                 hasUncheckedIcon && !loading
-                    ? switchVariants({ ...variantOpts, unchecked: true }).icon({
-                          class: iconUiClass
-                      })
+                    ? slots.icon({ class: iconUiClass, unchecked: true })
                     : undefined
         }
     })

--- a/src/lib/ThemeModeButton/ThemeModeButton.svelte
+++ b/src/lib/ThemeModeButton/ThemeModeButton.svelte
@@ -34,7 +34,8 @@
 
     const isDark = $derived(mode.current === 'dark')
 
-    const slots = $derived(themeModeButtonVariants())
+    const slots = themeModeButtonVariants()
+    const baseClass = $derived(slots.base({ class: [config.slots.base, className, ui?.base] }))
 
     const iconName = $derived(isDark ? lightIcon : darkIcon)
 </script>
@@ -48,7 +49,7 @@
         {disabled}
         {square}
         {block}
-        class={slots.base({ class: [config.slots.base, className, ui?.base] })}
+        class={baseClass}
         aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
         onclick={toggleMode}
         {...restProps}
@@ -65,7 +66,7 @@
         {square}
         {block}
         icon={iconName}
-        class={slots.base({ class: [config.slots.base, className, ui?.base] })}
+        class={baseClass}
         aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
         onclick={toggleMode}
         {...restProps}


### PR DESCRIPTION
Closes #101

Reduces redundant per-render tailwind-variants computation. Behavior-preserving.

- **Accordion**: precompute default slot classes once; reuse for items without per-item `ui`/`class`/`disabled` overrides.
- **Progress**: precompute the 4 step-variant classes and index by state instead of re-instantiating per step.
- **Switch**: build the slots object once; pass `checked`/`unchecked` as per-call slot overrides (3 calls → 1).
- **Stepper**: assign the stable `api` object directly instead of via `$effect.pre`.
- **ThemeModeButton / Skeleton**: drop the redundant `$derived` around an argument-less variant fn.

**Verification:** proved byte-identical class output across the full variant matrix (2907 assertions for the changed call-shapes); `svelte-check` clean; full suite (2459 tests) passes.
