### PR TITLE
refactor(hooks): route all listener management through useEventListener

### DIFF
--- a/HOOKS_PLAN.md
+++ b/HOOKS_PLAN.md
@@ -1,0 +1,93 @@
+# SV5UI Hooks — Roadmap & Packaging Plan
+
+Plan for growing the composables (`src/lib/hooks`) that ship with SV5UI.
+
+## Packaging decision
+
+**Keep hooks inside the `sv5ui` package — do NOT split into a separate npm.**
+
+Hooks are exported from the main entry (`export * from './hooks/index.js'`) and
+tree-shaking already works (ESM named exports + `sideEffects: ["**/*.css"]`), so
+importing a single hook does not pull components into the bundle. Adding more
+hooks scales fine in one package.
+
+Optional polish (not required): a `sv5ui/hooks` subpath export — purely for API
+clarity, no meaningful bundle benefit. Worth doing only if/when the public
+surface needs the clearer separation.
+
+### When a separate package WOULD be justified
+
+Split into `@sv5ui/hooks` only if **all** of these become true — none apply today:
+
+- The hooks have an audience that wants them **without** the components.
+- They genuinely need an **independent release cadence**.
+- They carry their own peer deps / different version policy.
+
+Number of hooks (7 vs 25) is not the trigger — independent audience + lifecycle is.
+
+> Caveat: `useFormField` / `useFormFieldEmit` / `FORM_FIELD_CONTEXT_KEY` are coupled
+> to the Form/FormField components (shared context key). They cannot be extracted
+> cleanly and should stay regardless.
+
+## Existing hooks (7)
+
+`useMediaQuery`, `useClipboard`, `useFormField` (+ `useFormFieldEmit`,
+`FORM_FIELD_CONTEXT_KEY`), `useClickOutside`, `useInfiniteScroll`,
+`useEscapeKeydown`, `useDebounce`.
+
+## Proposed new hooks
+
+### Group A — Component support (UI-library fit, dogfood-able)
+
+| Hook                                   | Signature (sketch)                                            | Dogfood target                                            | Value                                             |
+| -------------------------------------- | ------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------- |
+| `useEventListener`                     | `useEventListener(target, type, handler, opts?)`              | many hand-rolled `addEventListener`                       | Foundation; auto-cleanup; other hooks build on it |
+| `useResizeObserver` / `useElementSize` | `const size = useElementSize(() => el)` → `{ width, height }` | Tabs indicator, Carousel, Table                           | Repeated pattern, easy to leak; centralize        |
+| `useScrollLock`                        | `useScrollLock(() => open)`                                   | Modal / Slideover / Drawer (existing `scroll-lock` chunk) | Body scroll lock without layout shift             |
+| `useFocusTrap`                         | `useFocusTrap(() => el, { active, restore })`                 | Modal / Slideover / Drawer / Popover                      | a11y; hard to get right — worth packaging         |
+| `useThrottle`                          | `const t = useThrottle({ delay }); t.run(fn)`                 | scroll / resize / search                                  | Natural companion to `useDebounce`                |
+| `useIntersectionObserver`              | `useIntersectionObserver(() => el, cb, opts)`                 | generalizes `useInfiniteScroll`                           | Lazy images, reveal-on-scroll, visibility         |
+| `useTimeout` / `useInterval`           | `useInterval(fn, () => ms, { paused })`                       | Toast auto-dismiss, Carousel autoplay                     | Timers with proper runes teardown                 |
+| `useHotkeys`                           | `useHotkeys({ 'mod+k': open, esc: close })`                   | Command (⌘K palette)                                      | Declarative shortcuts, auto listener cleanup      |
+
+### Group B — Large-system / scale & robustness
+
+| Hook                        | Signature (sketch)                                                          | Value for large apps                                                                                                                                        |
+| --------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `useLocalStorage`           | `const v = useLocalStorage('key', default)`                                 | Persistent reactive state + **cross-tab sync** (storage event): prefs, drafts, theme, Table column state. Dogfood: Banner                                   |
+| `useVirtualizer` ⭐         | `useVirtualizer({ count, estimateSize, getScrollEl })`                      | **Highest impact** — virtual scrolling for thousand-row lists/tables (Table review flagged the missing virtualization). Serves Table / SelectMenu / Command |
+| `useAsync` / `useAsyncData` | `useAsync(fetcher, { immediate })` → `{ data, error, loading, run, abort }` | Async state machine + abort-on-unmount + race protection. Backs async SelectMenu options, Table server data                                                 |
+| `useDebouncedState`         | `let s = useDebouncedState('', 200)`                                        | State + debounce combined — the pattern hand-written in SelectMenu, reusable for search at scale                                                            |
+| `useBroadcastChannel`       | `const ch = useBroadcastChannel('auth')`                                    | Cross-tab sync (logout/login, cache invalidation) — enterprise standard                                                                                     |
+| `useNetworkStatus`          | `const net = useNetworkStatus()` → `{ online, effectiveType }`              | Offline banners, queue/defer actions when offline                                                                                                           |
+| `useIdle`                   | `const idle = useIdle({ timeout })`                                         | Auto-logout, pause polling when idle — internal/secure systems                                                                                              |
+| `usePreferredReducedMotion` | `const reduce = usePreferredReducedMotion()`                                | a11y across all SV5UI animations (`theme.css` keyframes) — respect `prefers-reduced-motion`                                                                 |
+
+### Explicitly skipped
+
+`useDarkMode` (covered by the `mode-watcher` peer), `useId` (provided by bits-ui),
+`useToggle` / `useBoolean` (too trivial to justify).
+
+## Sequencing (composition-aware)
+
+1. **Foundation** — `useEventListener`, then `useResizeObserver`,
+   `useIntersectionObserver`, `useTimeout`/`useInterval` build on it.
+2. **a11y / overlays (dogfood)** — `useScrollLock`, `useFocusTrap`; refactor
+   Modal/Slideover/Drawer to use them (cuts internal duplication, real tests).
+3. **Scale tier 1** — `useLocalStorage`, `useDebouncedState`, `useThrottle`, `useAsync`.
+4. **Scale tier 2 (enterprise)** — `useVirtualizer` (large; own milestone),
+   `useBroadcastChannel`, `useNetworkStatus`, `useIdle`,
+   `usePreferredReducedMotion`, `useHotkeys`.
+
+### Suggested starter batch (best value/effort)
+
+`useEventListener` + `useResizeObserver` + `useScrollLock` + `useFocusTrap` +
+`useLocalStorage` — all dogfood-able immediately (Tabs / overlays / Banner),
+reduce duplicated internal code, and have real components to test against.
+
+## Delivery convention (per hook)
+
+- One file `src/lib/hooks/useX.svelte.ts` + `useX.svelte.spec.ts`.
+- Export from `src/lib/hooks/index.ts` (hook + its options type).
+- Svelte 5 runes; every listener/observer/timer cleaned up in the effect teardown.
+- One issue + one branch + PR into `dev`, following the project's branch/release flow.

