### PR TITLE
fix(package): preprocess TS in .svelte when packaging (Rolldown / Vite 8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - **`hydration_mismatch`** — when the trigger held interactive content (the multi-select `selected` slot renders chip-remove `<button>`s), those buttons nested inside the trigger's own `<button>`, which is invalid HTML the browser restructures — so the hydrated DOM no longer matched the server output. The trigger now renders a `<div role="button">` (via bits-ui's `child` snippet) so interactive trigger content is valid. Consumers that select the trigger by tag should target `[data-combobox-trigger]` instead of `button`.
     - **"aria-hidden on a focused element"** — the visually-hidden combobox input carried `aria-hidden` while bits-ui focuses it on open; it now uses `aria-label`, so the real control is accessible rather than hidden-yet-focused.
     - **blocked `autofocus`** — removed the `autofocus` on the in-dropdown search input; it was already blocked (bits-ui focuses the combobox input first) and therefore non-functional.
+- **Packaging** — Published `dist/*.svelte` files are now preprocessed to plain JavaScript instead of shipping un-transpiled TypeScript in `<script lang="ts">`. This fixes parse errors with strict bundlers — notably Rolldown in Vite 8 (`optimizeDeps` and SSR) rejecting TypeScript-only syntax such as optional parameters (`event?: Event`). No API, type, or runtime behavior change — only the published `.svelte` source is type-stripped. ([#138](https://github.com/ndlabdev/sv5ui/issues/138))
 
 ## [2.1.0] - 2026-06-13
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,7 +1,11 @@
 import adapter from '@sveltejs/adapter-auto'
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
+    // Transpile <script lang="ts"> → JS when packaging so dist is plain JS,
+    // not TS (Rolldown / Vite 8 compatibility). See #138.
+    preprocess: vitePreprocess({ script: true }),
     kit: {
         // adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
         // If your environment is not supported, or you settled on a specific environment, switch out the adapter.


### PR DESCRIPTION
Fixes the root cause of #138.

## Problem
`svelte-package` shipped `dist/**/*.svelte` with **un-transpiled TypeScript** in `<script lang="ts">` (e.g. `function handleClose(event?: Event)`), because `svelte.config.js` had no `preprocess` configured.

- The docs app built fine because the **Svelte 5 compiler strips TS natively** at compile time.
- But `svelte-package` does **not** run the compiler — it ships `.svelte` source + applies the configured preprocessors. With none configured, the raw TS survived into `dist`.
- Vite ≤7's dep optimizer used **esbuild** (lenient → stripped TS). **Vite 8** switched to **Rolldown** (oxc parser, strict), which correctly rejects TS-only syntax as invalid JS → `[PARSE_ERROR] Expected ',' or ')' but found '?'` during `optimizeDeps` + SSR.

## Fix
```js
// svelte.config.js
preprocess: vitePreprocess({ script: true }),
```
`{ script: true }` is required: the default `vitePreprocess()` leaves script TS for Svelte 5's native stripping (which `svelte-package` doesn't invoke), so it would not strip it.

## Proof (A/B on Vite 8.0.16 + Rolldown, real `npm pack` install)
| build | `dist` `.svelte` | Vite 8 optimizeDeps |
| --- | --- | --- |
| without fix | `handleClose(event?: Event)` | ❌ exact PARSE_ERROR from #138 (Timeline:78, Stepper:184, Banner:102) |
| with fix | `handleClose(event)` | ✅ succeeds |

## Safety — no behavior/API change
A full dist A/B diff (681 files) shows the change is **only** type-stripping in `.svelte`:
- `.d.ts` (public API/types): **0 differences — byte-identical**
- `.js` (variants/hooks/config/utils): **0 differences**
- package structure (file list): identical
- `.svelte`: 65 files differ — only TS annotations stripped + esbuild cosmetic reformat; optional chaining preserved, logic unchanged.

`prettier`/`eslint` clean · `svelte-check` 0 · **2,533 tests pass** · `publint` All good.

> Marked "Relates to #138" rather than "Closes" — the fix only reaches users when **published** (v2.2.0); #138 will close on release.