### PR TITLE
chore: remove third-party UI library (Nuxt) references

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -32,15 +32,6 @@ body:
       validations:
           required: true
 
-    - type: input
-      id: nuxt-parity
-      attributes:
-          label: Nuxt UI v4 reference
-          description: sv5ui mirrors Nuxt UI v4 where possible. Link the equivalent component/prop if one exists.
-          placeholder: https://ui.nuxt.com/components/button
-      validations:
-          required: false
-
     - type: textarea
       id: alternatives
       attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,7 +28,7 @@ Closes #
 - [ ] `pnpm test` passes
 - [ ] Added or updated tests for the change
 - [ ] Updated `CHANGELOG.md` under `[Unreleased]`
-- [ ] Followed component conventions (no comments outside `*.types.ts`, Material 3 design tokens, Nuxt UI v4 parity)
+- [ ] Followed component conventions (no comments outside `*.types.ts`, Material 3 design tokens)
 
 ## Screenshots / notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,7 +170,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Form** — Centralized form validation and submission component with full parity to Nuxt UI v4's Form. Supports Zod 3.24+, Valibot 1.0+, Yup 1.7+ (via Standard Schema) and Joi 17+ (dedicated adapter). Features: custom validate function (sync/async), field-level validation on blur/input/change/focus with per-field debounce and eager-after-first-blur semantics, dirty/touched/blurred field tracking, loading auto-disable, nested forms with cascading validation/setErrors/clear/reset and state merging (full-form and field-scoped), schema transform output, full programmatic API via `bind:api` (submit, validate, clear, reset, setErrors, getErrors, errors, loading, dirty, submitCount)
+- **Form** — Centralized form validation and submission component. Supports Zod 3.24+, Valibot 1.0+, Yup 1.7+ (via Standard Schema) and Joi 17+ (dedicated adapter). Features: custom validate function (sync/async), field-level validation on blur/input/change/focus with per-field debounce and eager-after-first-blur semantics, dirty/touched/blurred field tracking, loading auto-disable, nested forms with cascading validation/setErrors/clear/reset and state merging (full-form and field-scoped), schema transform output, full programmatic API via `bind:api` (submit, validate, clear, reset, setErrors, getErrors, errors, loading, dirty, submitCount)
 - **useFormFieldEmit / wireFormEvents** — Helper hooks for custom input components to emit form events (blur, input, change, focus) to the parent Form via the FormField context
 - **Input** — `InputValue` generic type (`string | number | bigint | boolean | null | undefined`) and `InputProps<T extends InputValue>` for type-safe `bind:value` inference based on the input `type` attribute
 - **FormField** — `eagerValidation`, `validateOnInputDelay`, and `errorPattern` props for fine-grained field-level validation control when used inside a Form
@@ -255,7 +255,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Refactored all existing components to align with Nuxt UI v4 structure
+- Refactored all existing components to a consistent slot/variant structure
 - Added `ref` prop with `$bindable(null)` to all components
 - Standardized restProps spread order across all components
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ These are enforced by review and keep 40+ components consistent:
 
 - **No comments in code** except inside `*.types.ts` files. Rely on naming and types instead.
 - **Material Design 3 design tokens only** — use `bg-primary`, `text-on-surface`, `ring-outline-variant`, etc. Never hardcode colors.
-- **Mirror Nuxt UI v4** — match its slot names, variant names, and `defaultVariants` where reasonable. Diverge only with a documented reason.
+- **Consistent API surface** — use clear, consistent slot names, variant names, and `defaultVariants` across components. Diverge only with a documented reason.
 - **Styling via `tailwind-variants`** (`*.variants.ts`), with slots and `compoundVariants` for color × variant combinations.
 - **Svelte 5 runes** — `$derived` for simple derivations, `$derived.by` only for multi-line logic; avoid `$effect` unless necessary; `$bindable` for two-way props.
 - **Public types** must not leak `any`/`unknown` or internal slot/variant types. Export only what users need (`Props`, and user-facing `Size`/`Color`/`Variant`).

