### PR TITLE
fix: RadioGroup a11y, FileUpload URL leak, SelectMenu filter perf

### DIFF
--- a/src/lib/FileUpload/FileUpload.svelte
+++ b/src/lib/FileUpload/FileUpload.svelte
@@ -154,6 +154,13 @@
         }
     })
 
+    $effect(() => {
+        return () => {
+            for (const [, url] of urlCache) URL.revokeObjectURL(url)
+            urlCache.clear()
+        }
+    })
+
     export function open() {
         if (isDisabled) return
         inputRef?.click()

--- a/src/lib/RadioGroup/RadioGroup.svelte
+++ b/src/lib/RadioGroup/RadioGroup.svelte
@@ -54,6 +54,7 @@
     const resolvedId = $derived(id ?? formFieldContext?.ariaId ?? autoId)
     const resolvedName = $derived(name ?? formFieldContext?.name)
     const isDisabled = $derived(disabled || loading)
+    const legendId = $derived(`${resolvedId}-legend`)
 
     const ariaDescribedBy = $derived(
         !formFieldContext
@@ -186,13 +187,14 @@
         {orientation}
         aria-describedby={ariaDescribedBy}
         aria-invalid={hasError ? true : undefined}
+        aria-labelledby={legend && !legendSlot ? legendId : undefined}
         class={layoutClasses.fieldset}
     >
         {#if legend || legendSlot}
             {#if legendSlot}
                 {@render legendSlot({ legend })}
             {:else}
-                <span class={layoutClasses.legend}>{legend}</span>
+                <span id={legendId} class={layoutClasses.legend}>{legend}</span>
             {/if}
         {/if}
 

--- a/src/lib/SelectMenu/SelectMenu.svelte
+++ b/src/lib/SelectMenu/SelectMenu.svelte
@@ -23,6 +23,7 @@
     import Avatar from '../Avatar/Avatar.svelte'
     import type { AvatarSize } from '../Avatar/avatar.types.js'
     import { useFormField, useFormFieldEmit } from '../hooks/useFormField.svelte.js'
+    import { useDebounce } from '../hooks/useDebounce.svelte.js'
 
     const config = getComponentConfig('selectMenu', selectMenuDefaults)
     const icons = getComponentConfig('icons', iconsDefaults)
@@ -181,13 +182,28 @@
 
     // ---- Search & filtering ----
     let searchTerm = $state('')
+    let debouncedSearch = $state('')
+    const searchDebounce = useDebounce({ delay: 200 })
+
+    function setSearch(term: string) {
+        searchTerm = term
+        searchDebounce.run(() => {
+            debouncedSearch = term
+        })
+    }
+
+    function resetSearch() {
+        searchDebounce.cancel()
+        searchTerm = ''
+        debouncedSearch = ''
+    }
 
     const filteredItems = $derived(
-        ignoreFilter || !searchTerm.trim()
+        ignoreFilter || !debouncedSearch.trim()
             ? combinedItems
             : combinedItems.filter((item) => {
                   if ('type' in item) return true
-                  const query = searchTerm.toLowerCase()
+                  const query = debouncedSearch.toLowerCase()
                   return filterFields.some((field) => {
                       const val = (item as unknown as Record<string, unknown>)[field]
                       return typeof val === 'string' && val.toLowerCase().includes(query)
@@ -256,7 +272,7 @@
         }
 
         emit.onChange()
-        searchTerm = ''
+        resetSearch()
     }
 
     // ---- Leading / trailing ----
@@ -386,7 +402,7 @@
     // ---- Event handlers (Nuxt UI v4 pattern) ----
     function onUpdateOpen(val: boolean) {
         if (!val) {
-            searchTerm = ''
+            resetSearch()
             emit.onBlur()
         } else {
             emit.onFocus()
@@ -450,7 +466,7 @@
             autofocus
             placeholder={searchPlaceholder}
             value={searchTerm}
-            oninput={(e) => (searchTerm = (e.currentTarget as HTMLInputElement).value)}
+            oninput={(e) => setSearch((e.currentTarget as HTMLInputElement).value)}
             onkeydown={(e: KeyboardEvent) => {
                 if (e.key !== 'Enter') return
                 if (!showCreateItem) return


### PR DESCRIPTION
Closes #103

Three independent component fixes (3 commits):

- **fix(radio-group):** associate the legend with the radiogroup via `aria-labelledby` so screen readers announce the group name.
- **fix(file-upload):** revoke cached blob object URLs on unmount (was leaking URLs for files still in `value`).
- **perf(select-menu):** debounce the heavy filter (200ms) via the existing `useDebounce` hook; the input, create-on-Enter logic, slots and reset stay on the immediate term, so only filter timing changes.

**Verification:** `svelte-check` clean; full suite (2459 tests) passes. RadioGroup association proven via a render test; SelectMenu create-on-Enter proven unaffected (uses the immediate term).
