### PR TITLE
fix(menu): size the checkbox/radio checked indicator icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - **`hydration_mismatch`** — when the trigger held interactive content (the multi-select `selected` slot renders chip-remove `<button>`s), those buttons nested inside the trigger's own `<button>`, which is invalid HTML the browser restructures — so the hydrated DOM no longer matched the server output. The trigger now renders a `<div role="button">` (via bits-ui's `child` snippet) so interactive trigger content is valid. Consumers that select the trigger by tag should target `[data-combobox-trigger]` instead of `button`.
     - **"aria-hidden on a focused element"** — the visually-hidden combobox input carried `aria-hidden` while bits-ui focuses it on open; it now uses `aria-label`, so the real control is accessible rather than hidden-yet-focused.
     - **blocked `autofocus`** — removed the `autofocus` on the in-dropdown search input; it was already blocked (bits-ui focuses the combobox input first) and therefore non-functional.
+- **DropdownMenu / ContextMenu** — The checkbox/radio checked indicator no longer renders an oversized, unstyled checkmark. The indicator `<Icon>` had no size and fell back to the 24px default, overflowing its slot; it now fills the slot (`size-full`) so it scales with the component size.
 
 ## [2.1.0] - 2026-06-13
 

--- a/src/lib/components/ContextMenu/ContextMenu.svelte
+++ b/src/lib/components/ContextMenu/ContextMenu.svelte
@@ -177,7 +177,7 @@
             {:else}
                 <span class={classes.itemIndicator}>
                     {#if item.checked}
-                        <Icon name={checkedIcon} />
+                        <Icon name={checkedIcon} class="size-full" />
                     {/if}
                 </span>
             {/if}
@@ -206,7 +206,7 @@
             {:else}
                 <span class={classes.itemIndicator}>
                     {#if firstRadioGroup?.value === item.value}
-                        <Icon name={checkedIcon} />
+                        <Icon name={checkedIcon} class="size-full" />
                     {/if}
                 </span>
             {/if}

--- a/src/lib/components/DropdownMenu/DropdownMenu.svelte
+++ b/src/lib/components/DropdownMenu/DropdownMenu.svelte
@@ -187,7 +187,7 @@
             {:else}
                 <span class={classes.itemIndicator}>
                     {#if item.checked}
-                        <Icon name={checkedIcon} />
+                        <Icon name={checkedIcon} class="size-full" />
                     {/if}
                 </span>
             {/if}
@@ -216,7 +216,7 @@
             {:else}
                 <span class={classes.itemIndicator}>
                     {#if firstRadioGroup?.value === item.value}
-                        <Icon name={checkedIcon} />
+                        <Icon name={checkedIcon} class="size-full" />
                     {/if}
                 </span>
             {/if}


### PR DESCRIPTION
## Summary

The checked indicator in DropdownMenu and ContextMenu rendered an **oversized, unstyled checkmark** (visible on multi-select / checkbox items).

**Cause:** the indicator rendered `<Icon name={checkedIcon} />` with **no size**, so it used the `Icon` component's 24px default and overflowed its 16px (`size-4`) indicator slot.

**Fix:** the icon now fills its variant-sized slot via `class="size-full"` (the same pattern SelectMenu already uses for its indicator), so it scales correctly with the component size. Applied to both DropdownMenu and ContextMenu (checkbox item + radio item).

## Verification
- `svelte-check` — 0 errors
- DropdownMenu + ContextMenu specs — **104 passed**
- Confirmed visually (Playwright screenshot): the checkmark is now small and aligned with the label.

## Before / after
- Before: large bare ✓ to the left of the label
- After: a neat checkmark sized to the text