### PR TITLE
Release v2.1.0: types, perf, a11y & editor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-06-13
+
 ### Added
 
 - **Editor** — `onImageUploadError` prop, called when `onImageUpload` rejects (previously upload failures were only logged to the console). Use it to surface errors to the user.
 - **Command** — Exported the `CommandGroup` and `CommandItem` types from the package entry, so consumers can type the `groups` data with full type-checking without importing from internal paths.
 - **Command** — `CommandProps` now type-checks `id` and `data-*` attributes on the root element (useful as a scoping/anchor target and for test/analytics hooks); previously these were rejected by the type even though `restProps` already reached the root.
+- **Input** — Exported the `InputValue` type from the package entry; it is the constraint behind the public `InputProps<T>` generic, so consumers can now name it directly.
 
 ### Changed
 
@@ -33,16 +36,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Editor** — Halved the serialization work per keystroke: the value-sync effect no longer re-serializes the document to compare it against a value the editor itself just emitted (it short-circuits on its own echo). Previously every edit serialized twice — once to push `value`, then again in the sync effect to compare. Most noticeable for `output="markdown"` and large documents. No API or behavior change.
 - **Editor** — The heavy optional extensions are now lazy-loaded via dynamic `import()`: `tiptap-markdown` (only when `output="markdown"`) and the table packages (only when `tables` is enabled). Editors that don't use them no longer pull `markdown-it` (~80 KB gzip) or `prosemirror-tables` (~25 KB gzip) into the bundle — the consumer's bundler now code-splits them into separate chunks loaded on demand. Editors that enable neither still mount **synchronously** (no behavior change); only `markdown`/`tables` editors initialize asynchronously while their chunk loads (toolbar actions are briefly disabled and `bind:api` methods are no-ops until then).
+- **Components** — Reduced per-render styling cost: Accordion, Progress, Switch, Stepper, ThemeModeButton, and Skeleton no longer re-instantiate their `tailwind-variants` function on every render (defaults are precomputed/memoized and reused). No API or behavior change.
+- **SelectMenu** — The in-dropdown search now debounces filtering (200ms) so large item lists are not re-scanned on every keystroke. Typing stays instant; only the filtered list updates after a short pause. The displayed search term and create-on-Enter are unaffected.
+- **Types** — Tightened several public types (no runtime change): the `data-*` passthrough index signatures are now `string | number | boolean | null | undefined` instead of `unknown` (Icon, Tabs, Pagination, Command, Select, SelectMenu, Collapsible), and `Separator` no longer intersects bits-ui's `class` type with `ClassNameValue`.
 
 ### Removed
 
 - **Editor** — Removed the unused `toolbarGroup` key from the `ui` slot type; it was computed but never rendered, so setting it had no effect.
+- **Badge** — Removed the internal `leadingAvatarSize` key from the `ui` prop type; it was accepted by the type but silently ignored at runtime (mirrors the Button fix in 2.0.0).
 
 ### Fixed
 
 - **Editor** — Changing the `output` prop on an already-mounted editor no longer corrupts the content. `output` is read once at mount (it also decides whether the Markdown extension is loaded); it is now applied consistently to serialization, so a runtime change is simply ignored instead of producing a format/extension mismatch. Re-key the component (`{#key output}`) to switch formats.
 - **Editor** — The mention (`@`) and slash (`/`) autocomplete popups are now proper ARIA listboxes: each item exposes `role="option"` + `aria-selected`, the listbox has an accessible name, and while a popup is open the editor's contenteditable exposes `aria-controls`, `aria-expanded`, and `aria-activedescendant` (cleared on close) so screen readers announce the highlighted option as the user navigates.
 - **Calendar** — The Previous/Next year navigation buttons did nothing on initial render. They advanced an internal `placeholder` that stayed `undefined` until the first month navigation, so the first year click was a no-op. The placeholder is now initialized (from `value` when provided, otherwise today) so year navigation works immediately.
+- **RadioGroup** — The legend is now programmatically associated with the radiogroup via `aria-labelledby`, so screen readers announce the group name. Applies to the default text legend; a custom `legendSlot` remains the consumer's responsibility.
+- **FileUpload** — Cached blob object URLs are now revoked when the component unmounts. Previously only URLs for files removed from `value` were revoked, so files still present at unmount leaked their object URLs.
 
 ### Security
 
@@ -299,7 +308,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tailwind CSS 4 + Tailwind Variants integration
 - bits-ui and Vaul Svelte headless primitives
 
-[Unreleased]: https://github.com/ndlabdev/sv5ui/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/ndlabdev/sv5ui/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/ndlabdev/sv5ui/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/ndlabdev/sv5ui/compare/v1.8.0...v2.0.0
 [1.6.0]: https://github.com/ndlabdev/sv5ui/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/ndlabdev/sv5ui/compare/v1.5.0...v1.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Editor** — Halved the serialization work per keystroke: the value-sync effect no longer re-serializes the document to compare it against a value the editor itself just emitted (it short-circuits on its own echo). Previously every edit serialized twice — once to push `value`, then again in the sync effect to compare. Most noticeable for `output="markdown"` and large documents. No API or behavior change.
 - **Editor** — The heavy optional extensions are now lazy-loaded via dynamic `import()`: `tiptap-markdown` (only when `output="markdown"`) and the table packages (only when `tables` is enabled). Editors that don't use them no longer pull `markdown-it` (~80 KB gzip) or `prosemirror-tables` (~25 KB gzip) into the bundle — the consumer's bundler now code-splits them into separate chunks loaded on demand. Editors that enable neither still mount **synchronously** (no behavior change); only `markdown`/`tables` editors initialize asynchronously while their chunk loads (toolbar actions are briefly disabled and `bind:api` methods are no-ops until then).
 
+### Security
+
+- **Editor** — Image URLs returned by `onImageUpload` are now validated before insertion: relative URLs, `http(s)`, and raster `data:image/*` URIs are allowed, while `javascript:`, `data:text/*`, and `data:image/svg+xml` (an SVG script vector) are rejected (the image is not inserted and a warning is logged). The `value` docs now state that the HTML output is schema-validated but not sanitizer-clean — consumers must sanitize (e.g. with DOMPurify) before rendering it as raw markup elsewhere.
+
 ## [2.0.0] - 2026-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Editor** — Halved the serialization work per keystroke: the value-sync effect no longer re-serializes the document to compare it against a value the editor itself just emitted (it short-circuits on its own echo). Previously every edit serialized twice — once to push `value`, then again in the sync effect to compare. Most noticeable for `output="markdown"` and large documents. No API or behavior change.
 - **Editor** — The heavy optional extensions are now lazy-loaded via dynamic `import()`: `tiptap-markdown` (only when `output="markdown"`) and the table packages (only when `tables` is enabled). Editors that don't use them no longer pull `markdown-it` (~80 KB gzip) or `prosemirror-tables` (~25 KB gzip) into the bundle — the consumer's bundler now code-splits them into separate chunks loaded on demand. Editors that enable neither still mount **synchronously** (no behavior change); only `markdown`/`tables` editors initialize asynchronously while their chunk loads (toolbar actions are briefly disabled and `bind:api` methods are no-ops until then).
 
+### Fixed
+
+- **Editor** — The mention (`@`) and slash (`/`) autocomplete popups are now proper ARIA listboxes: each item exposes `role="option"` + `aria-selected`, the listbox has an accessible name, and while a popup is open the editor's contenteditable exposes `aria-controls`, `aria-expanded`, and `aria-activedescendant` (cleared on close) so screen readers announce the highlighted option as the user navigates.
+
 ### Security
 
 - **Editor** — Image URLs returned by `onImageUpload` are now validated before insertion: relative URLs, `http(s)`, and raster `data:image/*` URIs are allowed, while `javascript:`, `data:text/*`, and `data:image/svg+xml` (an SVG script vector) are rejected (the image is not inserted and a warning is logged). The `value` docs now state that the HTML output is schema-validated but not sanitizer-clean — consumers must sanitize (e.g. with DOMPurify) before rendering it as raw markup elsewhere.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Calendar** — The Previous/Next year navigation buttons did nothing on initial render. They advanced an internal `placeholder` that stayed `undefined` until the first month navigation, so the first year click was a no-op. The placeholder is now initialized (from `value` when provided, otherwise today) so year navigation works immediately.
+
 ## [2.0.0] - 2026-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Editor** — The heavy optional extensions are now lazy-loaded via dynamic `import()`: `tiptap-markdown` (only when `output="markdown"`) and the table packages (only when `tables` is enabled). Editors that don't use them no longer pull `markdown-it` (~80 KB gzip) or `prosemirror-tables` (~25 KB gzip) into the bundle — the consumer's bundler now code-splits them into separate chunks loaded on demand. Editors that enable neither still mount **synchronously** (no behavior change); only `markdown`/`tables` editors initialize asynchronously while their chunk loads (toolbar actions are briefly disabled and `bind:api` methods are no-ops until then).
+
 ## [2.0.0] - 2026-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Components** — Reduced per-render styling cost: Accordion, Progress, Switch, Stepper, ThemeModeButton, and Skeleton no longer re-instantiate their `tailwind-variants` function on every render (defaults are precomputed/memoized and reused). No API or behavior change.
 - **SelectMenu** — The in-dropdown search now debounces filtering (200ms) so large item lists are not re-scanned on every keystroke. Typing stays instant; only the filtered list updates after a short pause. The displayed search term and create-on-Enter are unaffected.
 - **Types** — Tightened several public types (no runtime change): the `data-*` passthrough index signatures are now `string | number | boolean | null | undefined` instead of `unknown` (Icon, Tabs, Pagination, Command, Select, SelectMenu, Collapsible), and `Separator` no longer intersects bits-ui's `class` type with `ClassNameValue`.
+- **Table** — Internal refactor of `table.utils.ts` (the default sort comparator and pin-offset computation) to bring both functions under the lint complexity limit by extracting small helpers. No API or behavior change.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Editor** — `onImageUploadError` prop, called when `onImageUpload` rejects (previously upload failures were only logged to the console). Use it to surface errors to the user.
+
 ### Changed
 
 - **Editor** — Halved the serialization work per keystroke: the value-sync effect no longer re-serializes the document to compare it against a value the editor itself just emitted (it short-circuits on its own echo). Previously every edit serialized twice — once to push `value`, then again in the sync effect to compare. Most noticeable for `output="markdown"` and large documents. No API or behavior change.
 - **Editor** — The heavy optional extensions are now lazy-loaded via dynamic `import()`: `tiptap-markdown` (only when `output="markdown"`) and the table packages (only when `tables` is enabled). Editors that don't use them no longer pull `markdown-it` (~80 KB gzip) or `prosemirror-tables` (~25 KB gzip) into the bundle — the consumer's bundler now code-splits them into separate chunks loaded on demand. Editors that enable neither still mount **synchronously** (no behavior change); only `markdown`/`tables` editors initialize asynchronously while their chunk loads (toolbar actions are briefly disabled and `bind:api` methods are no-ops until then).
 
+### Removed
+
+- **Editor** — Removed the unused `toolbarGroup` key from the `ui` slot type; it was computed but never rendered, so setting it had no effect.
+
 ### Fixed
 
+- **Editor** — Changing the `output` prop on an already-mounted editor no longer corrupts the content. `output` is read once at mount (it also decides whether the Markdown extension is loaded); it is now applied consistently to serialization, so a runtime change is simply ignored instead of producing a format/extension mismatch. Re-key the component (`{#key output}`) to switch formats.
 - **Editor** — The mention (`@`) and slash (`/`) autocomplete popups are now proper ARIA listboxes: each item exposes `role="option"` + `aria-selected`, the listbox has an accessible name, and while a popup is open the editor's contenteditable exposes `aria-controls`, `aria-expanded`, and `aria-activedescendant` (cleared on close) so screen readers announce the highlighted option as the user navigates.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Editor** — Halved the serialization work per keystroke: the value-sync effect no longer re-serializes the document to compare it against a value the editor itself just emitted (it short-circuits on its own echo). Previously every edit serialized twice — once to push `value`, then again in the sync effect to compare. Most noticeable for `output="markdown"` and large documents. No API or behavior change.
 - **Editor** — The heavy optional extensions are now lazy-loaded via dynamic `import()`: `tiptap-markdown` (only when `output="markdown"`) and the table packages (only when `tables` is enabled). Editors that don't use them no longer pull `markdown-it` (~80 KB gzip) or `prosemirror-tables` (~25 KB gzip) into the bundle — the consumer's bundler now code-splits them into separate chunks loaded on demand. Editors that enable neither still mount **synchronously** (no behavior change); only `markdown`/`tables` editors initialize asynchronously while their chunk loads (toolbar actions are briefly disabled and `bind:api` methods are no-ops until then).
 
 ## [2.0.0] - 2026-06-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Command** — Exported the `CommandGroup` and `CommandItem` types from the package entry, so consumers can type the `groups` data with full type-checking without importing from internal paths.
+- **Command** — `CommandProps` now type-checks `id` and `data-*` attributes on the root element (useful as a scoping/anchor target and for test/analytics hooks); previously these were rejected by the type even though `restProps` already reached the root.
+
 ## [2.0.0] - 2026-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Modal / Slideover / Drawer** — **BREAKING.** The trigger is no longer wrapped in an extra `<button>`. Previously the `children` snippet was rendered inside the component's own trigger button, so passing a `<Button>`/`<Link>` produced an invalid nested `<button>` inside `<button>` (an SSR `node_invalid_placement_ssr` hydration error that can escalate to a hard `The deferred DOM Node could not be resolved` failure). The `children` snippet now receives a `props` argument that you must spread onto your own focusable element, so the trigger ARIA and event handlers land on the real control. Migration:
+
+    ```svelte
+    <!-- Before -->
+    <Modal title="…">
+        <Button>Open</Button>
+    </Modal>
+
+    <!-- After -->
+    <Modal title="…">
+        {#snippet children({ props })}
+            <Button {...props}>Open</Button>
+        {/snippet}
+    </Modal>
+    ```
+
 ## [2.0.0] - 2026-06-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sv5ui",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "A modern Svelte 5 UI component library with Tailwind CSS",
     "author": "ndlabdev",
     "license": "MIT",

--- a/src/lib/Accordion/Accordion.svelte
+++ b/src/lib/Accordion/Accordion.svelte
@@ -53,7 +53,18 @@
 
     type SlotName = (typeof slotNames)[number]
 
