### PR TITLE
feat(hooks): add useResizeObserver / useElementSize

### DIFF
--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -18,3 +18,6 @@ export type { UseEscapeKeydownOptions } from './useEscapeKeydown.svelte.js'
 
 export { useDebounce } from './useDebounce.svelte.js'
 export type { UseDebounceOptions } from './useDebounce.svelte.js'
+
+export { useResizeObserver, useElementSize } from './useResizeObserver.svelte.js'
+export type { UseElementSizeReturn } from './useResizeObserver.svelte.js'

--- a/src/lib/hooks/useResizeObserver.svelte.spec.ts
+++ b/src/lib/hooks/useResizeObserver.svelte.spec.ts
@@ -1,0 +1,199 @@
+import { flushSync } from 'svelte'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useResizeObserver, useElementSize } from './useResizeObserver.svelte.js'
+
+describe('useResizeObserver / useElementSize', () => {
+    class FakeRO {
+        cb: ResizeObserverCallback
+        observed: { el: Element; options?: ResizeObserverOptions }[] = []
+        disconnected = 0
+        constructor(cb: ResizeObserverCallback) {
+            this.cb = cb
+            instances.push(this)
+        }
+        observe(el: Element, options?: ResizeObserverOptions) {
+            this.observed.push({ el, options })
+        }
+        unobserve() {}
+        disconnect() {
+            this.disconnected++
+        }
+        emit(entries: Partial<ResizeObserverEntry>[]) {
+            this.cb(entries as ResizeObserverEntry[], this as unknown as ResizeObserver)
+        }
+    }
+
+    let originalRO: typeof ResizeObserver
+    let instances: FakeRO[]
+
+    beforeEach(() => {
+        originalRO = globalThis.ResizeObserver
+        instances = []
+        globalThis.ResizeObserver = FakeRO as unknown as typeof ResizeObserver
+    })
+
+    afterEach(() => {
+        globalThis.ResizeObserver = originalRO
+    })
+
+    it('observes the target on mount', () => {
+        const el = document.createElement('div')
+        const cleanup = $effect.root(() => {
+            useResizeObserver(el, () => {})
+        })
+        flushSync()
+        expect(instances).toHaveLength(1)
+        expect(instances[0].observed[0].el).toBe(el)
+        cleanup()
+    })
+
+    it('invokes the callback when the observer fires', () => {
+        const el = document.createElement('div')
+        const cb = vi.fn()
+        const cleanup = $effect.root(() => {
+            useResizeObserver(el, cb)
+        })
+        flushSync()
+        instances[0].emit([{ contentRect: { width: 100, height: 50 } as DOMRectReadOnly }])
+        expect(cb).toHaveBeenCalledTimes(1)
+        cleanup()
+    })
+
+    it('disconnects on cleanup', () => {
+        const el = document.createElement('div')
+        const cleanup = $effect.root(() => {
+            useResizeObserver(el, () => {})
+        })
+        flushSync()
+        expect(instances[0].disconnected).toBe(0)
+        cleanup()
+        expect(instances[0].disconnected).toBe(1)
+    })
+
+    it('accepts a getter target', () => {
+        const el = document.createElement('div')
+        const cleanup = $effect.root(() => {
+            useResizeObserver(
+                () => el,
+                () => {}
+            )
+        })
+        flushSync()
+        expect(instances[0].observed[0].el).toBe(el)
+        cleanup()
+    })
+
+    it('is a no-op for a nullish target', () => {
+        const cleanup = $effect.root(() => {
+            useResizeObserver(null, () => {})
+        })
+        flushSync()
+        expect(instances).toHaveLength(0)
+        cleanup()
+    })
+
+    it('re-observes when a reactive getter target changes', () => {
+        const a = document.createElement('div')
+        const b = document.createElement('div')
+        let current = $state(a)
+        const cleanup = $effect.root(() => {
+            useResizeObserver(
+                () => current,
+                () => {}
+            )
+        })
+        flushSync()
+        expect(instances).toHaveLength(1)
+        expect(instances[0].observed[0].el).toBe(a)
+
+        current = b
+        flushSync()
+        expect(instances[0].disconnected).toBe(1)
+        expect(instances).toHaveLength(2)
+        expect(instances[1].observed[0].el).toBe(b)
+        cleanup()
+    })
+
+    it('useElementSize reflects content-box size reactively', () => {
+        const el = document.createElement('div')
+        let size: ReturnType<typeof useElementSize>
+        const cleanup = $effect.root(() => {
+            size = useElementSize(el)
+        })
+        flushSync()
+        expect(size!.width).toBe(0)
+        expect(size!.height).toBe(0)
+
+        instances[0].emit([{ contentRect: { width: 120, height: 80 } as DOMRectReadOnly }])
+        flushSync()
+        expect(size!.width).toBe(120)
+        expect(size!.height).toBe(80)
+        cleanup()
+    })
+
+    it('disconnects every observer it creates (no dangling observers)', () => {
+        const a = document.createElement('div')
+        const b = document.createElement('div')
+        let current = $state(a)
+        const cleanup = $effect.root(() => {
+            useResizeObserver(
+                () => current,
+                () => {}
+            )
+        })
+        flushSync()
+        current = b
+        flushSync()
+        cleanup()
+        expect(instances).toHaveLength(2)
+        expect(instances.every((i) => i.disconnected === 1)).toBe(true)
+    })
+
+    it('observes once for a static target despite unrelated state changes', () => {
+        const el = document.createElement('div')
+        let unrelated = $state(0)
+        let ticks = 0
+        const cleanup = $effect.root(() => {
+            useResizeObserver(el, () => {})
+            $effect(() => {
+                void unrelated
+                ticks++
+            })
+        })
+        flushSync()
+        expect(instances).toHaveLength(1)
+        unrelated = 1
+        flushSync()
+        unrelated = 2
+        flushSync()
+        expect(ticks).toBeGreaterThan(1)
+        expect(instances).toHaveLength(1)
+        cleanup()
+    })
+
+    it('useElementSize does not trigger updates when the size is unchanged', () => {
+        const el = document.createElement('div')
+        let renders = 0
+        let size: ReturnType<typeof useElementSize>
+        const cleanup = $effect.root(() => {
+            size = useElementSize(el)
+            $effect(() => {
+                void size!.width
+                void size!.height
+                renders++
+            })
+        })
+        flushSync()
+        const initial = renders
+
+        instances[0].emit([{ contentRect: { width: 100, height: 50 } as DOMRectReadOnly }])
+        flushSync()
+        const afterChange = renders
+        expect(afterChange).toBeGreaterThan(initial)
+
+        instances[0].emit([{ contentRect: { width: 100, height: 50 } as DOMRectReadOnly }])
+        flushSync()
+        expect(renders).toBe(afterChange)
+        cleanup()
+    })
+})