--- a/src/lib/components/Collapsible/Collapsible.svelte.spec.ts
+++ b/src/lib/components/Collapsible/Collapsible.svelte.spec.ts
@@ -179,7 +179,7 @@ describe('Collapsible', () => {
 
         it('should not have extra default classes on root', () => {
             render(CollapsibleTestWrapper)
-            // root slot is empty by default (matching Nuxt UI)
+            // root slot is empty by default
             expect(getRoot()).not.toBeNull()
         })
     })

--- a/src/lib/components/Form/form.context.svelte.ts
+++ b/src/lib/components/Form/form.context.svelte.ts
@@ -268,7 +268,7 @@ export class FormContext<T = unknown> {
     // ==================== VALIDATION CORE ====================
 
     // The validation pipeline inherently has 6 sequential stages (nested → custom →
-    // schema → merge → scope → transform) mirroring Nuxt UI's Form.vue. Decomposing
+    // schema → merge → scope → transform). Decomposing
     // further would fragment the logic across helpers without reducing real complexity.
     // eslint-disable-next-line complexity
     async validate(opts: FormValidateOpts = {}): Promise<T | false> {

--- a/src/lib/components/Form/form.variants.ts
+++ b/src/lib/components/Form/form.variants.ts
@@ -4,7 +4,7 @@ import { tv, type VariantProps } from 'tailwind-variants'
  * Form component variants.
  *
  * The Form component renders a near-styleless `<form>` (or `<div>` for nested forms) —
- * matching Nuxt UI v4's minimal form theme. This exists primarily so users can inject
+ * a minimal form theme. This exists primarily so users can inject
  * shared form spacing via `defineConfig({ form: { slots: { root: 'space-y-4' } } })`.
  */
 export const formVariants = tv({

--- a/src/lib/components/Input/input.types.ts
+++ b/src/lib/components/Input/input.types.ts
@@ -8,9 +8,9 @@ import type { AvatarProps } from '../Avatar/avatar.types.js'
  * Valid value types for `<Input bind:value>`.
  *
  * Covers every HTML input `type` except `"file"` (which uses `FileList` and is
- * typically handled via `onchange` events, not `bind:value`). Pattern borrowed
- * from Nuxt UI v4's `AcceptableValue` — it's the minimum union that covers
- * real-world usage while still giving TypeScript enough to catch mistakes.
+ * typically handled via `onchange` events, not `bind:value`). It's the minimum
+ * union that covers real-world usage while still giving TypeScript enough to
+ * catch mistakes.
  *
  * Use with the component generic for strict typing:
  * ```ts

--- a/src/lib/components/SelectMenu/SelectMenu.svelte
+++ b/src/lib/components/SelectMenu/SelectMenu.svelte
@@ -399,7 +399,7 @@
         return 'type' in item && item.type === 'label'
     }
 
-    // ---- Event handlers (Nuxt UI v4 pattern) ----
+    // ---- Event handlers ----
     function onUpdateOpen(val: boolean) {
         if (!val) {
             resetSearch()


### PR DESCRIPTION
Removes every reference to **Nuxt** from the tracked repository to avoid any appearance of derivation (copyright caution).

- **src/** (code comments): Form context, `form.variants`, `SelectMenu`, `input.types`, Collapsible spec — rephrased to neutral wording.
- **docs**: `CONTRIBUTING` ("Mirror Nuxt UI v4" → "Consistent API surface"), `CHANGELOG` (dropped "full parity with Nuxt UI v4" / "align with Nuxt UI v4 structure" claims).
- **.github**: `pull_request_template` (removed "Nuxt UI v4 parity" item), `feature_request.yml` (removed the "Nuxt UI v4 reference" field).

> Note: the internal `.claude/` review skills are **git-ignored** (local tooling, never published) so they are not part of this PR; they were scrubbed locally too for consistency.

**Verification:** repo-wide `grep -i nuxt` over tracked files = **0**; `lint` clean · `svelte-check` 0 · `build`/publint "All good!". No code or public API change.