--- a/src/lib/components/Tabs/Tabs.svelte
+++ b/src/lib/components/Tabs/Tabs.svelte
@@ -9,6 +9,7 @@
     import { tick, untrack } from 'svelte'
     import { tabsVariants, tabsDefaults } from './tabs.variants.js'
     import { getComponentConfig } from '../../config.js'
+    import { useResizeObserver } from '../../hooks/useResizeObserver/index.js'
     import Icon from '../Icon/Icon.svelte'
 
     const config = getComponentConfig('tabs', tabsDefaults)
@@ -118,17 +119,8 @@
     })
 
     // Handle resize with rAF debouncing
-    $effect(() => {
-        if (!listEl) return
-
-        const observer = new ResizeObserver(scheduleIndicatorUpdate)
-        observer.observe(listEl)
-
-        return () => {
-            observer.disconnect()
-            cancelAnimationFrame(rafId)
-        }
-    })
+    useResizeObserver(() => listEl, scheduleIndicatorUpdate)
+    $effect(() => () => cancelAnimationFrame(rafId))
 </script>
 
 <Tabs.Root

--- a/src/lib/hooks/useClickOutside/useClickOutside.svelte.spec.ts
+++ b/src/lib/hooks/useClickOutside/useClickOutside.svelte.spec.ts
@@ -1,5 +1,7 @@
+import { flushSync } from 'svelte'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { useClickOutside } from './useClickOutside.svelte.js'
+import type { Action } from 'svelte/action'
+import { useClickOutside, type UseClickOutsideOptions } from './useClickOutside.svelte.js'
 
 describe('useClickOutside', () => {
     let node: HTMLDivElement
@@ -13,48 +15,57 @@ describe('useClickOutside', () => {
         node.remove()
     })
 
+    function mount(options: UseClickOutsideOptions) {
+        let action: ReturnType<Action<HTMLElement, UseClickOutsideOptions>>
+        const cleanup = $effect.root(() => {
+            action = useClickOutside(node, options)
+        })
+        flushSync()
+        return { action: action!, cleanup }
+    }
+
     it('should call the handler on a pointerdown outside the node', () => {
         const handler = vi.fn()
-        const action = useClickOutside(node, { handler })
+        const { cleanup } = mount({ handler })
 
         document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
         expect(handler).toHaveBeenCalledTimes(1)
-        action?.destroy?.()
+        cleanup()
     })
 
     it('should not call the handler on a pointerdown inside the node', () => {
         const handler = vi.fn()
-        const action = useClickOutside(node, { handler })
+        const { cleanup } = mount({ handler })
 
         node.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
         expect(handler).not.toHaveBeenCalled()
-        action?.destroy?.()
+        cleanup()
     })
 
     it('should not call the handler when disabled', () => {
         const handler = vi.fn()
-        const action = useClickOutside(node, { handler, enabled: false })
+        const { cleanup } = mount({ handler, enabled: false })
 
         document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
         expect(handler).not.toHaveBeenCalled()
-        action?.destroy?.()
+        cleanup()
     })
 
     it('should react to enabled toggled via update', () => {
         const handler = vi.fn()
-        const action = useClickOutside(node, { handler, enabled: false })
+        const { action, cleanup } = mount({ handler, enabled: false })
 
         action?.update?.({ handler, enabled: true })
         document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
         expect(handler).toHaveBeenCalledTimes(1)
-        action?.destroy?.()
+        cleanup()
     })
 
-    it('should stop calling the handler after destroy', () => {
+    it('should stop calling the handler after the action is destroyed', () => {
         const handler = vi.fn()
-        const action = useClickOutside(node, { handler })
+        const { cleanup } = mount({ handler })
 
-        action?.destroy?.()
+        cleanup()
         document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
         expect(handler).not.toHaveBeenCalled()
     })

--- a/src/lib/hooks/useClickOutside/useClickOutside.svelte.ts
+++ b/src/lib/hooks/useClickOutside/useClickOutside.svelte.ts
@@ -1,4 +1,5 @@
 import type { Action } from 'svelte/action'
+import { useEventListener } from '../useEventListener/index.js'
 
 export interface UseClickOutsideOptions {
     /**
@@ -37,21 +38,21 @@ export const useClickOutside: Action<HTMLElement, UseClickOutsideOptions> = (
 ) => {
     let currentOptions = initialOptions!
 
-    function handlePointerDown(event: PointerEvent) {
-        if (currentOptions.enabled === false) return
-        if (!node.contains(event.target as Node)) {
-            currentOptions.handler(event)
-        }
-    }
-
-    document.addEventListener('pointerdown', handlePointerDown, true)
+    useEventListener(
+        () => document,
+        'pointerdown',
+        (event) => {
+            if (currentOptions.enabled === false) return
+            if (!node.contains(event.target as Node)) {
+                currentOptions.handler(event)
+            }
+        },
+        true
+    )
 
     return {
         update(newOptions) {
             currentOptions = newOptions
-        },
-        destroy() {
-            document.removeEventListener('pointerdown', handlePointerDown, true)
         }
     }
 }

--- a/src/lib/hooks/useEscapeKeydown/useEscapeKeydown.svelte.spec.ts
+++ b/src/lib/hooks/useEscapeKeydown/useEscapeKeydown.svelte.spec.ts
@@ -1,5 +1,7 @@
+import { flushSync } from 'svelte'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { useEscapeKeydown } from './useEscapeKeydown.svelte.js'
+import type { Action } from 'svelte/action'
+import { useEscapeKeydown, type UseEscapeKeydownOptions } from './useEscapeKeydown.svelte.js'
 
 describe('useEscapeKeydown', () => {
     let node: HTMLDivElement
@@ -13,48 +15,57 @@ describe('useEscapeKeydown', () => {
         node.remove()
     })
 
+    function mount(options: UseEscapeKeydownOptions) {
+        let action: ReturnType<Action<HTMLElement, UseEscapeKeydownOptions>>
+        const cleanup = $effect.root(() => {
+            action = useEscapeKeydown(node, options)
+        })
+        flushSync()
+        return { action: action!, cleanup }
+    }
+
     it('should call the handler on Escape keydown', () => {
         const handler = vi.fn()
-        const action = useEscapeKeydown(node, { handler })
+        const { cleanup } = mount({ handler })
 
         document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
         expect(handler).toHaveBeenCalledTimes(1)
-        action?.destroy?.()
+        cleanup()
     })
 
     it('should not call the handler for other keys', () => {
         const handler = vi.fn()
-        const action = useEscapeKeydown(node, { handler })
+        const { cleanup } = mount({ handler })
 
         document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
         expect(handler).not.toHaveBeenCalled()
-        action?.destroy?.()
+        cleanup()
     })
 
     it('should not call the handler when disabled', () => {
         const handler = vi.fn()
-        const action = useEscapeKeydown(node, { handler, enabled: false })
+        const { cleanup } = mount({ handler, enabled: false })
 
         document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
         expect(handler).not.toHaveBeenCalled()
-        action?.destroy?.()
+        cleanup()
     })
 
     it('should react to enabled toggled via update', () => {
         const handler = vi.fn()
-        const action = useEscapeKeydown(node, { handler, enabled: false })
+        const { action, cleanup } = mount({ handler, enabled: false })
 
         action?.update?.({ handler, enabled: true })
         document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
         expect(handler).toHaveBeenCalledTimes(1)
-        action?.destroy?.()
+        cleanup()
     })
 
-    it('should stop calling the handler after destroy', () => {
+    it('should stop calling the handler after the action is destroyed', () => {
         const handler = vi.fn()
-        const action = useEscapeKeydown(node, { handler })
+        const { cleanup } = mount({ handler })
 
-        action?.destroy?.()
+        cleanup()
         document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
         expect(handler).not.toHaveBeenCalled()
     })

--- a/src/lib/hooks/useEscapeKeydown/useEscapeKeydown.svelte.ts
+++ b/src/lib/hooks/useEscapeKeydown/useEscapeKeydown.svelte.ts
@@ -1,4 +1,5 @@
 import type { Action } from 'svelte/action'
+import { useEventListener } from '../useEventListener/index.js'
 
 export interface UseEscapeKeydownOptions {
     /**
@@ -37,21 +38,20 @@ export const useEscapeKeydown: Action<HTMLElement, UseEscapeKeydownOptions> = (
 ) => {
     let currentOptions = initialOptions!
 
-    function handleKeydown(event: KeyboardEvent) {
-        if (currentOptions.enabled === false) return
-        if (event.key === 'Escape') {
-            currentOptions.handler(event)
+    useEventListener(
+        () => document,
+        'keydown',
+        (event) => {
+            if (currentOptions.enabled === false) return
+            if (event.key === 'Escape') {
+                currentOptions.handler(event)
+            }
         }
-    }
-
-    document.addEventListener('keydown', handleKeydown)
+    )
 
     return {
         update(newOptions) {
             currentOptions = newOptions
-        },
-        destroy() {
-            document.removeEventListener('keydown', handleKeydown)
         }
     }
 }

--- a/src/lib/hooks/useFocusTrap/useFocusTrap.svelte.ts
+++ b/src/lib/hooks/useFocusTrap/useFocusTrap.svelte.ts
@@ -1,4 +1,5 @@
 import { toGetter } from '../utils.js'
+import { useEventListener } from '../useEventListener/index.js'
 
 type ElementTarget = HTMLElement | null | undefined | (() => HTMLElement | null | undefined)
 
@@ -81,8 +82,21 @@ export function useFocusTrap(target: ElementTarget, options: UseFocusTrapOptions
             ;(initial ?? getFocusable(el)[0] ?? el).focus()
         }
 
-        function handleKeydown(event: KeyboardEvent) {
+        return () => {
+            if (restoreFocus && previouslyFocused && document.contains(previouslyFocused)) {
+                previouslyFocused.focus()
+            }
+        }
+    })
+
+    useEventListener(
+        () => (resolveActive() && resolveTarget() ? document : null),
+        'keydown',
+        (event) => {
             if (event.key !== 'Tab') return
+            const el = resolveTarget()
+            if (!el) return
+
             const focusable = getFocusable(el)
             if (focusable.length === 0) {
                 event.preventDefault()
@@ -101,15 +115,7 @@ export function useFocusTrap(target: ElementTarget, options: UseFocusTrapOptions
                 event.preventDefault()
                 first.focus()
             }
-        }
-
-        document.addEventListener('keydown', handleKeydown, true)
-
-        return () => {
-            document.removeEventListener('keydown', handleKeydown, true)
-            if (restoreFocus && previouslyFocused && document.contains(previouslyFocused)) {
-                previouslyFocused.focus()
-            }
-        }
-    })
+        },
+        true
+    )
 }

--- a/src/lib/hooks/useInfiniteScroll/useInfiniteScroll.svelte.spec.ts
+++ b/src/lib/hooks/useInfiniteScroll/useInfiniteScroll.svelte.spec.ts
@@ -1,3 +1,4 @@
+import { flushSync } from 'svelte'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useInfiniteScroll } from './useInfiniteScroll.svelte.js'
 
@@ -46,8 +47,9 @@ describe('useInfiniteScroll', () => {
         let api: ReturnType<typeof useInfiniteScroll>
         const cleanup = $effect.root(() => {
             api = useInfiniteScroll({ onLoad })
+            api.action(node)
         })
-        api!.action(node)
+        flushSync()
 
         node.scrollTop = node.scrollHeight - node.clientHeight
         node.dispatchEvent(new Event('scroll'))
@@ -69,8 +71,9 @@ describe('useInfiniteScroll', () => {
         let api: ReturnType<typeof useInfiniteScroll>
         const cleanup = $effect.root(() => {
             api = useInfiniteScroll({ onLoad, enabled: () => false })
+            api.action(node)
         })
-        api!.action(node)
+        flushSync()
 
         node.scrollTop = node.scrollHeight - node.clientHeight
         node.dispatchEvent(new Event('scroll'))
@@ -92,8 +95,9 @@ describe('useInfiniteScroll', () => {
         let api: ReturnType<typeof useInfiniteScroll>
         const cleanup = $effect.root(() => {
             api = useInfiniteScroll({ onLoad })
+            api.action(node)
         })
-        api!.action(node)
+        flushSync()
 
         node.scrollTop = node.scrollHeight - node.clientHeight
         node.dispatchEvent(new Event('scroll'))
@@ -114,8 +118,9 @@ describe('useInfiniteScroll', () => {
         let api: ReturnType<typeof useInfiniteScroll>
         const cleanup = $effect.root(() => {
             api = useInfiniteScroll({ onLoad, threshold: 50 })
+            api.action(node)
         })
-        api!.action(node)
+        flushSync()
 
         node.scrollTop = 0
         node.dispatchEvent(new Event('scroll'))

--- a/src/lib/hooks/useInfiniteScroll/useInfiniteScroll.svelte.ts
+++ b/src/lib/hooks/useInfiniteScroll/useInfiniteScroll.svelte.ts
@@ -1,4 +1,5 @@
 import type { Action } from 'svelte/action'
+import { useEventListener } from '../useEventListener/index.js'
 
 export interface UseInfiniteScrollOptions {
     /**
@@ -83,17 +84,12 @@ export function useInfiniteScroll(
     }
 
     const action: Action<HTMLElement> = (node) => {
-        function handleScroll() {
-            check(node)
-        }
-
-        node.addEventListener('scroll', handleScroll, { passive: true })
-
-        return {
-            destroy() {
-                node.removeEventListener('scroll', handleScroll)
-            }
-        }
+        useEventListener(
+            () => node,
+            'scroll',
+            () => check(node),
+            { passive: true }
+        )
     }
 
     return {


### PR DESCRIPTION
## Summary

Compose the foundation hooks instead of hand-rolling event/observer wiring, so every listener in the hooks layer goes through a single audited code path with automatic cleanup.

| Hook / Component | Before | After |
|---|---|---|
| `useFocusTrap` | manual `document.addEventListener('keydown', …, true)` + remove | `useEventListener(() => active && target ? document : null, 'keydown', …, true)`; the `$effect` now only handles initial-focus + restore |
| `Tabs` | manual `new ResizeObserver` | `useResizeObserver(() => listEl, …)` (keeps the rAF-cancel cleanup) |
| `useClickOutside` | add/remove `pointerdown` + `destroy` | `useEventListener(() => document, 'pointerdown', …, true)` |
| `useEscapeKeydown` | add/remove `keydown` + `destroy` | `useEventListener(() => document, 'keydown', …)` |
| `useInfiniteScroll` | `node.addEventListener('scroll', …, { passive: true })` + `destroy` | `useEventListener(() => node, 'scroll', …, { passive: true })` |

### Why the actions changed
Svelte 5 actions run inside an effect context, so `$effect` (and therefore `useEventListener`) works within them and tears down automatically when the node is removed. The manual `removeEventListener` / `destroy` returns are no longer needed.

### Tests
The three action specs move to the `$effect.root` + `flushSync` pattern, exercising the real Svelte 5 action lifecycle (cleanup via effect teardown rather than calling `destroy()` directly).

## Skipped (intentionally)
- `useMediaQuery` — the `MediaQueryList` is created, read (`matches`), and listened to within one effect; `useEventListener` can't own the MQL creation, so a rewrite would be more complex.
- `Table` column-resize drag and `Editor` outside-click — transient/imperative listeners bound inside component-specific logic.

## Verification
- `prettier --check .` + `eslint .` — clean
- `svelte-check` — 0 errors / 0 warnings
- `vite build` + `svelte-package` + `publint` — All good!
- Full test suite — **2496 passed (69 files)**, including components that consume these actions via `use:`