--- a/src/lib/hooks/useResizeObserver.svelte.ts
+++ b/src/lib/hooks/useResizeObserver.svelte.ts
@@ -1,0 +1,87 @@
+type ElementTarget = HTMLElement | null | undefined | (() => HTMLElement | null | undefined)
+
+/**
+ * Observe an element's size changes with a `ResizeObserver` and automatic cleanup.
+ *
+ * The target may be a value or a getter; when it is a getter that reads reactive
+ * state, the observer re-attaches as the target changes. SSR-safe: a nullish
+ * target is a no-op.
+ *
+ * @example
+ * ```svelte
+ * <script>
+ *   import { useResizeObserver } from 'sv5ui'
+ *
+ *   let el = $state<HTMLElement>()
+ *   useResizeObserver(() => el, ([entry]) => {
+ *     console.log(entry.contentRect.width)
+ *   })
+ * </script>
+ *
+ * <div bind:this={el}>resize me</div>
+ * ```
+ */
+export function useResizeObserver(
+    target: ElementTarget,
+    callback: ResizeObserverCallback,
+    options?: ResizeObserverOptions
+): void {
+    const resolveTarget = typeof target === 'function' ? target : () => target
+
+    $effect(() => {
+        const el = resolveTarget()
+        if (!el) return
+
+        const observer = new ResizeObserver(callback)
+        observer.observe(el, options)
+
+        return () => observer.disconnect()
+    })
+}
+
+export interface UseElementSizeReturn {
+    /** Current content-box width in pixels. */
+    readonly width: number
+    /** Current content-box height in pixels. */
+    readonly height: number
+}
+
+/**
+ * Track an element's content-box size reactively.
+ *
+ * Built on `useResizeObserver`. The size starts at `0` and updates on the
+ * observer's initial callback and on every subsequent resize. SSR-safe.
+ *
+ * @example
+ * ```svelte
+ * <script>
+ *   import { useElementSize } from 'sv5ui'
+ *
+ *   let el = $state<HTMLElement>()
+ *   const size = useElementSize(() => el)
+ * </script>
+ *
+ * <div bind:this={el}>...</div>
+ * <p>{size.width} × {size.height}</p>
+ * ```
+ */
+export function useElementSize(target: ElementTarget): UseElementSizeReturn {
+    let width = $state(0)
+    let height = $state(0)
+
+    useResizeObserver(target, (entries) => {
+        const entry = entries[0]
+        if (!entry) return
+        width = entry.contentRect.width
+        height = entry.contentRect.height
+    })
+
+    return {
+        get width() {
+            return width
+        },
+        get height() {
+            return height
+        }
+    }
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -74,7 +74,8 @@
             icon: 'lucide:arrow-down-to-line'
         },
         { href: '/use-escape-keydown', label: 'useEscapeKeydown', icon: 'lucide:keyboard' },
