### PR TITLE
feat(hooks): add useEventListener

### DIFF
--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -18,3 +18,5 @@ export type { UseEscapeKeydownOptions } from './useEscapeKeydown.svelte.js'
 
 export { useDebounce } from './useDebounce.svelte.js'
 export type { UseDebounceOptions } from './useDebounce.svelte.js'
+
+export { useEventListener } from './useEventListener.svelte.js'

--- a/src/lib/hooks/useEventListener.svelte.spec.ts
+++ b/src/lib/hooks/useEventListener.svelte.spec.ts
@@ -141,7 +141,11 @@ describe('useEventListener', () => {
         const bAdd = vi.spyOn(b, 'addEventListener')
         let current = $state(a)
         const cleanup = $effect.root(() => {
-            useEventListener(() => current, 'click', () => {})
+            useEventListener(
+                () => current,
+                'click',
+                () => {}
+            )
         })
         flushSync()
         current = b

--- a/src/lib/hooks/useEventListener.svelte.spec.ts
+++ b/src/lib/hooks/useEventListener.svelte.spec.ts
@@ -1,0 +1,153 @@
+import { flushSync } from 'svelte'
+import { describe, expect, it, vi } from 'vitest'
+import { useEventListener } from './useEventListener.svelte.js'
+
+describe('useEventListener', () => {
+    it('binds a listener on a value target and fires on the event', () => {
+        const el = document.createElement('div')
+        const handler = vi.fn()
+        const cleanup = $effect.root(() => {
+            useEventListener(el, 'click', handler)
+        })
+        flushSync()
+        el.dispatchEvent(new MouseEvent('click'))
+        expect(handler).toHaveBeenCalledTimes(1)
+        cleanup()
+    })
+
+    it('accepts a getter target', () => {
+        const el = document.createElement('div')
+        const handler = vi.fn()
+        const cleanup = $effect.root(() => {
+            useEventListener(() => el, 'click', handler)
+        })
+        flushSync()
+        el.dispatchEvent(new MouseEvent('click'))
+        expect(handler).toHaveBeenCalledTimes(1)
+        cleanup()
+    })
+
+    it('binds multiple event types', () => {
+        const el = document.createElement('div')
+        const handler = vi.fn()
+        const cleanup = $effect.root(() => {
+            useEventListener(el, ['click', 'pointerdown'], handler)
+        })
+        flushSync()
+        el.dispatchEvent(new MouseEvent('click'))
+        el.dispatchEvent(new PointerEvent('pointerdown'))
+        expect(handler).toHaveBeenCalledTimes(2)
+        cleanup()
+    })
+
+    it('removes the listener on cleanup', () => {
+        const el = document.createElement('div')
+        const handler = vi.fn()
+        const cleanup = $effect.root(() => {
+            useEventListener(el, 'click', handler)
+        })
+        flushSync()
+        cleanup()
+        el.dispatchEvent(new MouseEvent('click'))
+        expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op for a nullish target', () => {
+        const handler = vi.fn()
+        const cleanup = $effect.root(() => {
+            useEventListener(null, 'click', handler)
+        })
+        expect(() => flushSync()).not.toThrow()
+        cleanup()
+    })
+
+    it('respects listener options (once)', () => {
+        const el = document.createElement('div')
+        const handler = vi.fn()
+        const cleanup = $effect.root(() => {
+            useEventListener(el, 'click', handler, { once: true })
+        })
+        flushSync()
+        el.dispatchEvent(new MouseEvent('click'))
+        el.dispatchEvent(new MouseEvent('click'))
+        expect(handler).toHaveBeenCalledTimes(1)
+        cleanup()
+    })
+
+    it('re-binds when a reactive getter target changes', () => {
+        const a = document.createElement('div')
+        const b = document.createElement('div')
+        const handler = vi.fn()
+        let current = $state(a)
+        const cleanup = $effect.root(() => {
+            useEventListener(() => current, 'click', handler)
+        })
+        flushSync()
+        a.dispatchEvent(new MouseEvent('click'))
+        expect(handler).toHaveBeenCalledTimes(1)
+
+        current = b
+        flushSync()
+        a.dispatchEvent(new MouseEvent('click'))
+        expect(handler).toHaveBeenCalledTimes(1)
+        b.dispatchEvent(new MouseEvent('click'))
+        expect(handler).toHaveBeenCalledTimes(2)
+        cleanup()
+    })
+
+    it('does not leak: every addEventListener is matched by removeEventListener with identical args', () => {
+        const el = document.createElement('div')
+        const addSpy = vi.spyOn(el, 'addEventListener')
+        const removeSpy = vi.spyOn(el, 'removeEventListener')
+        const handler = vi.fn()
+        const options = { capture: true }
+        const cleanup = $effect.root(() => {
+            useEventListener(el, ['click', 'keydown'], handler, options)
+        })
+        flushSync()
+        expect(addSpy).toHaveBeenCalledTimes(2)
+        cleanup()
+        expect(removeSpy).toHaveBeenCalledTimes(2)
+        expect(removeSpy.mock.calls).toEqual(addSpy.mock.calls)
+    })
+
+    it('binds once for a static target and does not re-bind on unrelated state changes', () => {
+        const el = document.createElement('div')
+        const addSpy = vi.spyOn(el, 'addEventListener')
+        let unrelated = $state(0)
+        let ticks = 0
+        const cleanup = $effect.root(() => {
+            useEventListener(el, 'click', () => {})
+            $effect(() => {
+                void unrelated
+                ticks++
+            })
+        })
+        flushSync()
+        expect(addSpy).toHaveBeenCalledTimes(1)
+        unrelated = 1
+        flushSync()
+        unrelated = 2
+        flushSync()
+        expect(ticks).toBeGreaterThan(1)
+        expect(addSpy).toHaveBeenCalledTimes(1)
+        cleanup()
+    })
+
+    it('on target change, removes the old target exactly once and binds the new one', () => {
+        const a = document.createElement('div')
+        const b = document.createElement('div')
+        const aRemove = vi.spyOn(a, 'removeEventListener')
+        const bAdd = vi.spyOn(b, 'addEventListener')
+        let current = $state(a)
+        const cleanup = $effect.root(() => {
+            useEventListener(() => current, 'click', () => {})
+        })
+        flushSync()
+        current = b
+        flushSync()
+        expect(aRemove).toHaveBeenCalledTimes(1)
+        expect(bAdd).toHaveBeenCalledTimes(1)
+        cleanup()
+    })
+})

--- a/src/lib/hooks/useEventListener.svelte.ts
+++ b/src/lib/hooks/useEventListener.svelte.ts
@@ -1,0 +1,74 @@
+type MaybeGetter<T> = T | (() => T)
+
+function toGetter<T>(value: MaybeGetter<T>): () => T {
+    return typeof value === 'function' ? (value as () => T) : () => value
+}
+
+/**
+ * Attach event listener(s) to a target with automatic cleanup.
+ *
+ * Binds inside an `$effect` and removes the listener(s) on teardown. The target
+ * may be a value or a getter; when it is a getter that reads reactive state, the
+ * listener re-binds as the target changes. SSR-safe: a nullish target is a no-op.
+ *
+ * @example
+ * ```svelte
+ * <script>
+ *   import { useEventListener } from 'sv5ui'
+ *
+ *   let el = $state<HTMLElement>()
+ *
+ *   // Window target (static)
+ *   useEventListener(window, 'resize', () => console.log('resized'))
+ *
+ *   // Element target (reactive getter) + multiple event types
+ *   useEventListener(() => el, ['pointerenter', 'focus'], () => console.log('active'))
+ * </script>
+ *
+ * <div bind:this={el}>hover or focus me</div>
+ * ```
+ */
+export function useEventListener<K extends keyof WindowEventMap>(
+    target: MaybeGetter<Window | null | undefined>,
+    type: K | K[],
+    handler: (this: Window, event: WindowEventMap[K]) => void,
+    options?: boolean | AddEventListenerOptions
+): void
+export function useEventListener<K extends keyof DocumentEventMap>(
+    target: MaybeGetter<Document | null | undefined>,
+    type: K | K[],
+    handler: (this: Document, event: DocumentEventMap[K]) => void,
+    options?: boolean | AddEventListenerOptions
+): void
+export function useEventListener<K extends keyof HTMLElementEventMap>(
+    target: MaybeGetter<HTMLElement | null | undefined>,
+    type: K | K[],
+    handler: (this: HTMLElement, event: HTMLElementEventMap[K]) => void,
+    options?: boolean | AddEventListenerOptions
+): void
+export function useEventListener(
+    target: MaybeGetter<EventTarget | null | undefined>,
+    type: string | string[],
+    handler: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions
+): void
+export function useEventListener(
+    target: MaybeGetter<EventTarget | null | undefined>,
+    type: string | string[],
+    handler: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions
+): void {
+    const resolveTarget = toGetter(target)
+    const types = Array.isArray(type) ? type : [type]
+
+    $effect(() => {
+        const el = resolveTarget()
+        if (!el) return
+
+        for (const t of types) el.addEventListener(t, handler, options)
+
+        return () => {
+            for (const t of types) el.removeEventListener(t, handler, options)
+        }
+    })
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -74,7 +74,8 @@
             icon: 'lucide:arrow-down-to-line'
         },
         { href: '/use-escape-keydown', label: 'useEscapeKeydown', icon: 'lucide:keyboard' },
-        { href: '/use-debounce', label: 'useDebounce', icon: 'lucide:timer' }
+        { href: '/use-debounce', label: 'useDebounce', icon: 'lucide:timer' },
+        { href: '/use-event-listener', label: 'useEventListener', icon: 'lucide:radio' }
     ]
 
     const docItems = [

--- a/src/routes/use-event-listener/+page.svelte
+++ b/src/routes/use-event-listener/+page.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+    import { useEventListener } from '$lib/index.js'
+    import { Badge, Card, Icon } from '$lib/index.js'
+
+    // ==================== Window resize (value/getter target) ====================
+    let width = $state(0)
+    let height = $state(0)
+
+    $effect(() => {
+        width = window.innerWidth
+        height = window.innerHeight
+    })
+
+    useEventListener(
+        () => window,
+        'resize',
+        () => {
+            width = window.innerWidth
+            height = window.innerHeight
+        }
+    )
+
+    // ==================== Window keydown (multiple-target demo) ====================
+    let lastKey = $state('—')
+    let keyCount = $state(0)
+
+    useEventListener(
+        () => window,
+        'keydown',
+        (e) => {
+            lastKey = e.key === ' ' ? 'Space' : e.key
+            keyCount++
+        }
+    )
+
+    // ==================== Element pointermove (reactive getter target) ====================
+    let box = $state<HTMLElement>()
+    let pos = $state({ x: 0, y: 0 })
+    let inside = $state(false)
+
+    useEventListener(
+        () => box,
+        'pointermove',
+        (e) => {
+            const rect = box!.getBoundingClientRect()
+            pos = { x: Math.round(e.clientX - rect.left), y: Math.round(e.clientY - rect.top) }
+        }
+    )
+    useEventListener(
+        () => box,
+        ['pointerenter', 'pointerleave'],
+        (e) => {
+            inside = e.type === 'pointerenter'
+        }
+    )
+</script>
+
+<div class="space-y-8">
+    <div class="space-y-2">
+        <h1 class="text-2xl font-bold">useEventListener</h1>
+        <p class="text-on-surface-variant">
+            Attach event listener(s) to a target with automatic cleanup. The target may be a value
+            or a reactive getter, accepts one or many event types, and forwards listener options.
+            SSR-safe — a nullish target is a no-op.
+        </p>
+    </div>
+
+    <!-- Window resize -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Window resize</h2>
+        <p class="text-sm text-on-surface-variant">
+            Listens to <code>resize</code> on <code>window</code>. Resize the browser window to see
+            it update.
+        </p>
+        <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
+            <Badge label="{width} × {height}" color="primary" variant="soft" size="lg" />
+            <span class="text-sm text-on-surface-variant">live viewport size</span>
+        </div>
+    </section>
+
+    <!-- Keydown -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Keyboard</h2>
+        <p class="text-sm text-on-surface-variant">
+            Listens to <code>keydown</code> on <code>window</code>. Press any key.
+        </p>
+        <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
+            <Badge label="Last key: {lastKey}" color="info" variant="soft" />
+            <Badge label="Pressed: {keyCount}x" color="surface" variant="subtle" />
+        </div>
+    </section>
+
+    <!-- Pointer position -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Pointer position (reactive element target)</h2>
+        <p class="text-sm text-on-surface-variant">
+            Listens to <code>pointermove</code> / <code>pointerenter</code> /
+            <code>pointerleave</code> on an element resolved via a <code>() => box</code> getter, so the
+            listener binds once the element mounts. Move your cursor inside the box.
+        </p>
+        <div
+            bind:this={box}
+            class="relative flex h-48 items-center justify-center rounded-lg border-2 border-dashed border-outline-variant bg-surface-container-high transition-colors"
+            class:border-primary={inside}
+        >
+            {#if inside}
+                <div
+                    class="pointer-events-none absolute size-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary"
+                    style="left: {pos.x}px; top: {pos.y}px;"
+                ></div>
+            {/if}
+            <Card class="p-3">
+                <div class="flex items-center gap-2 text-sm">
+                    <Icon name="lucide:move" size="16" class="text-on-surface-variant" />
+                    <span>x: <strong>{pos.x}</strong>, y: <strong>{pos.y}</strong></span>
+                </div>
+            </Card>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
Closes #112

Adds `useEventListener` — a declarative event-listener composable with automatic cleanup.

- Value or reactive-getter target; single or multiple event types; listener-options passthrough.
- SSR-safe no-op on a nullish target; re-binds when a reactive target changes.
- Other DOM hooks build on it.

**Verification:** 10 tests (binding, multi-type, cleanup/no-leak symmetry incl. capture flag, no unnecessary re-bind, reactive re-bind); svelte-check clean; demo page + nav; build/publint pass.