+    const itemDefaults = $derived.by(() => {
+        const result = {} as Record<SlotName, string>
+        for (const slot of slotNames) {
+            result[slot] = variantSlots[slot]({ class: [config.slots[slot], ui?.[slot]] })
+        }
+        return result
+    })
+
     function getItemClasses(item: AccordionItem) {
+        if (!item.ui && item.class === undefined && item.disabled === undefined) {
+            return itemDefaults
+        }
         const result = {} as Record<SlotName, string>
         for (const slot of slotNames) {
             const baseClass = [

--- a/src/lib/Badge/badge.types.ts
+++ b/src/lib/Badge/badge.types.ts
@@ -20,7 +20,7 @@ export type BadgeProps = Omit<HTMLAttributes<HTMLSpanElement>, 'class'> & {
      * Override styles for specific badge slots.
      * Available slots: base, label, leadingIcon, trailingIcon, leadingAvatar.
      */
-    ui?: Partial<Record<BadgeSlots, ClassNameValue>>
+    ui?: Partial<Record<Exclude<BadgeSlots, 'leadingAvatarSize'>, ClassNameValue>>
 
     /**
      * Sets the text content displayed inside the badge.

--- a/src/lib/Calendar/Calendar.svelte
+++ b/src/lib/Calendar/Calendar.svelte
@@ -14,7 +14,7 @@
     import { calendarVariants, calendarDefaults } from './calendar.variants.js'
     import { getComponentConfig } from '../config.js'
     import Icon from '../Icon/Icon.svelte'
-    import type { DateValue } from '@internationalized/date'
+    import { type DateValue, today, getLocalTimeZone } from '@internationalized/date'
     import type { Month } from 'bits-ui'
     import { useFormField, useFormFieldEmit } from '../hooks/useFormField.svelte.js'
 
@@ -62,6 +62,19 @@
         weekDay: weekDaySlot,
         ...restProps
     }: Props = $props()
+
+    function firstDateOf(val: unknown): DateValue | undefined {
+        if (!val) return undefined
+        if (Array.isArray(val)) return val[0] as DateValue | undefined
+        if (typeof val === 'object' && 'start' in val) {
+            return (val as { start?: DateValue }).start
+        }
+        return val as DateValue
+    }
+
+    if (placeholder === undefined) {
+        placeholder = firstDateOf(value) ?? today(getLocalTimeZone())
+    }
 
     const formFieldContext = useFormField()
     const emit = useFormFieldEmit()

--- a/src/lib/Calendar/Calendar.svelte.spec.ts
+++ b/src/lib/Calendar/Calendar.svelte.spec.ts
@@ -222,6 +222,66 @@ describe('Calendar', () => {
                 expect(buttons.length).toBeGreaterThanOrEqual(4)
             })
         })
+
+        it('should advance the year when Next year is clicked (no placeholder provided)', async () => {
+            render(Calendar)
+            await vi.waitFor(() => expect(getHeading()).not.toBeNull())
+            const before = getHeading()!.textContent ?? ''
+            const yearBefore = Number(before.match(/\d{4}/)?.[0])
+            const nextYear = document.querySelector('[aria-label="Next year"]') as HTMLButtonElement
+            expect(nextYear).not.toBeNull()
+            nextYear.click()
+            await vi.waitFor(() => {
+                const yearAfter = Number((getHeading()!.textContent ?? '').match(/\d{4}/)?.[0])
+                expect(yearAfter).toBe(yearBefore + 1)
+            })
+        })
+
+        it('should go back a year when Previous year is clicked (no placeholder provided)', async () => {
+            render(Calendar)
+            await vi.waitFor(() => expect(getHeading()).not.toBeNull())
+            const yearBefore = Number((getHeading()!.textContent ?? '').match(/\d{4}/)?.[0])
+            const prevYear = document.querySelector(
+                '[aria-label="Previous year"]'
+            ) as HTMLButtonElement
+            expect(prevYear).not.toBeNull()
+            prevYear.click()
+            await vi.waitFor(() => {
+                const yearAfter = Number((getHeading()!.textContent ?? '').match(/\d{4}/)?.[0])
+                expect(yearAfter).toBe(yearBefore - 1)
+            })
+        })
+
+        it('should open on the value month when a value is provided without a placeholder', async () => {
+            render(Calendar, { value: new CalendarDate(2020, 1, 15) })
+            await vi.waitFor(() => {
+                const heading = getHeading()
+                expect(heading).not.toBeNull()
+                expect(heading!.textContent).toContain('January')
+                expect(heading!.textContent).toContain('2020')
+            })
+        })
+
+        it('should still navigate months when no placeholder is provided', async () => {
+            render(Calendar)
+            await vi.waitFor(() => expect(getHeading()).not.toBeNull())
+            const before = getHeading()!.textContent ?? ''
+            getNextButton()!.click()
+            await vi.waitFor(() => {
+                expect((getHeading()!.textContent ?? '') !== before).toBe(true)
+            })
+        })
+
+        it('should move to the value month when value is set after mount', async () => {
+            const screen = render(Calendar, {})
+            await vi.waitFor(() => expect(getHeading()).not.toBeNull())
+            await screen.rerender({ value: new CalendarDate(2019, 7, 4) })
+            await vi.waitFor(() => {
+                const heading = getHeading()!
+                expect(heading.textContent).toContain('July')
+                expect(heading.textContent).toContain('2019')
+            })
+        })
     })
 
     // ==================== DISABLED STATE ====================

--- a/src/lib/Collapsible/collapsible.types.ts
+++ b/src/lib/Collapsible/collapsible.types.ts
@@ -46,7 +46,7 @@ export interface CollapsibleProps
             | 'onblur'
         > {
     /** Custom data attributes are forwarded to the root element. */
-    [key: `data-${string}`]: unknown
+    [key: `data-${string}`]: string | number | boolean | null | undefined
 
     // -------------------------------------------------------------------------
     // Refs

--- a/src/lib/Command/Command.svelte.spec.ts
+++ b/src/lib/Command/Command.svelte.spec.ts
@@ -231,6 +231,21 @@ describe('Command', () => {
         })
     })
 
+    // ==================== ROOT ATTRIBUTES ====================
+
+    describe('root html attributes', () => {
+        it('should forward id and data-* attributes to the root element', () => {
+            render(CommandTestWrapper, {
+                groups: sampleGroups,
+                id: 'my-command',
+                'data-foo': 'bar'
+            })
+            const root = getRoot()!
+            expect(root.id).toBe('my-command')
+            expect(root.getAttribute('data-foo')).toBe('bar')
+        })
+    })
+
     // ==================== COMBINED ====================
 
     describe('combined', () => {

--- a/src/lib/Command/command.types.ts
+++ b/src/lib/Command/command.types.ts
@@ -81,7 +81,7 @@ export interface CommandProps
         >,
         Pick<CommandRootProps, 'id'> {
     /** Custom data attributes are forwarded to the root element. */
-    [key: `data-${string}`]: unknown
+    [key: `data-${string}`]: string | number | boolean | null | undefined
 
     // -------------------------------------------------------------------------
     // Refs

--- a/src/lib/Command/command.types.ts
+++ b/src/lib/Command/command.types.ts
@@ -1,6 +1,6 @@
 import type { Snippet } from 'svelte'
 import type { ClassNameValue } from 'tailwind-merge'
-import type { CommandRootPropsWithoutHTML } from 'bits-ui'
+import type { CommandRootProps, CommandRootPropsWithoutHTML } from 'bits-ui'
 import type { CommandSlots, CommandVariantProps } from './command.variants.js'
 
 // ============================================================================
@@ -73,10 +73,16 @@ export interface CommandItemSlotProps {
  *
  * @see https://bits-ui.com/docs/components/command
  */
-export interface CommandProps extends Pick<
-    CommandRootPropsWithoutHTML,
-    'value' | 'onValueChange' | 'filter' | 'shouldFilter' | 'loop' | 'vimBindings' | 'label'
-> {
+export interface CommandProps
+    extends
+        Pick<
+            CommandRootPropsWithoutHTML,
+            'value' | 'onValueChange' | 'filter' | 'shouldFilter' | 'loop' | 'vimBindings' | 'label'
+        >,
+        Pick<CommandRootProps, 'id'> {
+    /** Custom data attributes are forwarded to the root element. */
+    [key: `data-${string}`]: unknown
+
     // -------------------------------------------------------------------------
     // Refs
     // -------------------------------------------------------------------------

--- a/src/lib/Command/index.ts
+++ b/src/lib/Command/index.ts
@@ -1,2 +1,2 @@
 export { default as Command } from './Command.svelte'
-export type { CommandProps } from './command.types.js'
+export type { CommandProps, CommandGroup, CommandItem } from './command.types.js'

--- a/src/lib/ContextMenu/ContextMenu.svelte
+++ b/src/lib/ContextMenu/ContextMenu.svelte
@@ -329,7 +329,7 @@
 
 <ContextMenu.Root bind:open {onOpenChange}>
     {#if children}
-        <ContextMenu.Trigger class={className as string}>
+        <ContextMenu.Trigger class={[className]}>
             {@render children({ open })}
         </ContextMenu.Trigger>
     {/if}

--- a/src/lib/Drawer/Drawer.svelte
+++ b/src/lib/Drawer/Drawer.svelte
@@ -177,8 +177,10 @@
 
 {#snippet drawerBody()}
     {#if children}
-        <Drawer.Trigger class={className as string}>
-            {@render children()}
+        <Drawer.Trigger>
+            {#snippet child({ props })}
+                {@render children({ props })}
+            {/snippet}
         </Drawer.Trigger>
     {/if}
 

--- a/src/lib/Drawer/Drawer.svelte.spec.ts
+++ b/src/lib/Drawer/Drawer.svelte.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-svelte'
 import { page } from 'vitest/browser'
 import Drawer from './Drawer.svelte'
+import DrawerTriggerTestWrapper from './DrawerTriggerTestWrapper.svelte'
 
 describe('Drawer', () => {
     // Helper: query inside the portal (document.body) since Drawer portals its content
@@ -725,6 +726,21 @@ describe('Drawer', () => {
             } finally {
                 el.remove()
             }
+        })
+    })
+
+    describe('trigger', () => {
+        it('forwards trigger props to the caller element without nesting a button', async () => {
+            const { container } = render(DrawerTriggerTestWrapper)
+            const btn = container.querySelector('[data-testid="trigger"]') as HTMLButtonElement
+            expect(btn).not.toBeNull()
+            expect(btn.tagName).toBe('BUTTON')
+            expect(btn.querySelector('button')).toBeNull()
+            expect(btn.getAttribute('data-state')).toBe('closed')
+            btn.click()
+            await vi.waitFor(() => {
+                expect(btn.getAttribute('data-state')).toBe('open')
+            })
         })
     })
 })

--- a/src/lib/Drawer/DrawerTriggerTestWrapper.svelte
+++ b/src/lib/Drawer/DrawerTriggerTestWrapper.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+    import Drawer from './Drawer.svelte'
+</script>
+
+<Drawer>
+    {#snippet children({ props })}
+        <button data-testid="trigger" {...props}>Open</button>
+    {/snippet}
+    {#snippet content()}<p>Body</p>{/snippet}
+</Drawer>

--- a/src/lib/Drawer/drawer.types.ts
+++ b/src/lib/Drawer/drawer.types.ts
@@ -86,9 +86,18 @@ export type DrawerProps = VaulRootProps & {
     class?: ClassNameValue
 
     /**
-     * Default slot renders the trigger element.
+     * Trigger content. Spread the provided `props` onto your own focusable
+     * element (e.g. a `<Button>`) so the drawer's trigger ARIA and event
+     * handlers land on the real control instead of a nested wrapper button.
+     *
+     * @example
+     * ```svelte
+     * {#snippet children({ props })}
+     *   <Button {...props}>Open</Button>
+     * {/snippet}
+     * ```
      */
-    children?: Snippet
+    children?: Snippet<[{ props: Record<string, unknown> }]>
 
     /**
      * Custom content slot (replaces default layout with header/body/footer).

--- a/src/lib/Editor/Editor.svelte
+++ b/src/lib/Editor/Editor.svelte
@@ -245,10 +245,6 @@
     $effect(() => {
         if (!contentElement) return
 
-        // Untrack: these props would otherwise cause editor recreation on every
-        // keystroke (value changes via onUpdate → effect re-runs → destroy + rebuild
-        // → cursor lost → can only type 1 char). value sync is handled by a
-        // dedicated effect below; disabled/readonly toggle via setEditable.
         const initialContent = untrack(() => value ?? '')
         const initialEditable = untrack(() => !disabled && !readonly)
         const initialAutofocus = untrack(() => autofocus)
@@ -321,9 +317,6 @@
         }
     })
 
-    // Sync aria attributes on the ProseMirror element when error/id state changes.
-    // Tiptap's editorProps.attributes is read once at init, so toggling needs
-    // direct DOM access. Run on every state change.
     $effect(() => {
         if (!contentElement) return
         const pm = contentElement.querySelector('.ProseMirror') as HTMLElement | null
@@ -421,7 +414,6 @@
         }
     })
 
-    // ----- URL prompt modal (shared by YouTube/Image/Link toolbar + slash) -----
     interface UrlPromptState {
         open: boolean
         title: string
@@ -465,7 +457,6 @@
         }
     }
 
-    // ----- Image upload via hidden file input -----
     let fileInput: HTMLInputElement | null = $state(null)
 
     async function handleFileSelected(event: Event): Promise<void> {
@@ -537,7 +528,6 @@
         })
     }
 
-    // ----- Table dimension picker -----
     let tableMenuOpen = $state(false)
     let tablePickerRows = $state(0)
     let tablePickerCols = $state(0)

--- a/src/lib/Editor/Editor.svelte
+++ b/src/lib/Editor/Editor.svelte
@@ -228,6 +228,7 @@
     }
 
     let suppressUpdate = false
+    let lastEmitted: string | EditorJSON | undefined
 
     $effect(() => {
         if (!contentElement) return
@@ -267,6 +268,7 @@
                     syncState(e)
                     if (suppressUpdate) return
                     const serialized = serialize(e)
+                    lastEmitted = serialized
                     value = serialized
                     emit.onInput()
                     onValueChange?.(serialized)
@@ -324,6 +326,7 @@
     $effect(() => {
         if (!editor) return
         if (value === undefined) return
+        if (typeof value === 'string' && value === lastEmitted) return
         const current = serialize(editor)
         if (isContentEqual(current, value)) return
         suppressUpdate = true

--- a/src/lib/Editor/Editor.svelte
+++ b/src/lib/Editor/Editor.svelte
@@ -58,6 +58,7 @@
         markdownAllowHtml = false,
         image = false,
         onImageUpload,
+        onImageUploadError,
         tables = false,
         onMention,
         mentionTrigger = '@',
@@ -81,6 +82,14 @@
 
     const formFieldContext = useFormField()
     const emit = useFormFieldEmit()
+
+    const resolvedOutput = untrack(() => output)
+
+    function getMarkdownStorage(ed: Editor): { getMarkdown?: () => string } | undefined {
+        return (ed.storage as unknown as Record<string, unknown>).markdown as
+            | { getMarkdown?: () => string }
+            | undefined
+    }
 
     const hasError = $derived(
         formFieldContext?.error !== undefined && formFieldContext?.error !== false
@@ -148,11 +157,9 @@
     }
 
     function serialize(ed: Editor): string | EditorJSON {
-        if (output === 'json') return ed.getJSON() as EditorJSON
-        if (output === 'markdown') {
-            const md = (ed.storage as unknown as Record<string, unknown>).markdown as
-                | { getMarkdown?: () => string }
-                | undefined
+        if (resolvedOutput === 'json') return ed.getJSON() as EditorJSON
+        if (resolvedOutput === 'markdown') {
+            const md = getMarkdownStorage(ed)
             if (md && typeof md.getMarkdown === 'function') {
                 return md.getMarkdown()
             }
@@ -208,7 +215,7 @@
             tables,
             youtube,
             dragHandle,
-            markdown: output === 'markdown',
+            markdown: resolvedOutput === 'markdown',
             markdownAllowHtml,
             mentionTrigger,
             mentionSuggestion: onMention
@@ -355,13 +362,11 @@
             TOOLBAR_ACTIONS[action].run(editor)
         },
         getValue(format) {
-            if (!editor) return output === 'json' ? ({} as EditorJSON) : ''
-            const fmt = format ?? output
+            if (!editor) return resolvedOutput === 'json' ? ({} as EditorJSON) : ''
+            const fmt = format ?? resolvedOutput
             if (fmt === 'json') return editor.getJSON() as EditorJSON
             if (fmt === 'markdown') {
-                const md = (editor.storage as unknown as Record<string, unknown>).markdown as
-                    | { getMarkdown?: () => string }
-                    | undefined
+                const md = getMarkdownStorage(editor)
                 if (md && typeof md.getMarkdown === 'function') return md.getMarkdown()
                 return editor.getHTML()
             }
@@ -405,7 +410,6 @@
         return {
             root: slots.root({ class: [c.root, className, u.root] }),
             toolbar: slots.toolbar({ class: [c.toolbar, u.toolbar] }),
-            toolbarGroup: slots.toolbarGroup({ class: [c.toolbarGroup, u.toolbarGroup] }),
             toolbarButton: slots.toolbarButton({ class: [c.toolbarButton, u.toolbarButton] }),
             toolbarSeparator: slots.toolbarSeparator({
                 class: [c.toolbarSeparator, u.toolbarSeparator]
@@ -480,8 +484,12 @@
             }
             editor.chain().focus().setImage({ src: url }).run()
         } catch (err) {
-            // eslint-disable-next-line no-console
-            console.error('[Editor] image upload failed', err)
+            if (onImageUploadError) {
+                onImageUploadError(err)
+            } else {
+                // eslint-disable-next-line no-console
+                console.error('[Editor] image upload failed', err)
+            }
         }
     }
 

--- a/src/lib/Editor/Editor.svelte
+++ b/src/lib/Editor/Editor.svelte
@@ -24,7 +24,12 @@
     import Icon from '../Icon/Icon.svelte'
     import Tooltip from '../Tooltip/Tooltip.svelte'
     import EditorUrlPrompt from './EditorUrlPrompt.svelte'
-    import { httpUrlSchema, youtubeUrlSchema, type UrlSchema } from './editor.schemas.js'
+    import {
+        httpUrlSchema,
+        youtubeUrlSchema,
+        isSafeImageSrc,
+        type UrlSchema
+    } from './editor.schemas.js'
 
     const config = getComponentConfig('editor', editorDefaults)
 
@@ -468,6 +473,11 @@
         if (!onImageUpload) return
         try {
             const url = await onImageUpload(file)
+            if (!isSafeImageSrc(url)) {
+                // eslint-disable-next-line no-console
+                console.warn('[Editor] blocked unsafe image src from onImageUpload:', url)
+                return
+            }
             editor.chain().focus().setImage({ src: url }).run()
         } catch (err) {
             // eslint-disable-next-line no-console

--- a/src/lib/Editor/Editor.svelte
+++ b/src/lib/Editor/Editor.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <script lang="ts">
-    import { Editor } from '@tiptap/core'
+    import { Editor, type AnyExtension } from '@tiptap/core'
     import BubbleMenuExt from '@tiptap/extension-bubble-menu'
     import { untrack } from 'svelte'
     import { editorVariants, editorDefaults } from './editor.variants.js'
@@ -191,7 +191,7 @@
         })
     }
 
-    function resolveExtensions() {
+    function resolveExtensions(): AnyExtension[] | Promise<AnyExtension[]> {
         if (extensionsOverride) return extensionsOverride
         return buildExtensions({
             headingLevels,
@@ -245,43 +245,56 @@
             ...(ariaDescribedBy ? { 'aria-describedby': ariaDescribedBy } : {}),
             ...(hasError ? { 'aria-invalid': 'true' } : {})
         }))
-        const exts = untrack(() => resolveExtensions())
+        const el = contentElement
+        const result = untrack(() => resolveExtensions())
 
-        const ed = new Editor({
-            element: contentElement,
-            extensions: exts,
-            content: initialContent,
-            editable: initialEditable,
-            autofocus: initialAutofocus,
-            editorProps: {
-                attributes: initialAttrs as Record<string, string>
-            },
-            onCreate: ({ editor: e }) => syncState(e),
-            onUpdate: ({ editor: e }) => {
-                syncState(e)
-                if (suppressUpdate) return
-                const serialized = serialize(e)
-                value = serialized
-                emit.onInput()
-                onValueChange?.(serialized)
-            },
-            onSelectionUpdate: ({ editor: e }) => syncState(e),
-            onFocus: ({ editor: e }) => {
-                syncState(e)
-                emit.onFocus()
-                onFocus?.()
-            },
-            onBlur: ({ editor: e }) => {
-                syncState(e)
-                emit.onBlur()
-                onBlur?.()
-            }
-        })
+        let ed: Editor | null = null
+        let cancelled = false
 
-        editor = ed
+        const create = (exts: AnyExtension[]) => {
+            if (cancelled) return
+            ed = new Editor({
+                element: el,
+                extensions: exts,
+                content: initialContent,
+                editable: initialEditable,
+                autofocus: initialAutofocus,
+                editorProps: {
+                    attributes: initialAttrs as Record<string, string>
+                },
+                onCreate: ({ editor: e }) => syncState(e),
+                onUpdate: ({ editor: e }) => {
+                    syncState(e)
+                    if (suppressUpdate) return
+                    const serialized = serialize(e)
+                    value = serialized
+                    emit.onInput()
+                    onValueChange?.(serialized)
+                },
+                onSelectionUpdate: ({ editor: e }) => syncState(e),
+                onFocus: ({ editor: e }) => {
+                    syncState(e)
+                    emit.onFocus()
+                    onFocus?.()
+                },
+                onBlur: ({ editor: e }) => {
+                    syncState(e)
+                    emit.onBlur()
+                    onBlur?.()
+                }
+            })
+            editor = ed
+        }
+
+        if (result instanceof Promise) {
+            result.then(create)
+        } else {
+            create(result)
+        }
 
         return () => {
-            ed.destroy()
+            cancelled = true
+            ed?.destroy()
             editor = null
         }
     })

--- a/src/lib/Editor/Editor.svelte.spec.ts
+++ b/src/lib/Editor/Editor.svelte.spec.ts
@@ -795,4 +795,96 @@ describe('Editor', () => {
             })
         })
     })
+
+    // ==================== POPUP ACCESSIBILITY ====================
+
+    describe('popup accessibility', () => {
+        it('slash popup exposes role=option, aria-selected, and editor aria-activedescendant', async () => {
+            let api: EditorApi | undefined
+            const { container } = render(Editor, {
+                slash: true,
+                get api() {
+                    return api
+                },
+                set api(v: EditorApi | undefined) {
+                    api = v
+                }
+            })
+            await vi.waitFor(() => expect(api?.editor).not.toBeNull())
+
+            api!.editor!.chain().focus().insertContent('/').run()
+
+            const popup = await vi.waitFor(() => {
+                const el = document.querySelector('[data-editor-slash-popup]')
+                expect(el).not.toBeNull()
+                return el as HTMLElement
+            })
+
+            const options = popup.querySelectorAll('[role="option"]')
+            expect(options.length).toBeGreaterThan(0)
+
+            const selected = popup.querySelectorAll('[role="option"][aria-selected="true"]')
+            expect(selected.length).toBe(1)
+
+            expect(popup.getAttribute('aria-label')).toBe('Slash commands')
+            expect(popup.id).not.toBe('')
+
+            const pm = getProseMirror(container)!
+            expect(pm.getAttribute('aria-controls')).toBe(popup.id)
+            expect(pm.getAttribute('aria-expanded')).toBe('true')
+
+            const activeId = pm.getAttribute('aria-activedescendant')
+            expect(activeId).toBeTruthy()
+            expect(popup.querySelector(`#${activeId}`)).not.toBeNull()
+            expect(popup.querySelector(`#${activeId}`)?.getAttribute('aria-selected')).toBe('true')
+        })
+
+        it('mention popup exposes role=option, aria-selected, and editor aria-activedescendant', async () => {
+            let api: EditorApi | undefined
+            const { container } = render(Editor, {
+                onMention: async () => [
+                    { id: 'alice', label: 'Alice' },
+                    { id: 'bob', label: 'Bob' }
+                ],
+                get api() {
+                    return api
+                },
+                set api(v: EditorApi | undefined) {
+                    api = v
+                }
+            })
+            await vi.waitFor(() => expect(api?.editor).not.toBeNull())
+
+            api!.editor!.chain().focus().insertContent('@').run()
+
+            const popup = await vi.waitFor(() => {
+                const el = document.querySelector('[data-editor-mention-popup]')
+                expect(el).not.toBeNull()
+                const list = (el as HTMLElement).querySelector('[role="listbox"]')
+                expect(list?.querySelectorAll('[role="option"]').length).toBeGreaterThan(0)
+                return el as HTMLElement
+            })
+
+            const listbox = popup.querySelector('[role="listbox"]') as HTMLElement
+            expect(listbox.getAttribute('aria-label')).toBe('Mentions')
+            expect(listbox.id).not.toBe('')
+
+            const options = listbox.querySelectorAll('[role="option"]')
+            expect(options.length).toBe(2)
+
+            const selected = listbox.querySelectorAll('[role="option"][aria-selected="true"]')
+            expect(selected.length).toBe(1)
+
+            const pm = getProseMirror(container)!
+            expect(pm.getAttribute('aria-controls')).toBe(listbox.id)
+            expect(pm.getAttribute('aria-expanded')).toBe('true')
+
+            const activeId = pm.getAttribute('aria-activedescendant')
+            expect(activeId).toBeTruthy()
+            expect(listbox.querySelector(`#${activeId}`)).not.toBeNull()
+            expect(listbox.querySelector(`#${activeId}`)?.getAttribute('aria-selected')).toBe(
+                'true'
+            )
+        })
+    })
 })

--- a/src/lib/Editor/Editor.svelte.spec.ts
+++ b/src/lib/Editor/Editor.svelte.spec.ts
@@ -463,6 +463,39 @@ describe('Editor', () => {
                 expect(btn).not.toBeNull()
             })
         })
+
+        const selectFile = (container: Element) => {
+            const input = container.querySelector('[data-editor-image-input]') as HTMLInputElement
+            const dt = new DataTransfer()
+            dt.items.add(new File(['x'], 'x.png', { type: 'image/png' }))
+            input.files = dt.files
+            input.dispatchEvent(new Event('change', { bubbles: true }))
+        }
+
+        it('blocks an unsafe image src returned by onImageUpload', async () => {
+            const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+            const { container } = render(Editor, {
+                image: true,
+                onImageUpload: async () => 'javascript:alert(1)'
+            })
+            await vi.waitFor(() => expect(container.querySelector('.ProseMirror')).not.toBeNull())
+            selectFile(container)
+            await vi.waitFor(() => expect(warn).toHaveBeenCalled())
+            expect(container.querySelector('img')).toBeNull()
+            warn.mockRestore()
+        })
+
+        it('inserts an image for a safe https src from onImageUpload', async () => {
+            const { container } = render(Editor, {
+                image: true,
+                onImageUpload: async () => 'https://example.com/a.png'
+            })
+            await vi.waitFor(() => expect(container.querySelector('.ProseMirror')).not.toBeNull())
+            selectFile(container)
+            await vi.waitFor(() => {
+                expect(container.querySelector('img')).not.toBeNull()
+            })
+        })
     })
 
     // ==================== PHASE 2: TABLES ====================

--- a/src/lib/Editor/Editor.svelte.spec.ts
+++ b/src/lib/Editor/Editor.svelte.spec.ts
@@ -116,6 +116,28 @@ describe('Editor', () => {
                 expect(getProseMirror(container)?.textContent).toContain('From JSON')
             })
         })
+
+        it('applies an external value change after the editor has emitted (echo-dedup stays correct)', async () => {
+            let api: EditorApi | undefined
+            const screen = render(Editor, {
+                value: '<p>start</p>',
+                get api() {
+                    return api
+                },
+                set api(v: EditorApi | undefined) {
+                    api = v
+                }
+            })
+            await vi.waitFor(() => expect(api?.editor).not.toBeNull())
+            api!.insert(' edited')
+            await vi.waitFor(() => {
+                expect(getProseMirror(screen.container)?.textContent).toContain('edited')
+            })
+            await screen.rerender({ value: '<p>external</p>' })
+            await vi.waitFor(() => {
+                expect(getProseMirror(screen.container)?.textContent).toContain('external')
+            })
+        })
     })
 
     // ==================== EDITABILITY ====================

--- a/src/lib/Editor/Editor.svelte.spec.ts
+++ b/src/lib/Editor/Editor.svelte.spec.ts
@@ -138,6 +138,24 @@ describe('Editor', () => {
                 expect(getProseMirror(screen.container)?.textContent).toContain('external')
             })
         })
+
+        it('treats output as fixed at mount (changing the prop later has no effect)', async () => {
+            let api: EditorApi | undefined
+            const screen = render(Editor, {
+                output: 'html',
+                value: '<p>hi</p>',
+                get api() {
+                    return api
+                },
+                set api(v: EditorApi | undefined) {
+                    api = v
+                }
+            })
+            await vi.waitFor(() => expect(api?.editor).not.toBeNull())
+            expect(typeof api!.getValue()).toBe('string')
+            await screen.rerender({ output: 'json', value: '<p>hi</p>' })
+            expect(typeof api!.getValue()).toBe('string')
+        })
     })
 
     // ==================== EDITABILITY ====================
@@ -495,6 +513,20 @@ describe('Editor', () => {
             await vi.waitFor(() => {
                 expect(container.querySelector('img')).not.toBeNull()
             })
+        })
+
+        it('calls onImageUploadError when the upload rejects', async () => {
+            const onImageUploadError = vi.fn()
+            const { container } = render(Editor, {
+                image: true,
+                onImageUpload: async () => {
+                    throw new Error('upload failed')
+                },
+                onImageUploadError
+            })
+            await vi.waitFor(() => expect(container.querySelector('.ProseMirror')).not.toBeNull())
+            selectFile(container)
+            await vi.waitFor(() => expect(onImageUploadError).toHaveBeenCalled())
         })
     })
 

--- a/src/lib/Editor/Editor.svelte.spec.ts
+++ b/src/lib/Editor/Editor.svelte.spec.ts
@@ -457,7 +457,12 @@ describe('Editor', () => {
         it('clicking table button opens dimension picker', async () => {
             const { container } = render(Editor, { tables: true, toolbar: ['table'] })
             await vi.waitFor(() => {
-                expect(container.querySelector('button[data-action="table"]')).not.toBeNull()
+                expect(container.querySelector('.ProseMirror')).not.toBeNull()
+                const btn = container.querySelector(
+                    'button[data-action="table"]'
+                ) as HTMLButtonElement | null
+                expect(btn).not.toBeNull()
+                expect(btn!.disabled).toBe(false)
             })
             const btn = container.querySelector('button[data-action="table"]') as HTMLButtonElement
             await btn.click()
@@ -469,7 +474,12 @@ describe('Editor', () => {
         it('clicking a dimension cell button inserts a table (UI flow)', async () => {
             const { container } = render(Editor, { tables: true, toolbar: ['table'] })
             await vi.waitFor(() => {
-                expect(container.querySelector('button[data-action="table"]')).not.toBeNull()
+                expect(container.querySelector('.ProseMirror')).not.toBeNull()
+                const btn = container.querySelector(
+                    'button[data-action="table"]'
+                ) as HTMLButtonElement | null
+                expect(btn).not.toBeNull()
+                expect(btn!.disabled).toBe(false)
             })
             const tableBtn = container.querySelector(
                 'button[data-action="table"]'
@@ -702,6 +712,31 @@ describe('Editor', () => {
             })
             await vi.waitFor(() => {
                 expect(getContent(container)?.className).toContain('custom-content-cls')
+            })
+        })
+    })
+
+    // ==================== LAZY EXTENSION LOADING ====================
+
+    describe('lazy extension loading', () => {
+        it('mounts synchronously when no lazy feature (markdown/tables) is enabled', () => {
+            const { container } = render(Editor, { toolbar: ['bold'] })
+            expect(container.querySelector('.ProseMirror')).not.toBeNull()
+        })
+
+        it('mounts asynchronously when tables are enabled (lazy chunk)', async () => {
+            const { container } = render(Editor, { tables: true })
+            expect(container.querySelector('.ProseMirror')).toBeNull()
+            await vi.waitFor(() => {
+                expect(container.querySelector('.ProseMirror')).not.toBeNull()
+            })
+        })
+
+        it('mounts asynchronously for markdown output (lazy chunk)', async () => {
+            const { container } = render(Editor, { output: 'markdown' })
+            expect(container.querySelector('.ProseMirror')).toBeNull()
+            await vi.waitFor(() => {
+                expect(container.querySelector('.ProseMirror')).not.toBeNull()
             })
         })
     })

--- a/src/lib/Editor/SlashPopup.svelte
+++ b/src/lib/Editor/SlashPopup.svelte
@@ -6,9 +6,11 @@
         items: SlashCommand[]
         selectedIndex: number
         onPick: (index: number) => void
+        listboxId: string
+        optionIdPrefix: string
     }
 
-    let { items, selectedIndex, onPick }: Props = $props()
+    let { items, selectedIndex, onPick, listboxId, optionIdPrefix }: Props = $props()
 
     let listEl: HTMLDivElement | null = $state(null)
 
@@ -24,7 +26,9 @@
 
 <div
     bind:this={listEl}
+    id={listboxId}
     role="listbox"
+    aria-label="Slash commands"
     data-editor-slash-popup
     class="max-h-72 max-w-80 min-w-64 overflow-y-auto rounded-lg border border-outline-variant bg-surface py-1 shadow-lg"
 >
@@ -35,6 +39,9 @@
             {@const active = i === selectedIndex}
             <button
                 type="button"
+                role="option"
+                id={`${optionIdPrefix}${i}`}
+                aria-selected={active}
                 data-slash-item
                 data-id={cmd.id}
                 data-index={i}

--- a/src/lib/Editor/editor.extensions.ts
+++ b/src/lib/Editor/editor.extensions.ts
@@ -6,11 +6,6 @@ import Typography from '@tiptap/extension-typography'
 import CharacterCount from '@tiptap/extension-character-count'
 import Image from '@tiptap/extension-image'
 import Mention from '@tiptap/extension-mention'
-import { Table } from '@tiptap/extension-table'
-import { TableRow } from '@tiptap/extension-table-row'
-import { TableCell } from '@tiptap/extension-table-cell'
-import { TableHeader } from '@tiptap/extension-table-header'
-import { Markdown } from 'tiptap-markdown'
 import Youtube from '@tiptap/extension-youtube'
 import { DragHandle } from '@tiptap/extension-drag-handle'
 import type { SuggestionOptions } from '@tiptap/suggestion'
@@ -68,7 +63,13 @@ function buildImageExt(): AnyExtension {
     })
 }
 
-function buildTableExts(): AnyExtension[] {
+async function buildTableExts(): Promise<AnyExtension[]> {
+    const [{ Table }, { TableRow }, { TableCell }, { TableHeader }] = await Promise.all([
+        import('@tiptap/extension-table'),
+        import('@tiptap/extension-table-row'),
+        import('@tiptap/extension-table-cell'),
+        import('@tiptap/extension-table-header')
+    ])
     return [
         Table.configure({
             resizable: true,
@@ -80,7 +81,8 @@ function buildTableExts(): AnyExtension[] {
     ]
 }
 
-function buildMarkdownExt(allowHtml: boolean): AnyExtension {
+async function buildMarkdownExt(allowHtml: boolean): Promise<AnyExtension> {
+    const { Markdown } = await import('tiptap-markdown')
     return Markdown.configure({
         html: allowHtml,
         tightLists: true,
@@ -133,7 +135,8 @@ function buildDragHandleExt(): AnyExtension {
     })
 }
 
-type OptionalBuilder = (o: BuildExtensionsOptions) => AnyExtension | AnyExtension[] | null
+type OptionalBuilderResult = AnyExtension | AnyExtension[] | Promise<AnyExtension | AnyExtension[]>
+type OptionalBuilder = (o: BuildExtensionsOptions) => OptionalBuilderResult | null
 
 const OPTIONAL_BUILDERS: OptionalBuilder[] = [
     (o) => (o.placeholder ? Placeholder.configure({ placeholder: o.placeholder }) : null),
@@ -150,17 +153,28 @@ const OPTIONAL_BUILDERS: OptionalBuilder[] = [
     (o) => (o.dragHandle ? buildDragHandleExt() : null)
 ]
 
-function collectOptionalExts(options: BuildExtensionsOptions): AnyExtension[] {
-    const acc: AnyExtension[] = []
+function collectOptionalExts(
+    options: BuildExtensionsOptions
+): AnyExtension[] | Promise<AnyExtension[]> {
+    const sync: AnyExtension[] = []
+    const lazy: Promise<AnyExtension | AnyExtension[]>[] = []
     for (const build of OPTIONAL_BUILDERS) {
         const result = build(options)
-        if (result === null) continue
-        if (Array.isArray(result)) acc.push(...result)
-        else acc.push(result)
+        if (result === null || result === undefined) continue
+        if (result instanceof Promise) lazy.push(result)
+        else if (Array.isArray(result)) sync.push(...result)
+        else sync.push(result)
     }
-    return acc
+    if (lazy.length === 0) return sync
+    return Promise.all(lazy).then((resolved) => [...sync, ...resolved.flat()])
 }
 
-export function buildExtensions(options: BuildExtensionsOptions = {}): AnyExtension[] {
-    return [...buildCore(options), ...collectOptionalExts(options), ...(options.extra ?? [])]
+export function buildExtensions(
+    options: BuildExtensionsOptions = {}
+): AnyExtension[] | Promise<AnyExtension[]> {
+    const optional = collectOptionalExts(options)
+    if (optional instanceof Promise) {
+        return optional.then((opt) => [...buildCore(options), ...opt, ...(options.extra ?? [])])
+    }
+    return [...buildCore(options), ...optional, ...(options.extra ?? [])]
 }

--- a/src/lib/Editor/editor.extensions.ts
+++ b/src/lib/Editor/editor.extensions.ts
@@ -112,8 +112,6 @@ function buildYoutubeExt(): AnyExtension {
     })
 }
 
-// lucide:grip-vertical inline SVG. Used directly because @iconify/svelte
-// component would need to be mounted via Svelte; this is a vanilla DOM helper.
 const GRIP_VERTICAL_SVG =
     '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="9" cy="5" r="1"/><circle cx="9" cy="12" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="19" r="1"/></svg>'
 

--- a/src/lib/Editor/editor.schemas.spec.ts
+++ b/src/lib/Editor/editor.schemas.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { isSafeImageSrc } from './editor.schemas.js'
+
+describe('isSafeImageSrc', () => {
+    it('allows http(s) and relative/protocol-relative urls', () => {
+        expect(isSafeImageSrc('https://example.com/a.png')).toBe(true)
+        expect(isSafeImageSrc('http://example.com/a.png')).toBe(true)
+        expect(isSafeImageSrc('/uploads/a.png')).toBe(true)
+        expect(isSafeImageSrc('./a.png')).toBe(true)
+        expect(isSafeImageSrc('../a.png')).toBe(true)
+        expect(isSafeImageSrc('a.png')).toBe(true)
+        expect(isSafeImageSrc('//cdn.example.com/a.png')).toBe(true)
+    })
+
+    it('allows raster data:image URIs', () => {
+        expect(isSafeImageSrc('data:image/png;base64,iVBORw0KGgo=')).toBe(true)
+        expect(isSafeImageSrc('data:image/jpeg;base64,/9j/4AAQ')).toBe(true)
+        expect(isSafeImageSrc('data:image/gif;base64,R0lGOD')).toBe(true)
+        expect(isSafeImageSrc('data:image/webp;base64,UklGR')).toBe(true)
+    })
+
+    it('blocks dangerous schemes (case/space-insensitive)', () => {
+        expect(isSafeImageSrc('javascript:alert(1)')).toBe(false)
+        expect(isSafeImageSrc('  JavaScript:alert(1)')).toBe(false)
+        expect(isSafeImageSrc('vbscript:msgbox(1)')).toBe(false)
+        expect(isSafeImageSrc('file:///etc/passwd')).toBe(false)
+    })
+
+    it('blocks svg and non-image data: URIs', () => {
+        expect(isSafeImageSrc('data:image/svg+xml,<svg onload=alert(1)>')).toBe(false)
+        expect(isSafeImageSrc('data:image/svg+xml;base64,PHN2Zz4=')).toBe(false)
+        expect(isSafeImageSrc('data:text/html,<script>alert(1)</script>')).toBe(false)
+    })
+
+    it('rejects empty input', () => {
+        expect(isSafeImageSrc('')).toBe(false)
+        expect(isSafeImageSrc('   ')).toBe(false)
+    })
+
+    it('resists control-character and embedded-newline scheme bypasses', () => {
+        const ctrl = String.fromCharCode(1)
+        expect(isSafeImageSrc(ctrl + 'javascript:alert(1)')).toBe(false)
+        expect(isSafeImageSrc(ctrl + 'data:image/svg+xml,<svg onload=alert(1)>')).toBe(false)
+        expect(isSafeImageSrc('java\nscript:alert(1)')).toBe(false)
+        expect(isSafeImageSrc('\tvbscript:x')).toBe(false)
+        expect(isSafeImageSrc('  https://example.com/a.png  ')).toBe(true)
+    })
+})

--- a/src/lib/Editor/editor.schemas.ts
+++ b/src/lib/Editor/editor.schemas.ts
@@ -11,17 +11,6 @@ export const httpUrlSchema: UrlSchema = v.pipe(
     v.regex(/^https?:\/\//i, 'URL must start with http:// or https://')
 )
 
-/**
- * Whether a string is safe to use as an `<img src>`. Allows relative URLs,
- * `http`/`https`, and raster `data:image/*` URIs; blocks `javascript:`,
- * `vbscript:`, `data:text/*`, and `data:image/svg+xml` (SVG can execute script).
- *
- * The input is first normalized the way the WHATWG URL parser does — tab/CR/LF
- * are removed and leading/trailing control characters and spaces (code point
- * <= 0x20) are stripped — so prefixed/embedded-control bypasses (a leading
- * control byte before `javascript:`, or `java\nscript:`) cannot slip past the
- * scheme check.
- */
 function normalizeUrl(src: string): string {
     const s = src.replace(/[\t\n\r]/g, '')
     let start = 0

--- a/src/lib/Editor/editor.schemas.ts
+++ b/src/lib/Editor/editor.schemas.ts
@@ -11,6 +11,40 @@ export const httpUrlSchema: UrlSchema = v.pipe(
     v.regex(/^https?:\/\//i, 'URL must start with http:// or https://')
 )
 
+/**
+ * Whether a string is safe to use as an `<img src>`. Allows relative URLs,
+ * `http`/`https`, and raster `data:image/*` URIs; blocks `javascript:`,
+ * `vbscript:`, `data:text/*`, and `data:image/svg+xml` (SVG can execute script).
+ *
+ * The input is first normalized the way the WHATWG URL parser does — tab/CR/LF
+ * are removed and leading/trailing control characters and spaces (code point
+ * <= 0x20) are stripped — so prefixed/embedded-control bypasses (a leading
+ * control byte before `javascript:`, or `java\nscript:`) cannot slip past the
+ * scheme check.
+ */
+function normalizeUrl(src: string): string {
+    const s = src.replace(/[\t\n\r]/g, '')
+    let start = 0
+    let end = s.length
+    while (start < end && s.charCodeAt(start) <= 0x20) start++
+    while (end > start && s.charCodeAt(end - 1) <= 0x20) end--
+    return s.slice(start, end)
+}
+
+export function isSafeImageSrc(src: string): boolean {
+    const s = normalizeUrl(src)
+    if (!s) return false
+    const scheme = /^([a-z][a-z0-9+.-]*):/i.exec(s)?.[1]?.toLowerCase()
+    if (!scheme) return true
+    if (scheme === 'http' || scheme === 'https') return true
+    if (scheme === 'data') {
+        return /^data:image\/(?:png|jpe?g|gif|webp|avif|bmp|x-icon|vnd\.microsoft\.icon)[;,]/i.test(
+            s
+        )
+    }
+    return false
+}
+
 export const youtubeUrlSchema: UrlSchema = v.pipe(
     v.string(),
     v.trim(),

--- a/src/lib/Editor/editor.slash.svelte.ts
+++ b/src/lib/Editor/editor.slash.svelte.ts
@@ -20,11 +20,6 @@ interface SlashCommandsContext {
     image?: boolean
     tables?: boolean
     youtube?: boolean
-    /**
-     * Override for the URL prompt used by image/youtube commands. Pass an
-     * async function that resolves to a URL string, or `null`/empty string
-     * to cancel. When omitted, falls back to `window.prompt`.
-     */
     promptUrl?: (opts: UrlPromptOptions) => Promise<string | null>
 }
 
@@ -33,10 +28,6 @@ function defaultPromptUrl(opts: UrlPromptOptions): Promise<string | null> {
     return Promise.resolve(window.prompt(opts.title, opts.initialValue ?? opts.placeholder ?? ''))
 }
 
-/**
- * Returns the built-in slash command list, optionally including media
- * commands based on which features are enabled in the host Editor.
- */
 export function buildDefaultSlashCommands(ctx: SlashCommandsContext = {}): SlashCommand[] {
     const commands: SlashCommand[] = [
         {
@@ -170,11 +161,6 @@ export function buildDefaultSlashCommands(ctx: SlashCommandsContext = {}): Slash
 
     return commands
 }
-
-// ----------------------------------------------------------------------------
-// Suggestion popup — mounts the SlashPopup Svelte component imperatively
-// (Tiptap's Suggestion render API expects DOM-level lifecycle hooks).
-// ----------------------------------------------------------------------------
 
 type MountedComponent = ReturnType<typeof mount>
 
@@ -326,10 +312,6 @@ function buildSuggestionRender() {
     }
 }
 
-// ----------------------------------------------------------------------------
-// Tiptap extension
-// ----------------------------------------------------------------------------
-
 interface SlashExtensionOptions {
     suggestion: Partial<SuggestionOptions>
 }
@@ -369,8 +351,6 @@ export function buildSlashExtension(commands: SlashCommand[], trigger: string = 
             allowSpaces: false,
             items: ({ query }: { query: string }) => substringFilter(commands, query),
             render: buildSuggestionRender as unknown as SuggestionOptions['render'],
-            // Tiptap merges `suggestion` shallowly when an extension is .configure()'d,
-            // so the command default in addOptions gets overwritten. Include it here.
             command: ({ editor, range, props }) => {
                 editor.chain().focus().deleteRange(range).run()
                 ;(props as SlashCommand).run({ editor })

--- a/src/lib/Editor/editor.slash.svelte.ts
+++ b/src/lib/Editor/editor.slash.svelte.ts
@@ -178,11 +178,21 @@ export function buildDefaultSlashCommands(ctx: SlashCommandsContext = {}): Slash
 
 type MountedComponent = ReturnType<typeof mount>
 
+let slashSeq = 0
+
 interface PopupHandle {
     container: HTMLElement
     component: MountedComponent
-    state: { items: SlashCommand[]; selectedIndex: number; onPick: (i: number) => void }
+    state: {
+        items: SlashCommand[]
+        selectedIndex: number
+        onPick: (i: number) => void
+        listboxId: string
+        optionIdPrefix: string
+    }
     cleanup: (() => void) | null
+    editorDom: HTMLElement | null
+    stopActiveDescendant: (() => void) | null
 }
 
 function substringFilter(commands: SlashCommand[], query: string): SlashCommand[] {
@@ -209,6 +219,11 @@ function buildSuggestionRender() {
         }) => {
             if (typeof document === 'undefined') return
 
+            const seq = ++slashSeq
+            const listboxId = `sv5ui-slash-listbox-${seq}`
+            const optionIdPrefix = `sv5ui-slash-${seq}-`
+            const editorDom = props.editor.view.dom as HTMLElement
+
             const container = document.createElement('div')
             container.setAttribute('data-editor-slash-container', '')
             container.style.cssText = 'position:absolute;top:0;left:0;z-index:50;'
@@ -217,6 +232,8 @@ function buildSuggestionRender() {
             const state = $state({
                 items: props.items,
                 selectedIndex: 0,
+                listboxId,
+                optionIdPrefix,
                 onPick: (i: number) => {
                     const cmd = state.items[i]
                     if (!cmd) return
@@ -229,7 +246,30 @@ function buildSuggestionRender() {
                 props: state
             })
 
-            handle = { container, component, state, cleanup: null }
+            editorDom.setAttribute('aria-controls', listboxId)
+            editorDom.setAttribute('aria-expanded', 'true')
+
+            const stopActiveDescendant = $effect.root(() => {
+                $effect(() => {
+                    if (state.items.length > 0) {
+                        editorDom.setAttribute(
+                            'aria-activedescendant',
+                            `${optionIdPrefix}${state.selectedIndex}`
+                        )
+                    } else {
+                        editorDom.removeAttribute('aria-activedescendant')
+                    }
+                })
+            })
+
+            handle = {
+                container,
+                component,
+                state,
+                cleanup: null,
+                editorDom,
+                stopActiveDescendant
+            }
 
             const rect = props.clientRect?.()
             if (rect) {
@@ -273,6 +313,12 @@ function buildSuggestionRender() {
         onExit: () => {
             if (!handle) return
             handle.cleanup?.()
+            handle.stopActiveDescendant?.()
+            if (handle.editorDom) {
+                handle.editorDom.removeAttribute('aria-controls')
+                handle.editorDom.removeAttribute('aria-expanded')
+                handle.editorDom.removeAttribute('aria-activedescendant')
+            }
             unmount(handle.component)
             handle.container.remove()
             handle = null

--- a/src/lib/Editor/editor.suggestion.ts
+++ b/src/lib/Editor/editor.suggestion.ts
@@ -7,6 +7,8 @@ interface BuildMentionSuggestionOptions {
     onQuery: (query: string) => Promise<MentionItem[]>
 }
 
+let mentionSeq = 0
+
 interface SuggestionRef {
     items: MentionItem[]
     selectedIndex: number
@@ -14,6 +16,9 @@ interface SuggestionRef {
     listEl: HTMLElement | null
     cleanup: (() => void) | null
     pickItem: (index: number) => void
+    editorDom: HTMLElement | null
+    listboxId: string
+    optionIdPrefix: string
 }
 
 function createPopup(): HTMLElement {
@@ -42,6 +47,9 @@ function renderItems(state: SuggestionRef): void {
         row.type = 'button'
         row.setAttribute('data-mention-item', '')
         row.setAttribute('data-index', String(i))
+        row.setAttribute('role', 'option')
+        row.id = `${state.optionIdPrefix}${i}`
+        row.setAttribute('aria-selected', i === state.selectedIndex ? 'true' : 'false')
         row.className = [
             'flex w-full items-center gap-2 px-3 py-1.5 text-sm text-start',
             'hover:bg-surface-container-high',
@@ -69,6 +77,13 @@ function renderItems(state: SuggestionRef): void {
         })
         state.listEl?.appendChild(row)
     })
+
+    if (state.editorDom && state.items.length > 0) {
+        state.editorDom.setAttribute(
+            'aria-activedescendant',
+            `${state.optionIdPrefix}${state.selectedIndex}`
+        )
+    }
 }
 
 export function buildMentionSuggestion(
@@ -89,11 +104,21 @@ export function buildMentionSuggestion(
                 onStart: (props: SuggestionProps) => {
                     if (typeof document === 'undefined') return
 
+                    const seq = ++mentionSeq
+                    const listboxId = `sv5ui-mention-listbox-${seq}`
+                    const optionIdPrefix = `sv5ui-mention-${seq}-`
+                    const editorDom = props.editor.view.dom as HTMLElement
+
                     const popupEl = createPopup()
                     const listEl = document.createElement('div')
                     listEl.setAttribute('role', 'listbox')
+                    listEl.id = listboxId
+                    listEl.setAttribute('aria-label', 'Mentions')
                     popupEl.appendChild(listEl)
                     document.body.appendChild(popupEl)
+
+                    editorDom.setAttribute('aria-controls', listboxId)
+                    editorDom.setAttribute('aria-expanded', 'true')
 
                     state = {
                         items: props.items as MentionItem[],
@@ -101,6 +126,9 @@ export function buildMentionSuggestion(
                         popupEl,
                         listEl,
                         cleanup: null,
+                        editorDom,
+                        listboxId,
+                        optionIdPrefix,
                         pickItem: (i: number) => {
                             const it = state?.items[i]
                             if (!it) return
@@ -160,6 +188,11 @@ export function buildMentionSuggestion(
                 onExit: () => {
                     state?.cleanup?.()
                     state?.popupEl?.remove()
+                    if (state?.editorDom) {
+                        state.editorDom.removeAttribute('aria-controls')
+                        state.editorDom.removeAttribute('aria-expanded')
+                        state.editorDom.removeAttribute('aria-activedescendant')
+                    }
                     state = null
                 }
             }

--- a/src/lib/Editor/editor.toolbar.ts
+++ b/src/lib/Editor/editor.toolbar.ts
@@ -9,14 +9,6 @@ export interface ToolbarActionDef {
     run: (editor: Editor) => void
 }
 
-// ---------------------------------------------------------------------------
-// Fallback `run` handlers below (link/image/youtube) use window.prompt because
-// they need to gather a URL. Editor.svelte intercepts these actions and routes
-// them through the EditorUrlPrompt modal instead. The fallbacks only execute
-// when a consumer calls `api.run('link'|'image'|'youtube')` directly — at
-// which point we have no modal mount point, so window.prompt is the simplest
-// non-UI fallback.
-// ---------------------------------------------------------------------------
 function promptForLink(editor: Editor): void {
     const previous = (editor.getAttributes('link').href as string | undefined) ?? 'https://'
     const url = typeof window === 'undefined' ? null : window.prompt('URL', previous)

--- a/src/lib/Editor/editor.types.ts
+++ b/src/lib/Editor/editor.types.ts
@@ -272,6 +272,10 @@ export interface EditorProps extends Omit<
 
     /**
      * Serialization format used for `value` and `onValueChange`.
+     *
+     * Read once when the editor mounts (it also decides whether the Markdown
+     * extension is loaded). Changing it on an existing editor has no effect —
+     * re-key the component (e.g. `{#key output}`) to switch formats.
      * @default 'html'
      */
     output?: EditorOutput
@@ -368,6 +372,12 @@ export interface EditorProps extends Omit<
      * inserted and a warning is logged).
      */
     onImageUpload?: (file: File) => Promise<string>
+
+    /**
+     * Called when `onImageUpload` rejects. When omitted, the error is logged to
+     * the console. Use this to surface upload failures to the user.
+     */
+    onImageUploadError?: (error: unknown) => void
 
     // ------------------------------------------------------------------------
     // Tables (Phase 2)

--- a/src/lib/Editor/editor.types.ts
+++ b/src/lib/Editor/editor.types.ts
@@ -261,6 +261,12 @@ export interface EditorProps extends Omit<
      * Bindable content. The runtime type depends on `output`:
      * - `output: 'html'` (default) → `string` of HTML
      * - `output: 'json'` → `EditorJSON` document
+     *
+     * Security: the serialized value is structurally validated by the editor
+     * schema (unknown tags, attributes, and event handlers are dropped), but it
+     * is NOT sanitizer-clean. It can still contain arbitrary image `src` values
+     * (including `data:` URIs from pasted content). Sanitize the HTML output
+     * (e.g. with DOMPurify) before rendering it as raw markup elsewhere.
      */
     value?: string | EditorJSON
 
@@ -355,6 +361,11 @@ export interface EditorProps extends Omit<
      * must return the resolved URL to insert as `<img src=...>`. When
      * omitted and `image` is `true`, images can only be inserted via URL
      * prompt (toolbar).
+     *
+     * The returned URL is validated before insertion: relative URLs,
+     * `http(s)`, and raster `data:image/*` URIs are allowed; `javascript:`,
+     * `data:text/*`, and `data:image/svg+xml` are rejected (the image is not
+     * inserted and a warning is logged).
      */
     onImageUpload?: (file: File) => Promise<string>
 

--- a/src/lib/Editor/editor.variants.ts
+++ b/src/lib/Editor/editor.variants.ts
@@ -14,7 +14,6 @@ export const editorVariants = tv({
             'bg-surface-container-low',
             'rounded-t-lg p-1.5'
         ],
-        toolbarGroup: 'flex items-center gap-0.5',
         toolbarButton: [
             'inline-flex items-center justify-center rounded text-on-surface-variant',
             'hover:bg-surface-container-high hover:text-on-surface',

--- a/src/lib/Editor/editor.variants.ts
+++ b/src/lib/Editor/editor.variants.ts
@@ -25,7 +25,6 @@ export const editorVariants = tv({
         toolbarSeparator: 'mx-1 h-5 w-px shrink-0 bg-outline-variant',
         content: [
             'text-on-surface',
-            // ----- Inner ProseMirror element (the actual contenteditable) -----
             '[&_.ProseMirror]:outline-none',
             '[&_.ProseMirror]:focus:outline-none',
             '[&_.ProseMirror]:focus-visible:outline-none',
@@ -33,13 +32,11 @@ export const editorVariants = tv({
             '[&_.ProseMirror]:min-h-32',
             '[&_.ProseMirror]:whitespace-pre-wrap',
             '[&_.ProseMirror]:break-words',
-            // ----- Placeholder (when editor is empty) -----
             '[&_.is-editor-empty]:before:content-[attr(data-placeholder)]',
             '[&_.is-editor-empty]:before:text-on-surface-variant/60',
             '[&_.is-editor-empty]:before:pointer-events-none',
             '[&_.is-editor-empty]:before:float-left',
             '[&_.is-editor-empty]:before:h-0',
-            // ----- Content typography (lightweight in-house prose) -----
             '[&_p]:my-2 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0',
             '[&_h1]:text-2xl [&_h1]:font-bold [&_h1]:my-3',
             '[&_h2]:text-xl [&_h2]:font-bold [&_h2]:my-3',
@@ -56,17 +53,13 @@ export const editorVariants = tv({
             '[&_hr]:border-outline-variant [&_hr]:my-4',
             '[&_strong]:font-semibold',
             '[&_em]:italic',
-            // ----- Image -----
             '[&_img]:max-w-full [&_img]:h-auto [&_img]:rounded-md [&_img]:my-2',
-            // ----- YouTube embed (responsive 16:9) -----
             '[&_iframe[src*="youtube"]]:aspect-video [&_iframe[src*="youtube"]]:w-full [&_iframe[src*="youtube"]]:rounded-md [&_iframe[src*="youtube"]]:my-3 [&_iframe[src*="youtube"]]:border-0',
-            // ----- Mention chip -----
             '[&_.sv5ui-editor-mention]:inline-flex [&_.sv5ui-editor-mention]:items-center',
             '[&_.sv5ui-editor-mention]:rounded [&_.sv5ui-editor-mention]:bg-primary-container/60',
             '[&_.sv5ui-editor-mention]:text-on-primary-container',
             '[&_.sv5ui-editor-mention]:px-1.5 [&_.sv5ui-editor-mention]:py-0.5',
             '[&_.sv5ui-editor-mention]:text-sm [&_.sv5ui-editor-mention]:font-medium',
-            // ----- Table -----
             '[&_.tableWrapper]:my-3 [&_.tableWrapper]:overflow-x-auto',
             '[&_table]:w-full [&_table]:border-collapse [&_table]:table-fixed',
             '[&_table]:border [&_table]:border-outline-variant [&_table]:rounded-md',
@@ -77,12 +70,10 @@ export const editorVariants = tv({
             '[&_td]:border [&_td]:border-outline-variant',
             '[&_td]:px-2 [&_td]:py-1.5 [&_td]:align-top',
             '[&_td]:relative [&_td]:min-w-16',
-            // Tiptap selectedCell highlight + column resize handle
             '[&_.selectedCell]:bg-primary/10',
             '[&_.column-resize-handle]:absolute [&_.column-resize-handle]:top-0 [&_.column-resize-handle]:bottom-[-2px]',
             '[&_.column-resize-handle]:-right-0.5 [&_.column-resize-handle]:w-1',
             '[&_.column-resize-handle]:bg-primary/40 [&_.column-resize-handle]:pointer-events-none',
-            // ----- Selection styling -----
             '[&_::selection]:bg-primary/20'
         ],
         footer: [
@@ -94,11 +85,6 @@ export const editorVariants = tv({
         ],
         countLabel: 'tabular-nums',
         bubbleMenu: [
-            // ⚠️ Tiptap's BubbleMenu only sets `visibility:hidden` initially,
-            // leaving the element in normal flow (taking up space below the editor)
-            // until the user first selects text. Setting `position:absolute` upfront
-            // keeps it out of flow from mount — extension's Floating UI positioning
-            // then overrides left/top inline on selection.
             'absolute top-0 left-0 z-50 invisible',
             'flex items-center gap-0.5 p-1',
             'rounded-lg border border-outline-variant bg-surface',

--- a/src/lib/Editor/index.ts
+++ b/src/lib/Editor/index.ts
@@ -29,10 +29,12 @@
  *
  * (`npm add` / `yarn add` work equally well.)
  *
- * All 18 packages are required, even if you only enable a subset of
- * features. Editor imports every extension at module load so toggling
- * `image`, `tables`, `youtube`, etc. via props doesn't trigger a dynamic
- * import. Missing peers fail at runtime with module-resolution errors.
+ * All 18 packages must be installed even if you only enable a subset of
+ * features — missing peers fail at runtime with module-resolution errors.
+ * Most extensions are imported eagerly, but the heaviest optional ones load
+ * on demand: `tiptap-markdown` (only with `output="markdown"`) and the table
+ * packages (only with `tables`) are pulled in via dynamic `import()`, so your
+ * bundler code-splits them out of the base editor chunk when unused.
  *
  * ## Usage
  *

--- a/src/lib/FileUpload/FileUpload.svelte
+++ b/src/lib/FileUpload/FileUpload.svelte
@@ -154,6 +154,13 @@
         }
     })
 
+    $effect(() => {
+        return () => {
+            for (const [, url] of urlCache) URL.revokeObjectURL(url)
+            urlCache.clear()
+        }
+    })
+
     export function open() {
         if (isDisabled) return
         inputRef?.click()

--- a/src/lib/Icon/icon.types.ts
+++ b/src/lib/Icon/icon.types.ts
@@ -21,7 +21,7 @@ export interface IconProps
             | 'onblur'
         > {
     /** Custom data attributes are forwarded to the rendered `<svg>`. */
-    [key: `data-${string}`]: unknown
+    [key: `data-${string}`]: string | number | boolean | null | undefined
     /**
      * Icon name in Iconify format: "collection:icon-name"
      * @example "lucide:home", "mdi:account", "heroicons:star"

--- a/src/lib/Input/index.ts
+++ b/src/lib/Input/index.ts
@@ -1,2 +1,2 @@
 export { default as Input } from './Input.svelte'
-export type { InputProps } from './input.types.js'
+export type { InputProps, InputValue } from './input.types.js'

--- a/src/lib/Modal/Modal.svelte
+++ b/src/lib/Modal/Modal.svelte
@@ -203,8 +203,10 @@
 
 <Dialog.Root bind:open onOpenChange={handleOpenChange} {onOpenChangeComplete}>
     {#if children}
-        <Dialog.Trigger class={className as string}>
-            {@render children()}
+        <Dialog.Trigger>
+            {#snippet child({ props })}
+                {@render children({ props })}
+            {/snippet}
         </Dialog.Trigger>
     {/if}
 

--- a/src/lib/Modal/Modal.svelte.spec.ts
+++ b/src/lib/Modal/Modal.svelte.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-svelte'
 import { page } from 'vitest/browser'
 import Modal from './Modal.svelte'
+import ModalTriggerTestWrapper from './ModalTriggerTestWrapper.svelte'
 
 describe('Modal', () => {
     const getOverlay = () => document.querySelector('[data-dialog-overlay]') as HTMLElement | null
@@ -544,6 +545,21 @@ describe('Modal', () => {
             await vi.waitFor(() => {
                 const content = getContent()
                 expect(content!.className).toMatch(/scale-in/)
+            })
+        })
+    })
+
+    describe('trigger', () => {
+        it('forwards trigger props to the caller element without nesting a button', async () => {
+            const { container } = render(ModalTriggerTestWrapper)
+            const btn = container.querySelector('[data-testid="trigger"]') as HTMLButtonElement
+            expect(btn).not.toBeNull()
+            expect(btn.tagName).toBe('BUTTON')
+            expect(btn.querySelector('button')).toBeNull()
+            expect(btn.getAttribute('data-state')).toBe('closed')
+            btn.click()
+            await vi.waitFor(() => {
+                expect(btn.getAttribute('data-state')).toBe('open')
             })
         })
     })

--- a/src/lib/Modal/ModalTriggerTestWrapper.svelte
+++ b/src/lib/Modal/ModalTriggerTestWrapper.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+    import Modal from './Modal.svelte'
+</script>
+
+<Modal title="Trigger test" description="D">
+    {#snippet children({ props })}
+        <button data-testid="trigger" {...props}>Open</button>
+    {/snippet}
+    {#snippet body()}<p>Body</p>{/snippet}
+</Modal>

--- a/src/lib/Modal/modal.types.ts
+++ b/src/lib/Modal/modal.types.ts
@@ -137,10 +137,18 @@ export interface ModalProps extends RootProps, ContentProps {
     // --- Slots ---
 
     /**
-     * Default slot content used as the trigger element.
-     * When provided, clicking this element opens the modal.
+     * Trigger content. Spread the provided `props` onto your own focusable
+     * element (e.g. a `<Button>`) so the dialog's trigger ARIA and event
+     * handlers land on the real control instead of a nested wrapper button.
+     *
+     * @example
+     * ```svelte
+     * {#snippet children({ props })}
+     *   <Button {...props}>Open</Button>
+     * {/snippet}
+     * ```
      */
-    children?: Snippet
+    children?: Snippet<[{ props: Record<string, unknown> }]>
 
     /**
      * Custom content slot that replaces the entire default layout

--- a/src/lib/Pagination/pagination.types.ts
+++ b/src/lib/Pagination/pagination.types.ts
@@ -68,7 +68,7 @@ export interface PaginationProps extends Pick<
     | 'onblur'
 > {
     /** Custom data attributes are forwarded to the root element. */
-    [key: `data-${string}`]: unknown
+    [key: `data-${string}`]: string | number | boolean | null | undefined
 
     /**
      * Bindable reference to the root DOM element.

--- a/src/lib/Popover/Popover.svelte
+++ b/src/lib/Popover/Popover.svelte
@@ -105,7 +105,7 @@
     {#if children}
         <Popover.Trigger>
             {#snippet child({ props })}
-                <span {...props} class={className as string}>
+                <span {...props} class={[className]}>
                     {@render children({ open })}
                 </span>
             {/snippet}

--- a/src/lib/Popover/popover.types.ts
+++ b/src/lib/Popover/popover.types.ts
@@ -30,6 +30,9 @@ type ContentProps = Pick<
 >
 
 export interface PopoverProps extends RootProps, ContentProps {
+    /** Custom data attributes are forwarded to the content element. */
+    [key: `data-${string}`]: string | number | boolean | null | undefined
+
     /**
      * Bindable reference to the content DOM element.
      */

--- a/src/lib/Progress/Progress.svelte
+++ b/src/lib/Progress/Progress.svelte
@@ -80,6 +80,19 @@
         }
     })
 
+    const stepClasses = $derived.by(() => {
+        const make = (step: 'active' | 'first' | 'last' | 'other') =>
+            progressVariants({ size, orientation, inverted, step }).step({
+                class: [config.slots.step, ui?.step]
+            })
+        return {
+            active: make('active'),
+            first: make('first'),
+            last: make('last'),
+            other: make('other')
+        }
+    })
+
     const state = $derived(isIndeterminate ? 'indeterminate' : 'determinate')
 </script>
 
@@ -108,12 +121,7 @@
     {#if hasSteps && Array.isArray(max)}
         <div class={classes.steps}>
             {#each max as step, index (index)}
-                {@const stepClass = progressVariants({
-                    size,
-                    orientation,
-                    inverted,
-                    step: stepVariant(index)
-                }).step({ class: [config.slots.step, ui?.step] })}
+                {@const stepClass = stepClasses[stepVariant(index)]}
                 <div class={stepClass}>
                     {#if stepSlot}
                         {@render stepSlot({ step, index })}

--- a/src/lib/RadioGroup/RadioGroup.svelte
+++ b/src/lib/RadioGroup/RadioGroup.svelte
@@ -54,6 +54,7 @@
     const resolvedId = $derived(id ?? formFieldContext?.ariaId ?? autoId)
     const resolvedName = $derived(name ?? formFieldContext?.name)
     const isDisabled = $derived(disabled || loading)
+    const legendId = $derived(`${resolvedId}-legend`)
 
     const ariaDescribedBy = $derived(
         !formFieldContext
@@ -186,13 +187,14 @@
         {orientation}
         aria-describedby={ariaDescribedBy}
         aria-invalid={hasError ? true : undefined}
+        aria-labelledby={legend && !legendSlot ? legendId : undefined}
         class={layoutClasses.fieldset}
     >
         {#if legend || legendSlot}
             {#if legendSlot}
                 {@render legendSlot({ legend })}
             {:else}
-                <span class={layoutClasses.legend}>{legend}</span>
+                <span id={legendId} class={layoutClasses.legend}>{legend}</span>
             {/if}
         {/if}
 

--- a/src/lib/Select/select.types.ts
+++ b/src/lib/Select/select.types.ts
@@ -170,7 +170,7 @@ type TriggerHTMLProps = Pick<
 
 export interface SelectProps extends RootProps, ContentProps, TriggerHTMLProps {
     /** Custom data attributes are forwarded to the trigger element. */
-    [key: `data-${string}`]: unknown
+    [key: `data-${string}`]: string | number | boolean | null | undefined
 
     // -------------------------------------------------------------------------
     // Ref

--- a/src/lib/SelectMenu/SelectMenu.svelte
+++ b/src/lib/SelectMenu/SelectMenu.svelte
@@ -23,6 +23,7 @@
     import Avatar from '../Avatar/Avatar.svelte'
     import type { AvatarSize } from '../Avatar/avatar.types.js'
     import { useFormField, useFormFieldEmit } from '../hooks/useFormField.svelte.js'
+    import { useDebounce } from '../hooks/useDebounce.svelte.js'
 
     const config = getComponentConfig('selectMenu', selectMenuDefaults)
     const icons = getComponentConfig('icons', iconsDefaults)
@@ -181,13 +182,28 @@
 
     // ---- Search & filtering ----
     let searchTerm = $state('')
+    let debouncedSearch = $state('')
+    const searchDebounce = useDebounce({ delay: 200 })
+
+    function setSearch(term: string) {
+        searchTerm = term
+        searchDebounce.run(() => {
+            debouncedSearch = term
+        })
+    }
+
+    function resetSearch() {
+        searchDebounce.cancel()
+        searchTerm = ''
+        debouncedSearch = ''
+    }
 
     const filteredItems = $derived(
-        ignoreFilter || !searchTerm.trim()
+        ignoreFilter || !debouncedSearch.trim()
             ? combinedItems
             : combinedItems.filter((item) => {
                   if ('type' in item) return true
-                  const query = searchTerm.toLowerCase()
+                  const query = debouncedSearch.toLowerCase()
                   return filterFields.some((field) => {
                       const val = (item as unknown as Record<string, unknown>)[field]
                       return typeof val === 'string' && val.toLowerCase().includes(query)
@@ -256,7 +272,7 @@
         }
 
         emit.onChange()
-        searchTerm = ''
+        resetSearch()
     }
 
     // ---- Leading / trailing ----
@@ -386,7 +402,7 @@
     // ---- Event handlers (Nuxt UI v4 pattern) ----
     function onUpdateOpen(val: boolean) {
         if (!val) {
-            searchTerm = ''
+            resetSearch()
             emit.onBlur()
         } else {
             emit.onFocus()
@@ -450,7 +466,7 @@
             autofocus
             placeholder={searchPlaceholder}
             value={searchTerm}
-            oninput={(e) => (searchTerm = (e.currentTarget as HTMLInputElement).value)}
+            oninput={(e) => setSearch((e.currentTarget as HTMLInputElement).value)}
             onkeydown={(e: KeyboardEvent) => {
                 if (e.key !== 'Enter') return
                 if (!showCreateItem) return

--- a/src/lib/SelectMenu/select-menu.types.ts
+++ b/src/lib/SelectMenu/select-menu.types.ts
@@ -143,7 +143,7 @@ type TriggerHTMLProps = Pick<
 
 export interface SelectMenuProps extends ContentProps, TriggerHTMLProps {
     /** Custom data attributes are forwarded to the trigger element. */
-    [key: `data-${string}`]: unknown
+    [key: `data-${string}`]: string | number | boolean | null | undefined
 
     // -------------------------------------------------------------------------
     // Ref

--- a/src/lib/Separator/separator.types.ts
+++ b/src/lib/Separator/separator.types.ts
@@ -4,7 +4,7 @@ import type { Separator } from 'bits-ui'
 import type { SeparatorVariantProps, SeparatorSlots } from './separator.variants.js'
 import type { AvatarProps } from '../Avatar/avatar.types.js'
 
-export type SeparatorProps = Separator.RootProps & {
+export type SeparatorProps = Omit<Separator.RootProps, 'class'> & {
     /**
      * Sets the color scheme applied to the separator.
      * @default 'surface'

--- a/src/lib/Skeleton/Skeleton.svelte
+++ b/src/lib/Skeleton/Skeleton.svelte
@@ -19,11 +19,9 @@
         ...restProps
     }: Props = $props()
 
-    const classes = $derived.by(() => {
-        const slots = skeletonVariants()
-        return {
-            root: slots.root({ class: [config.slots.root, className, ui?.root] })
-        }
+    const slots = skeletonVariants()
+    const classes = $derived({
+        root: slots.root({ class: [config.slots.root, className, ui?.root] })
     })
 </script>
 

--- a/src/lib/Slideover/Slideover.svelte
+++ b/src/lib/Slideover/Slideover.svelte
@@ -197,8 +197,10 @@
 
 <Dialog.Root bind:open onOpenChange={handleOpenChange} {onOpenChangeComplete}>
     {#if children}
-        <Dialog.Trigger class={className as string}>
-            {@render children()}
+        <Dialog.Trigger>
+            {#snippet child({ props })}
+                {@render children({ props })}
+            {/snippet}
         </Dialog.Trigger>
     {/if}
 

--- a/src/lib/Slideover/Slideover.svelte.spec.ts
+++ b/src/lib/Slideover/Slideover.svelte.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-svelte'
 import { page } from 'vitest/browser'
 import Slideover from './Slideover.svelte'
+import SlideoverTriggerTestWrapper from './SlideoverTriggerTestWrapper.svelte'
 
 describe('Slideover', () => {
     const getOverlay = () => document.querySelector('[data-dialog-overlay]') as HTMLElement | null
@@ -613,6 +614,21 @@ describe('Slideover', () => {
             await vi.waitFor(() => {
                 const content = getContent()
                 expect(content!.className).toMatch(/slide-in-full-left/)
+            })
+        })
+    })
+
+    describe('trigger', () => {
+        it('forwards trigger props to the caller element without nesting a button', async () => {
+            const { container } = render(SlideoverTriggerTestWrapper)
+            const btn = container.querySelector('[data-testid="trigger"]') as HTMLButtonElement
+            expect(btn).not.toBeNull()
+            expect(btn.tagName).toBe('BUTTON')
+            expect(btn.querySelector('button')).toBeNull()
+            expect(btn.getAttribute('data-state')).toBe('closed')
+            btn.click()
+            await vi.waitFor(() => {
+                expect(btn.getAttribute('data-state')).toBe('open')
             })
         })
     })

--- a/src/lib/Slideover/SlideoverTriggerTestWrapper.svelte
+++ b/src/lib/Slideover/SlideoverTriggerTestWrapper.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+    import Slideover from './Slideover.svelte'
+</script>
+
+<Slideover title="Trigger test" description="D">
+    {#snippet children({ props })}
+        <button data-testid="trigger" {...props}>Open</button>
+    {/snippet}
+    {#snippet body()}<p>Body</p>{/snippet}
+</Slideover>

--- a/src/lib/Slideover/slideover.types.ts
+++ b/src/lib/Slideover/slideover.types.ts
@@ -136,10 +136,18 @@ export interface SlideoverProps extends RootProps, ContentProps {
     // --- Slots ---
 
     /**
-     * Default slot content used as the trigger element.
-     * When provided, clicking this element opens the slideover.
+     * Trigger content. Spread the provided `props` onto your own focusable
+     * element (e.g. a `<Button>`) so the dialog's trigger ARIA and event
+     * handlers land on the real control instead of a nested wrapper button.
+     *
+     * @example
+     * ```svelte
+     * {#snippet children({ props })}
+     *   <Button {...props}>Open</Button>
+     * {/snippet}
+     * ```
      */
-    children?: Snippet
+    children?: Snippet<[{ props: Record<string, unknown> }]>
 
     /**
      * Custom content slot that replaces the entire default layout

--- a/src/lib/Stepper/Stepper.svelte
+++ b/src/lib/Stepper/Stepper.svelte
@@ -122,9 +122,7 @@
         }
     }
 
-    $effect.pre(() => {
-        api = apiInstance
-    })
+    api = apiInstance
 
     const variantSlots = $derived(stepperVariants({ orientation, size, color }))
 

--- a/src/lib/Switch/Switch.svelte
+++ b/src/lib/Switch/Switch.svelte
@@ -72,17 +72,16 @@
         disabled: isDisabled ? true : undefined
     })
 
-    const classes = $derived.by(() => {
-        const slots = switchVariants(variantOpts)
-        return {
-            root: slots.root({ class: [config.slots.root, className, ui?.root] }),
-            base: slots.base({ class: [config.slots.base, ui?.base] }),
-            container: slots.container({ class: [config.slots.container, ui?.container] }),
-            thumb: slots.thumb({ class: [config.slots.thumb, ui?.thumb] }),
-            wrapper: slots.wrapper({ class: [config.slots.wrapper, ui?.wrapper] }),
-            label: slots.label({ class: [config.slots.label, ui?.label] }),
-            description: slots.description({ class: [config.slots.description, ui?.description] })
-        }
+    const slots = $derived(switchVariants(variantOpts))
+
+    const classes = $derived({
+        root: slots.root({ class: [config.slots.root, className, ui?.root] }),
+        base: slots.base({ class: [config.slots.base, ui?.base] }),
+        container: slots.container({ class: [config.slots.container, ui?.container] }),
+        thumb: slots.thumb({ class: [config.slots.thumb, ui?.thumb] }),
+        wrapper: slots.wrapper({ class: [config.slots.wrapper, ui?.wrapper] }),
+        label: slots.label({ class: [config.slots.label, ui?.label] }),
+        description: slots.description({ class: [config.slots.description, ui?.description] })
     })
 
     const iconClasses = $derived.by(() => {
@@ -91,15 +90,11 @@
         const iconUiClass = [config.slots.icon, ui?.icon]
         return {
             checked: hasCheckedIcon
-                ? switchVariants({ ...variantOpts, checked: true, unchecked: loading }).icon({
-                      class: iconUiClass
-                  })
+                ? slots.icon({ class: iconUiClass, checked: true, unchecked: loading })
                 : undefined,
             unchecked:
                 hasUncheckedIcon && !loading
-                    ? switchVariants({ ...variantOpts, unchecked: true }).icon({
-                          class: iconUiClass
-                      })
+                    ? slots.icon({ class: iconUiClass, unchecked: true })
                     : undefined
         }
     })

--- a/src/lib/Table/table.utils.ts
+++ b/src/lib/Table/table.utils.ts
@@ -24,16 +24,24 @@ export function getRowKey<T extends Record<string, any>>(
     return index
 }
 
+function isNullish(v: unknown): boolean {
+    return v === null || v === undefined
+}
+
+function compareBooleans(a: boolean, b: boolean): number {
+    return a === b ? 0 : a ? -1 : 1
+}
+
 /**
  * Default sort comparator — handles string, number, boolean, null/undefined.
  */
 function defaultCompare(a: unknown, b: unknown): number {
     if (a === b) return 0
-    if (a === null || a === undefined) return 1
-    if (b === null || b === undefined) return -1
+    if (isNullish(a)) return 1
+    if (isNullish(b)) return -1
 
     if (typeof a === 'number' && typeof b === 'number') return a - b
-    if (typeof a === 'boolean' && typeof b === 'boolean') return a === b ? 0 : a ? -1 : 1
+    if (typeof a === 'boolean' && typeof b === 'boolean') return compareBooleans(a, b)
 
     return String(a).localeCompare(String(b))
 }
@@ -159,6 +167,26 @@ export function resolveVisibleColumns<T extends Record<string, any>>(
     return [...left, ...center, ...right]
 }
 
+type PinOffset = { side: 'left' | 'right'; offset: number }
+type PinOffsets = Map<string, PinOffset>
+
+function pinOffsetsForSide<T extends Record<string, any>>(
+    keys: string[],
+    side: 'left' | 'right',
+    columns: TableColumn<T>[],
+    columnSizing: Record<string, number>
+): [string, PinOffset][] {
+    const entries: [string, PinOffset][] = []
+    let offset = 0
+    for (const key of keys) {
+        const col = columns.find((c) => c.key === key)
+        if (!col) continue
+        entries.push([key, { side, offset }])
+        offset += columnSizing[key] ?? col.width ?? 150
+    }
+    return entries
+}
+
 /**
  * Compute cumulative left/right offsets for pinned columns.
  */
@@ -166,31 +194,18 @@ export function computePinOffsets<T extends Record<string, any>>(
     columns: TableColumn<T>[],
     columnSizing: Record<string, number>,
     columnPinning?: { left?: string[]; right?: string[] }
-): Map<string, { side: 'left' | 'right'; offset: number }> {
-    const offsets = new Map<string, { side: 'left' | 'right'; offset: number }>()
-    if (!columnPinning) return offsets
+): PinOffsets {
+    if (!columnPinning) return new Map()
 
-    const leftKeys = columnPinning.left ?? []
-    const rightKeys = columnPinning.right ?? []
-
-    let leftOffset = 0
-    for (const key of leftKeys) {
-        const col = columns.find((c) => c.key === key)
-        if (!col) continue
-        offsets.set(key, { side: 'left', offset: leftOffset })
-        leftOffset += columnSizing[key] ?? col.width ?? 150
-    }
-
-    let rightOffset = 0
-    for (let i = rightKeys.length - 1; i >= 0; i--) {
-        const key = rightKeys[i]
-        const col = columns.find((c) => c.key === key)
-        if (!col) continue
-        offsets.set(key, { side: 'right', offset: rightOffset })
-        rightOffset += columnSizing[key] ?? col.width ?? 150
-    }
-
-    return offsets
+    return new Map([
+        ...pinOffsetsForSide(columnPinning.left ?? [], 'left', columns, columnSizing),
+        ...pinOffsetsForSide(
+            [...(columnPinning.right ?? [])].reverse(),
+            'right',
+            columns,
+            columnSizing
+        )
+    ])
 }
 
 /**

--- a/src/lib/Tabs/tabs.types.ts
+++ b/src/lib/Tabs/tabs.types.ts
@@ -121,7 +121,7 @@ export interface TabsProps extends Pick<
     | 'onblur'
 > {
     /** Custom data attributes are forwarded to the root element. */
-    [key: `data-${string}`]: unknown
+    [key: `data-${string}`]: string | number | boolean | null | undefined
 
     /**
      * Bindable reference to the root DOM element.

--- a/src/lib/ThemeModeButton/ThemeModeButton.svelte
+++ b/src/lib/ThemeModeButton/ThemeModeButton.svelte
@@ -34,7 +34,8 @@
 
     const isDark = $derived(mode.current === 'dark')
 
-    const slots = $derived(themeModeButtonVariants())
+    const slots = themeModeButtonVariants()
+    const baseClass = $derived(slots.base({ class: [config.slots.base, className, ui?.base] }))
 
     const iconName = $derived(isDark ? lightIcon : darkIcon)
 </script>
@@ -48,7 +49,7 @@
         {disabled}
         {square}
         {block}
-        class={slots.base({ class: [config.slots.base, className, ui?.base] })}
+        class={baseClass}
         aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
         onclick={toggleMode}
         {...restProps}
@@ -65,7 +66,7 @@
         {square}
         {block}
         icon={iconName}
-        class={slots.base({ class: [config.slots.base, className, ui?.base] })}
+        class={baseClass}
         aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
         onclick={toggleMode}
         {...restProps}

--- a/src/lib/Tooltip/Tooltip.svelte
+++ b/src/lib/Tooltip/Tooltip.svelte
@@ -133,7 +133,7 @@
         {#if children}
             <Tooltip.Trigger>
                 {#snippet child({ props })}
-                    <span {...props} class={className as string}>
+                    <span {...props} class={[className]}>
                         {@render children({ open })}
                     </span>
                 {/snippet}

--- a/src/lib/Tooltip/tooltip.types.ts
+++ b/src/lib/Tooltip/tooltip.types.ts
@@ -37,6 +37,9 @@ type ContentProps = Pick<
 >
 
 export interface TooltipProps extends ProviderProps, RootProps, ContentProps {
+    /** Custom data attributes are forwarded to the content element. */
+    [key: `data-${string}`]: string | number | boolean | null | undefined
+
     /**
      * Bindable reference to the content DOM element.
      */

--- a/src/routes/command/+page.svelte
+++ b/src/routes/command/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { Command, Separator, Badge, Kbd, Button, Popover, Modal, Drawer } from '$lib/index.js'
-    import type { CommandGroup } from '$lib/Command/command.types.js'
+    import type { CommandGroup } from '$lib/index.js'
 
     // --- Basic groups ---
     const basicGroups: CommandGroup[] = [

--- a/src/routes/drawer/+page.svelte
+++ b/src/routes/drawer/+page.svelte
@@ -61,7 +61,9 @@
                 title="Basic Drawer"
                 description="This is a basic drawer with title, description, body and footer."
             >
-                <Button variant="outline" label="Open Drawer" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open Drawer" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Slides up from the bottom by default. Swipe down or click the overlay to
@@ -86,7 +88,13 @@
                     title="{dir.charAt(0).toUpperCase() + dir.slice(1)} Drawer"
                     description="Opens from the {dir}."
                 >
-                    <Button variant="outline" label={dir.charAt(0).toUpperCase() + dir.slice(1)} />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            label={dir.charAt(0).toUpperCase() + dir.slice(1)}
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <p class="text-on-surface-variant">
                             Drawer from the <strong>{dir}</strong>. Swipe towards the edge to
@@ -120,11 +128,14 @@
                     title="Inset {dir.charAt(0).toUpperCase() + dir.slice(1)}"
                     description="Inset + {dir} direction."
                 >
-                    <Button
-                        variant="soft"
-                        size="sm"
-                        label="Inset {dir.charAt(0).toUpperCase() + dir.slice(1)}"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="soft"
+                            size="sm"
+                            label="Inset {dir.charAt(0).toUpperCase() + dir.slice(1)}"
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <p class="text-on-surface-variant">
                             Inset mode combined with <strong>{dir}</strong> direction.
@@ -152,7 +163,9 @@
                 title="No Handle"
                 description="Handle is hidden."
             >
-                <Button variant="outline" label="No Handle" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="No Handle" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">No drag handle visible. Still swipeable.</p>
                 {/snippet}
@@ -171,7 +184,9 @@
                 title="Handle Only"
                 description="Only the handle can be dragged."
             >
-                <Button variant="outline" label="Handle Only" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Handle Only" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Content area is not draggable — only the handle responds to drag.
@@ -199,7 +214,9 @@
                 title="Non-Modal"
                 description="No overlay, background is interactive."
             >
-                <Button variant="outline" label="Non-Modal" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Non-Modal" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         No overlay. You can still interact with the page behind.
@@ -220,7 +237,9 @@
                 title="Scale Background"
                 description="Background scales down when opened."
             >
-                <Button variant="outline" label="Scale Background" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Scale Background" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         The page content behind scales down, creating a layered depth effect.
@@ -247,7 +266,9 @@
                 title="Non-Dismissible"
                 description="You must use the close button."
             >
-                <Button variant="outline" label="Open (Non-Dismissible)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open (Non-Dismissible)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Try swiping or clicking outside — the drawer will not close.
@@ -276,7 +297,9 @@
                 title="Snap Points"
                 description="Snaps at 25%, 50%, 100%."
             >
-                <Button variant="outline" label="3 Snap Points" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="3 Snap Points" />
+                {/snippet}
                 {#snippet body()}
                     <div class="space-y-2">
                         <p class="text-on-surface-variant">
@@ -299,7 +322,9 @@
                 title="Controlled Snap"
                 description="Active: {activeSnap}"
             >
-                <Button variant="outline" label="Controlled Snap" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Controlled Snap" />
+                {/snippet}
                 {#snippet body()}
                     <div class="space-y-3">
                         <p class="text-on-surface-variant">
@@ -340,7 +365,9 @@
                 title="Outer Drawer"
                 description="This is the parent drawer."
             >
-                <Button variant="outline" label="Open Nested" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open Nested" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Click below to open a child drawer on top of this one.
@@ -352,7 +379,14 @@
                             title="Inner Drawer"
                             description="Nested child drawer."
                         >
-                            <Button variant="solid" color="primary" label="Open Inner Drawer" />
+                            {#snippet children({ props })}
+                                <Button
+                                    {...props}
+                                    variant="solid"
+                                    color="primary"
+                                    label="Open Inner Drawer"
+                                />
+                            {/snippet}
                             {#snippet body()}
                                 <p class="text-on-surface-variant">
                                     This is the nested drawer. Closing it returns to the outer
@@ -386,7 +420,9 @@
         <div class="flex flex-wrap gap-3 rounded-lg bg-surface-container-high p-4">
             <!-- Custom header -->
             <Drawer bind:open={slotsOpen}>
-                <Button variant="outline" label="Custom Header" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Custom Header" />
+                {/snippet}
                 {#snippet header()}
                     <div class="flex items-center gap-3">
                         <div
@@ -426,7 +462,9 @@
 
             <!-- Full content slot -->
             <Drawer bind:open={customContentOpen} title="Custom Content">
-                <Button variant="outline" label="Content Slot" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Content Slot" />
+                {/snippet}
                 {#snippet content()}
                     <div class="flex flex-col items-center gap-4 p-6">
                         <div
@@ -472,7 +510,9 @@
                 title="Callback Demo"
                 description="Check the log above."
             >
-                <Button variant="outline" label="Open (With Callbacks)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open (With Callbacks)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Open, close, and watch the callback log update.
@@ -535,7 +575,9 @@
                     container: 'gap-3'
                 }}
             >
-                <Button variant="outline" label="Open Styled Drawer" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open Styled Drawer" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-primary-container/80">
                         This drawer overrides content, title, description, handle, and container
@@ -563,12 +605,15 @@
             <div class="rounded-lg bg-surface-container-high p-4">
                 <p class="mb-3 text-sm font-medium">Mobile Settings Panel</p>
                 <Drawer bind:open={settingsOpen} title="Settings">
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:settings"
-                        label="Settings"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:settings"
+                            label="Settings"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <div class="space-y-4">
                             {#each [{ icon: 'lucide:user', label: 'Account', desc: 'Manage your profile' }, { icon: 'lucide:bell', label: 'Notifications', desc: 'Push, email, SMS' }, { icon: 'lucide:shield', label: 'Privacy', desc: 'Data and permissions' }, { icon: 'lucide:palette', label: 'Appearance', desc: 'Theme and display' }, { icon: 'lucide:globe', label: 'Language', desc: 'English (US)' }] as item (item.label)}
@@ -616,12 +661,15 @@
             <div class="rounded-lg bg-surface-container-high p-4">
                 <p class="mb-3 text-sm font-medium">Notifications Drawer</p>
                 <Drawer bind:open={notificationsOpen} direction="right">
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:bell"
-                        label="Notifications"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:bell"
+                            label="Notifications"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet header()}
                         <div class="flex items-center justify-between">
                             <h3 class="text-lg font-semibold text-on-surface">Notifications</h3>
@@ -674,12 +722,15 @@
                     title="Filters"
                     description="Refine your search results."
                 >
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:filter"
-                        label="Filters"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:filter"
+                            label="Filters"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <div class="space-y-4">
                             <div>
@@ -735,13 +786,16 @@
             <div class="rounded-lg bg-surface-container-high p-4">
                 <p class="mb-3 text-sm font-medium">Confirmation (Non-Dismissible)</p>
                 <Drawer bind:open={confirmOpen} dismissible={false} handle={false}>
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:trash-2"
-                        label="Delete Account"
-                        color="error"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:trash-2"
+                            label="Delete Account"
+                            color="error"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet content()}
                         <div class="flex flex-col items-center gap-4 p-6 text-center">
                             <div

--- a/src/routes/modal/+page.svelte
+++ b/src/routes/modal/+page.svelte
@@ -59,7 +59,9 @@
                 title="Basic Modal"
                 description="This is a basic modal with title, description, body and footer."
             >
-                <Button variant="outline" label="Open Modal" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open Modal" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         A centered modal dialog. Click the X, press Escape, or click outside to
@@ -89,7 +91,9 @@
                 title="Fullscreen Modal"
                 description="This modal takes up the entire screen."
             >
-                <Button variant="outline" label="Open Fullscreen" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open Fullscreen" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Covers the entire viewport. Useful for complex forms or media viewers.
@@ -116,7 +120,9 @@
                 title="Scrollable Modal"
                 description="The entire modal scrolls within the overlay."
             >
-                <Button variant="outline" label="Scrollable" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Scrollable" />
+                {/snippet}
                 {#snippet body()}
                     <div class="space-y-3">
                         {#each Array.from({ length: 20 }, (_, i) => i) as i (i)}
@@ -142,7 +148,9 @@
                 title="Scrollable + Fullscreen"
                 description="Full viewport with scrollable content."
             >
-                <Button variant="outline" label="Scrollable + Fullscreen" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Scrollable + Fullscreen" />
+                {/snippet}
                 {#snippet body()}
                     <div class="space-y-3">
                         {#each Array.from({ length: 30 }, (_, i) => i) as i (i)}
@@ -173,7 +181,9 @@
                 title="No Transition"
                 description="Appears instantly without animation."
             >
-                <Button variant="outline" label="No Transition" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="No Transition" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">Modal opens and closes without animation.</p>
                 {/snippet}
@@ -192,7 +202,9 @@
                 title="No Close Button"
                 description="Close button is hidden."
             >
-                <Button variant="outline" label="No Close Button" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="No Close Button" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">Use the footer button or Escape to close.</p>
                 {/snippet}
@@ -207,7 +219,9 @@
                 title="No Overlay"
                 description="Background is visible."
             >
-                <Button variant="outline" label="No Overlay" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="No Overlay" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">No backdrop overlay behind the modal.</p>
                 {/snippet}
@@ -232,7 +246,9 @@
                 title="Non-Dismissible"
                 description="Must use the close button."
             >
-                <Button variant="outline" label="Open (Non-Dismissible)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open (Non-Dismissible)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Clicking outside or pressing Escape won't close this modal.
@@ -256,7 +272,9 @@
         <div class="flex flex-wrap gap-3 rounded-lg bg-surface-container-high p-4">
             <!-- Custom header -->
             <Modal bind:open={slotsOpen}>
-                <Button variant="outline" label="Custom Header" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Custom Header" />
+                {/snippet}
                 {#snippet header()}
                     <div class="flex items-center gap-3 p-4 sm:px-6">
                         <div
@@ -298,7 +316,9 @@
                 title="User Profile"
                 description="Manage your account settings."
             >
-                <Button variant="outline" label="Actions Slot" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Actions Slot" />
+                {/snippet}
                 {#snippet actions()}
                     <Badge variant="soft" color="success" size="xs" label="Active" />
                     <Badge variant="soft" color="info" size="xs" label="Pro" />
@@ -315,7 +335,9 @@
 
             <!-- Full content slot -->
             <Modal bind:open={customContentOpen} title="Custom Content">
-                <Button variant="outline" label="Content Slot" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Content Slot" />
+                {/snippet}
                 {#snippet content()}
                     <div class="flex flex-col items-center gap-4 p-6">
                         <div
@@ -360,7 +382,9 @@
                 title="Callback Demo"
                 description="Check the log above."
             >
-                <Button variant="outline" label="Open (With Callbacks)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open (With Callbacks)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Open, close, and watch the callback log update.
@@ -422,7 +446,9 @@
                     header: 'border-on-primary-container/10'
                 }}
             >
-                <Button variant="outline" label="Open Styled Modal" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open Styled Modal" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-primary-container/80">
                         This modal overrides content, title, description, and header slot classes.
@@ -449,13 +475,16 @@
             <div class="rounded-lg bg-surface-container-high p-4">
                 <p class="mb-3 text-sm font-medium">Confirmation Dialog</p>
                 <Modal bind:open={confirmOpen} dismissible={false} close={false}>
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:trash-2"
-                        label="Delete Item"
-                        color="error"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:trash-2"
+                            label="Delete Item"
+                            color="error"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet content()}
                         <div class="flex flex-col items-center gap-4 p-6 text-center">
                             <div
@@ -495,12 +524,15 @@
                     title="Create Project"
                     description="Fill in the details to create a new project."
                 >
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:plus"
-                        label="New Project"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:plus"
+                            label="New Project"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <div class="space-y-4">
                             <div>
@@ -556,12 +588,15 @@
                     description="Your session has timed out due to inactivity."
                     dismissible={false}
                 >
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:clock"
-                        label="Session Alert"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:clock"
+                            label="Session Alert"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <p class="text-on-surface-variant">
                             Please sign in again to continue using the application.
@@ -583,12 +618,15 @@
             <div class="rounded-lg bg-surface-container-high p-4">
                 <p class="mb-3 text-sm font-medium">Image Preview</p>
                 <Modal bind:open={imageOpen} close={{ color: 'surface', size: 'md' }}>
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:image"
-                        label="View Image"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:image"
+                            label="View Image"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet content()}
                         <div class="p-2">
                             <img
@@ -624,7 +662,9 @@
                     title={`Size: ${s}`}
                     description="Resize your browser to see how the modal width scales."
                 >
-                    <Button variant="outline" label={`size="${s}"`} />
+                    {#snippet children({ props })}
+                        <Button {...props} variant="outline" label={`size="${s}"`} />
+                    {/snippet}
                     {#snippet body()}
                         <p class="text-sm text-on-surface-variant">
                             Current size is <code>{s}</code>.
@@ -652,7 +692,9 @@
                     title={`Transition: ${t}`}
                     description="Open and close to see the animation."
                 >
-                    <Button variant="outline" label={`transition="${t}"`} />
+                    {#snippet children({ props })}
+                        <Button {...props} variant="outline" label={`transition="${t}"`} />
+                    {/snippet}
                 </Modal>
             {/each}
         </div>

--- a/src/routes/slideover/+page.svelte
+++ b/src/routes/slideover/+page.svelte
@@ -72,7 +72,9 @@
                 title="Right Slideover"
                 description="Slides in from the right (default)."
             >
-                <Button variant="outline" label="Right" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Right" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         This panel slides in from the right side (default).
@@ -89,7 +91,9 @@
                 title="Left Slideover"
                 description="Slides in from the left."
             >
-                <Button variant="outline" label="Left" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Left" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">This panel slides in from the left side.</p>
                 {/snippet}
@@ -104,7 +108,9 @@
                 title="Top Slideover"
                 description="Slides down from the top."
             >
-                <Button variant="outline" label="Top" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Top" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">This panel slides down from the top.</p>
                 {/snippet}
@@ -119,7 +125,9 @@
                 title="Bottom Slideover"
                 description="Slides up from the bottom."
             >
-                <Button variant="outline" label="Bottom" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Bottom" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">This panel slides up from the bottom.</p>
                 {/snippet}
@@ -145,7 +153,9 @@
                 title="Inset Right"
                 description="Inset mode with rounded corners."
             >
-                <Button variant="outline" label="Inset (Right)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Inset (Right)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         This slideover has margins and rounded corners, giving it a floating
@@ -168,7 +178,9 @@
                 title="Inset Left"
                 description="Inset mode from the left side."
             >
-                <Button variant="outline" label="Inset (Left)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Inset (Left)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Inset mode from the left with floating panel appearance.
@@ -190,7 +202,9 @@
                 title="Inset Top"
                 description="Inset mode from the top."
             >
-                <Button variant="outline" label="Inset (Top)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Inset (Top)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Inset mode from the top with floating panel appearance.
@@ -212,7 +226,9 @@
                 title="Inset Bottom"
                 description="Inset mode from the bottom."
             >
-                <Button variant="outline" label="Inset (Bottom)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Inset (Bottom)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Inset mode from the bottom with floating panel appearance.
@@ -246,7 +262,9 @@
                 title="No Transition"
                 description="This slideover appears and disappears instantly."
             >
-                <Button variant="outline" label="No Transition" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="No Transition" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         No slide or fade animation — the slideover snaps open and closed.
@@ -279,7 +297,9 @@
                 title="No Close Button"
                 description="The X button is hidden."
             >
-                <Button variant="outline" label="No Close Button" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="No Close Button" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         There's no X button. Use the footer button or Escape key to close.
@@ -313,7 +333,9 @@
                 title="No Overlay"
                 description="The backdrop is hidden."
             >
-                <Button variant="outline" label="No Overlay" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="No Overlay" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         The slideover has no backdrop overlay. The page content behind is fully
@@ -348,7 +370,9 @@
                 title="Non-Dismissible"
                 description="You must use the button to close."
             >
-                <Button variant="outline" label="Open (Non-Dismissible)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open (Non-Dismissible)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Try clicking outside or pressing Escape — the slideover will not close.
@@ -387,7 +411,9 @@
         <div class="flex flex-wrap gap-3 rounded-lg bg-surface-container-high p-4">
             <!-- Custom header slot -->
             <Slideover bind:open={slotsOpen}>
-                <Button variant="outline" label="Custom Header" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Custom Header" />
+                {/snippet}
                 {#snippet header()}
                     <div class="flex items-center gap-3 p-4 sm:px-6">
                         <div
@@ -422,7 +448,9 @@
 
             <!-- Custom title/description slots -->
             <Slideover bind:open={titleSlotOpen}>
-                <Button variant="outline" label="Custom Title/Desc" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Custom Title/Desc" />
+                {/snippet}
                 {#snippet titleSlot()}
                     <span class="flex items-center gap-2">
                         <Icon name="lucide:sparkles" size="16" class="text-warning" />
@@ -467,7 +495,9 @@
                 title="User Profile"
                 description="Manage your account settings."
             >
-                <Button variant="outline" label="Actions Slot" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Actions Slot" />
+                {/snippet}
                 {#snippet actions()}
                     <Badge variant="soft" color="success" size="xs" label="Active" />
                     <Badge variant="soft" color="info" size="xs" label="Pro" />
@@ -487,7 +517,9 @@
 
             <!-- Full content slot -->
             <Slideover bind:open={customContentOpen} title="Custom Content">
-                <Button variant="outline" label="Content Slot" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Content Slot" />
+                {/snippet}
                 {#snippet content()}
                     <div class="flex h-full flex-col items-center justify-center gap-4 p-6">
                         <div
@@ -544,7 +576,9 @@
                 title="Callback Demo"
                 description="Check the log above."
             >
-                <Button variant="outline" label="Open (With Callbacks)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open (With Callbacks)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         Open, close, and watch the callback log update in real-time.
@@ -578,7 +612,9 @@
                 title="No Portal"
                 description="Rendered inline, not in a portal."
             >
-                <Button variant="outline" label="Open (No Portal)" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open (No Portal)" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-surface-variant">
                         This slideover is rendered inline in the DOM.
@@ -650,7 +686,9 @@
                     description: 'text-on-primary-container/70'
                 }}
             >
-                <Button variant="outline" label="Open Styled Slideover" />
+                {#snippet children({ props })}
+                    <Button {...props} variant="outline" label="Open Styled Slideover" />
+                {/snippet}
                 {#snippet body()}
                     <p class="text-on-primary-container/80">
                         This slideover overrides
@@ -695,12 +733,15 @@
                     title="Filters"
                     description="Refine your search results."
                 >
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:sliders-horizontal"
-                        label="Filters"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:sliders-horizontal"
+                            label="Filters"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <div class="space-y-6">
                             <div>
@@ -786,12 +827,15 @@
                     title="Settings"
                     description="Customize your experience."
                 >
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:settings"
-                        label="Settings"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:settings"
+                            label="Settings"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <div class="space-y-6">
                             <div class="flex items-center justify-between">
@@ -866,12 +910,15 @@
                     title="Shopping Cart"
                     description="3 items in your cart"
                 >
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:shopping-cart"
-                        label="Cart (3)"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:shopping-cart"
+                            label="Cart (3)"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <div class="space-y-4">
                             {#each [{ name: 'Wireless Headphones', price: '$199.99', qty: 1 }, { name: 'USB-C Cable', price: '$19.99', qty: 2 }, { name: 'Phone Case', price: '$29.99', qty: 1 }] as item (item.name)}
@@ -932,12 +979,15 @@
                     title="Notifications"
                     description="You have 5 unread notifications"
                 >
-                    <Button
-                        variant="outline"
-                        leadingIcon="lucide:bell"
-                        label="Notifications"
-                        class="w-full"
-                    />
+                    {#snippet children({ props })}
+                        <Button
+                            {...props}
+                            variant="outline"
+                            leadingIcon="lucide:bell"
+                            label="Notifications"
+                            class="w-full"
+                        />
+                    {/snippet}
                     {#snippet body()}
                         <div class="space-y-3">
                             {#each [{ icon: 'lucide:package', title: 'Order shipped', desc: 'Your order #1234 has been shipped', time: '2m ago', color: 'text-info' }, { icon: 'lucide:user-plus', title: 'New follower', desc: 'John Doe started following you', time: '1h ago', color: 'text-primary' }, { icon: 'lucide:message-circle', title: 'New comment', desc: 'Sarah commented on your post', time: '3h ago', color: 'text-success' }, { icon: 'lucide:heart', title: 'Post liked', desc: 'Your post received 100 likes', time: '5h ago', color: 'text-error' }, { icon: 'lucide:calendar', title: 'Event reminder', desc: 'Team meeting in 30 minutes', time: '1d ago', color: 'text-warning' }] as notif (notif.title)}
@@ -991,7 +1041,9 @@
                     title={`Size: ${s}`}
                     description={`right side, size="${s}"`}
                 >
-                    <Button variant="outline" label={`size="${s}"`} />
+                    {#snippet children({ props })}
+                        <Button {...props} variant="outline" label={`size="${s}"`} />
+                    {/snippet}
                     {#snippet body()}
                         <p class="text-sm text-on-surface-variant">
                             Current size is <code>{s}</code>.
@@ -1019,7 +1071,9 @@
                     title={`Transition: ${t}`}
                     description="Open and close to see the animation."
                 >
-                    <Button variant="outline" label={`transition="${t}"`} />
+                    {#snippet children({ props })}
+                        <Button {...props} variant="outline" label={`transition="${t}"`} />
+                    {/snippet}
                 </Slideover>
             {/each}
         </div>


### PR DESCRIPTION
Integration of all `dev` work since `v2.0.0` into `main`. **Proposed version: `v2.1.0` (minor).**

28 commits ahead (16 functional + 12 merges), 57 files, +1158/−335.

## ✨ feat
- **Command**: export group/item types; type-check `id` + `data-*` on the root.

## 🐛 fix
- **Editor**: validate image `src` before insertion to block unsafe URLs (security).
- **Editor**: fix runtime output desync; add `onImageUploadError`; drop dead `toolbarGroup` slot.
- **Editor**: expose ARIA listbox semantics for mention & slash popups (a11y).
- **Calendar**: initialize placeholder so year navigation works on first render.
- **Modal / Slideover / Drawer**: render trigger via `child` snippet to avoid nested buttons.
- **RadioGroup**: associate the legend with the group for screen readers (a11y) — #107.
- **FileUpload**: revoke cached object URLs on unmount (memory leak) — #107.
- **types**: tighten public types — `data-*` `unknown`→union, `Separator` class collision, `Badge` `ui`, export `InputValue` — #104.

## ⚡ perf
- **Editor**: lazy-load markdown & table extensions via dynamic `import()` (code-splitting).
- **Editor**: skip redundant re-serialization of the editor's own value echo.
- **SelectMenu**: debounce search filtering (200ms) — #107.
- **components**: memoize per-render variant computation (Accordion/Progress/Switch/Stepper/ThemeModeButton/Skeleton) — #105.

## ♻️ refactor
- **types**: drop unsafe `as string` cast on trigger class (Popover/Tooltip/ContextMenu) — #106.

## 📝 docs / 🔧 chore
- **Editor**: clarify install note for the dynamic-import change; remove explanatory code comments.

## ⚠️ Notes (no runtime breaking changes)
Reviewed all risks — no runtime-breaking changes. Two harmless **type narrowings** may surface new TS errors only for code that was already a no-op or invalid:
- Editor `ui` no longer accepts `toolbarGroup` (was a dead, never-rendered slot).
- `Badge` `ui` no longer accepts `leadingAvatarSize`; component `data-*` attrs no longer accept object/function values.

Editor dynamic-import is consumer-transparent: `package.json` exports & all 18 peer deps unchanged; `buildExtensions` is internal; async extension loading is awaited with an unmount guard.

## Verification
- `svelte-check`: 0 errors / 0 warnings
- Full test suite: 65 files / 2459 tests passing
- All 4 feature PRs (#104–#107) merged green; CI on `dev` passing.