-        { href: '/use-debounce', label: 'useDebounce', icon: 'lucide:timer' }
+        { href: '/use-debounce', label: 'useDebounce', icon: 'lucide:timer' },
+        { href: '/use-resize-observer', label: 'useResizeObserver', icon: 'lucide:scaling' }
     ]
 
     const docItems = [

--- a/src/routes/use-resize-observer/+page.svelte
+++ b/src/routes/use-resize-observer/+page.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+    import { useElementSize, useResizeObserver } from '$lib/index.js'
+    import { Badge, Icon } from '$lib/index.js'
+
+    // ==================== useElementSize ====================
+    let box = $state<HTMLElement>()
+    const size = useElementSize(() => box)
+
+    // ==================== useResizeObserver (lower-level) ====================
+    let box2 = $state<HTMLElement>()
+    let breakpoint = $state('—')
+
+    useResizeObserver(
+        () => box2,
+        ([entry]) => {
+            const w = entry.contentRect.width
+            breakpoint = w < 260 ? 'sm' : w < 420 ? 'md' : 'lg'
+        }
+    )
+
+    const breakpointColor = $derived(
+        breakpoint === 'sm' ? 'warning' : breakpoint === 'md' ? 'info' : 'success'
+    )
+</script>
+
+<div class="space-y-8">
+    <div class="space-y-2">
+        <h1 class="text-2xl font-bold">useResizeObserver / useElementSize</h1>
+        <p class="text-on-surface-variant">
+            Observe an element's size with a <code>ResizeObserver</code> and automatic cleanup.
+            <code>useElementSize</code> returns the reactive content-box size; the target may be a value
+            or a reactive getter. SSR-safe.
+        </p>
+    </div>
+
+    <!-- useElementSize -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">useElementSize</h2>
+        <p class="text-sm text-on-surface-variant">
+            Drag the bottom-right corner of the box — the size updates live.
+        </p>
+        <div class="rounded-lg bg-surface-container-high p-4">
+            <div
+                bind:this={box}
+                class="flex min-h-32 max-w-full min-w-48 resize items-center justify-center overflow-auto rounded-lg border-2 border-dashed border-outline-variant bg-surface p-4"
+            >
+                <Badge
+                    label="{Math.round(size.width)} × {Math.round(size.height)}"
+                    color="primary"
+                    variant="soft"
+                    size="lg"
+                />
+            </div>
+        </div>
+    </section>
+
+    <!-- useResizeObserver -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">useResizeObserver (lower-level callback)</h2>
+        <p class="text-sm text-on-surface-variant">
+            The raw callback reads each entry's <code>contentRect</code>. Here it maps the width to
+            a responsive breakpoint — resize horizontally to see it change.
+        </p>
+        <div class="rounded-lg bg-surface-container-high p-4">
+            <div
+                bind:this={box2}
+                class="flex min-h-24 max-w-full min-w-44 resize-x items-center justify-center gap-2 overflow-auto rounded-lg border-2 border-dashed border-outline-variant bg-surface p-4"
+            >
+                <Icon name="lucide:scaling" size="16" class="text-on-surface-variant" />
+                <Badge label="breakpoint: {breakpoint}" color={breakpointColor} variant="soft" />
+            </div>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
Closes #113

Adds `useResizeObserver` + `useElementSize` — `ResizeObserver`-based composables with automatic cleanup.

- `useResizeObserver(target, callback, options?)` runs a callback on size changes; `useElementSize(target)` returns the reactive content-box size.
- Value or reactive-getter target; SSR-safe no-op; disconnects on unmount and re-attaches on target change.

**Verification:** 10 tests (observe/callback/disconnect, getter target, nullish no-op, re-observe, no dangling observers, no re-observe on unrelated state, no redundant update on unchanged size); svelte-check clean; demo page + nav; build/publint pass.
