### PR TITLE
refactor(types): drop unsafe `as string` cast on trigger class

### DIFF
--- a/src/lib/ContextMenu/ContextMenu.svelte
+++ b/src/lib/ContextMenu/ContextMenu.svelte
@@ -329,7 +329,7 @@
 
 <ContextMenu.Root bind:open {onOpenChange}>
     {#if children}
-        <ContextMenu.Trigger class={className as string}>
+        <ContextMenu.Trigger class={[className]}>
             {@render children({ open })}
         </ContextMenu.Trigger>
     {/if}

--- a/src/lib/Popover/Popover.svelte
+++ b/src/lib/Popover/Popover.svelte
@@ -105,7 +105,7 @@
     {#if children}
         <Popover.Trigger>
             {#snippet child({ props })}
-                <span {...props} class={className as string}>
+                <span {...props} class={[className]}>
                     {@render children({ open })}
                 </span>
             {/snippet}

--- a/src/lib/Tooltip/Tooltip.svelte
+++ b/src/lib/Tooltip/Tooltip.svelte
@@ -133,7 +133,7 @@
         {#if children}
             <Tooltip.Trigger>
                 {#snippet child({ props })}
-                    <span {...props} class={className as string}>
+                    <span {...props} class={[className]}>
                         {@render children({ open })}
                     </span>
                 {/snippet}


### PR DESCRIPTION
Closes #102

Popover/Tooltip/ContextMenu cast the trigger `class` (`ClassNameValue`) to `string`. The cast was a type-level lie; Svelte 5 already flattens array/object class values via clsx at runtime, so output was already correct. Replace with the Svelte array-class form (already used in Popover's content slot) so it type-checks honestly.

**Verification:** confirmed empirically that old and new render byte-identical for array classes; `svelte-check` clean; component specs (104 tests) pass. Not a runtime bug — type hygiene only.
