### PR TITLE
feat(tree): add Tree component with multi-select, checkbox propagation and full keyboard nav

### DIFF
--- a/src/lib/components/Tree/Tree.svelte
+++ b/src/lib/components/Tree/Tree.svelte
@@ -1,0 +1,773 @@
+<script lang="ts" module>
+    import type { TreeItem as TreeItemType, TreeProps } from './tree.types.js'
+
+    export type Props<T extends TreeItemType = TreeItemType> = TreeProps<T>
+</script>
+
+<script lang="ts" generics="T extends TreeItem">
+    import type { ClassNameValue } from 'tailwind-merge'
+    import { untrack } from 'svelte'
+    import { SvelteSet } from 'svelte/reactivity'
+    import { slide } from 'svelte/transition'
+    import { treeVariants, treeDefaults } from './tree.variants.js'
+    import type { TreeApi, TreeItem, TreeValue } from './tree.types.js'
+    import { getComponentConfig, iconsDefaults } from '../../config.js'
+    import Icon from '../Icon/Icon.svelte'
+
+    const config = getComponentConfig('tree', treeDefaults)
+    const icons = getComponentConfig('icons', iconsDefaults)
+
+    let {
+        ref = $bindable(null),
+        items = [],
+        getKey,
+        labelKey = 'label' as keyof T & string,
+        value = $bindable(),
+        defaultValue,
+        onValueChange,
+        expanded = $bindable(),
+        defaultExpanded,
+        onExpandedChange,
+        api = $bindable(),
+        multiple = false,
+        selectionBehavior = 'toggle',
+        propagateSelect = false,
+        bubbleSelect = false,
+        disabled = false,
+        color = config.defaultVariants.color ?? 'primary',
+        size = config.defaultVariants.size ?? 'md',
+        trailingIcon = icons.chevronDown,
+        expandedIcon = icons.folderOpen,
+        collapsedIcon = icons.folder,
+        class: className,
+        ui,
+        item: itemSnippet,
+        itemLeading,
+        itemLabel,
+        itemTrailing,
+        onclick,
+        onkeydown,
+        onpointerdown,
+        onfocusout,
+        ...restProps
+    }: TreeProps<T> = $props()
+
+    interface FlatNode {
+        item: T
+        key: string
+        parentKey: string | null
+        level: number
+        index: number
+        setsize: number
+        posinset: number
+        hasChildren: boolean
+        childKeys: string[]
+        selectableDescendantKeys: string[]
+    }
+
+    interface NodeIndex {
+        byKey: Map<string, FlatNode>
+        topLevelKeys: string[]
+        parentKeys: string[]
+    }
+
+    function resolveKey(item: T, indexPath: string): string {
+        if (getKey) return getKey(item, indexPath)
+        if (item.value !== undefined) return item.value
+        const label = item[labelKey]
+        if (typeof label === 'string' && label) return label
+        return indexPath
+    }
+
+    const nodeIndex = $derived.by((): NodeIndex => {
+        const entries: [string, FlatNode][] = []
+        const seen: Record<string, true> = Object.create(null)
+        const parentKeys: string[] = []
+
+        const walk = (
+            levelItems: T[],
+            parentKey: string | null,
+            level: number,
+            parentPath: string
+        ): { childKeys: string[]; selectable: string[] } => {
+            const childKeys: string[] = []
+            const selectable: string[] = []
+
+            levelItems.forEach((levelItem, index) => {
+                const indexPath = parentPath ? `${parentPath}.${index}` : String(index)
+                let key = resolveKey(levelItem, indexPath)
+                if (seen[key]) {
+                    key = indexPath
+                    while (seen[key]) key = `#${key}`
+                }
+                seen[key] = true
+
+                const children = Array.isArray(levelItem.children) ? levelItem.children : []
+                const node: FlatNode = {
+                    item: levelItem,
+                    key,
+                    parentKey,
+                    level,
+                    index,
+                    setsize: levelItems.length,
+                    posinset: index + 1,
+                    hasChildren: children.length > 0,
+                    childKeys: [],
+                    selectableDescendantKeys: []
+                }
+                entries.push([key, node])
+                childKeys.push(key)
+
+                if (node.hasChildren) {
+                    parentKeys.push(key)
+                    const sub = walk(children, key, level + 1, indexPath)
+                    node.childKeys = sub.childKeys
+                    node.selectableDescendantKeys = sub.selectable
+                }
+
+                if (levelItem.disabled !== true) {
+                    selectable.push(key, ...node.selectableDescendantKeys)
+                }
+            })
+
+            return { childKeys, selectable }
+        }
+
+        const root = walk(items, null, 0, '')
+        return { byKey: new Map(entries), topLevelKeys: root.childKeys, parentKeys }
+    })
+
+    if (expanded === undefined) {
+        expanded = untrack(() => {
+            if (defaultExpanded) return defaultExpanded
+            const keys: string[] = []
+            for (const node of nodeIndex.byKey.values()) {
+                if (node.item.defaultExpanded === true && node.item.disabled !== true) {
+                    keys.push(node.key)
+                }
+            }
+            return keys
+        })
+    }
+
+    if (value === undefined) {
+        value = untrack(() => defaultValue ?? (multiple ? [] : undefined))
+    }
+
+    const expandedSet = $derived(new Set(expanded ?? []))
+
+    const selectedKeys = $derived.by((): string[] => {
+        if (multiple) return Array.isArray(value) ? value : []
+        return typeof value === 'string' ? [value] : []
+    })
+
+    const selectedSet = $derived(new Set(selectedKeys))
+
+    const checkboxSelection = $derived(multiple && (propagateSelect || bubbleSelect))
+
+    const visibleKeys = $derived.by(() => {
+        const out: string[] = []
+        const visit = (keys: string[]) => {
+            for (const key of keys) {
+                out.push(key)
+                const node = nodeIndex.byKey.get(key)
+                if (node?.hasChildren && node.item.disabled !== true && expandedSet.has(key)) {
+                    visit(node.childKeys)
+                }
+            }
+        }
+        visit(nodeIndex.topLevelKeys)
+        return out
+    })
+
+    const indeterminateSet = $derived.by(() => {
+        if (!multiple || (!propagateSelect && !bubbleSelect)) return new Set<string>()
+        const keys = nodeIndex.parentKeys.filter((key) => {
+            if (selectedSet.has(key)) return false
+            const node = nodeIndex.byKey.get(key)
+            return node?.selectableDescendantKeys.some((k) => selectedSet.has(k)) === true
+        })
+        return new Set(keys)
+    })
+
+    let focusedKey = $state<string | null>(null)
+    let keyboardActive = $state(false)
+    const itemEls: Record<string, HTMLElement> = Object.create(null)
+
+    function isNodeDisabled(key: string): boolean {
+        return disabled || nodeIndex.byKey.get(key)?.item.disabled === true
+    }
+
+    const rovingKey = $derived.by(() => {
+        if (
+            focusedKey !== null &&
+            !isNodeDisabled(focusedKey) &&
+            visibleKeys.includes(focusedKey)
+        ) {
+            return focusedKey
+        }
+        return visibleKeys.find((key) => !isNodeDisabled(key)) ?? null
+    })
+
+    function registerItem(key: string) {
+        return (el: HTMLElement) => {
+            itemEls[key] = el
+            return () => {
+                delete itemEls[key]
+            }
+        }
+    }
+
+    function moveFocus(key: string | null) {
+        if (key === null) return
+        focusedKey = key
+        itemEls[key]?.focus()
+    }
+
+    function getLabel(node: FlatNode): string {
+        const label = node.item[labelKey]
+        return typeof label === 'string' ? label : ''
+    }
+
+    function isDescendantOf(key: string, ancestorKey: string): boolean {
+        let current = nodeIndex.byKey.get(key)?.parentKey ?? null
+        while (current !== null) {
+            if (current === ancestorKey) return true
+            current = nodeIndex.byKey.get(current)?.parentKey ?? null
+        }
+        return false
+    }
+
+    function setExpanded(next: string[]) {
+        expanded = next
+        onExpandedChange?.(next)
+    }
+
+    function toggleExpand(key: string) {
+        const node = nodeIndex.byKey.get(key)
+        if (!node?.hasChildren || isNodeDisabled(key)) return
+        const isOpen = expandedSet.has(key)
+        if (isOpen) {
+            setExpanded((expanded ?? []).filter((k) => k !== key))
+            if (focusedKey !== null && isDescendantOf(focusedKey, key)) moveFocus(key)
+        } else {
+            setExpanded([...(expanded ?? []), key])
+        }
+        node.item.onToggle?.(!isOpen)
+    }
+
+    function setValue(next: TreeValue | undefined) {
+        value = next
+        onValueChange?.(next)
+    }
+
+    function handleSelectSingle(node: FlatNode, wasSelected: boolean) {
+        if (!wasSelected) {
+            setValue(node.key)
+            node.item.onSelect?.(true)
+        } else if (selectionBehavior === 'toggle') {
+            setValue(undefined)
+            node.item.onSelect?.(false)
+        }
+    }
+
+    function applyPropagate(node: FlatNode, next: Set<string>, nowSelected: boolean) {
+        for (const k of node.selectableDescendantKeys) {
+            if (nowSelected) next.add(k)
+            else next.delete(k)
+        }
+    }
+
+    function applyBubble(node: FlatNode, next: Set<string>) {
+        let parentKey = node.parentKey
+        while (parentKey !== null) {
+            const parent = nodeIndex.byKey.get(parentKey)
+            if (!parent) break
+            if (parent.item.disabled !== true) {
+                const selectableChildKeys = parent.childKeys.filter(
+                    (k) => nodeIndex.byKey.get(k)?.item.disabled !== true
+                )
+                const allSelected =
+                    selectableChildKeys.length > 0 && selectableChildKeys.every((k) => next.has(k))
+                if (allSelected) next.add(parent.key)
+                else next.delete(parent.key)
+            }
+            parentKey = parent.parentKey
+        }
+    }
+
+    function handleSelectMultiple(node: FlatNode, wasSelected: boolean) {
+        const next = new SvelteSet(selectionBehavior === 'replace' ? [node.key] : selectedSet)
+        if (selectionBehavior !== 'replace') {
+            if (wasSelected) next.delete(node.key)
+            else next.add(node.key)
+        }
+
+        const nowSelected = next.has(node.key)
+        if (propagateSelect) applyPropagate(node, next, nowSelected)
+        if (bubbleSelect) applyBubble(node, next)
+
+        const changed = next.size !== selectedSet.size || [...next].some((k) => !selectedSet.has(k))
+        if (changed) setValue([...next])
+        if (wasSelected !== nowSelected) node.item.onSelect?.(nowSelected)
+    }
+
+    function handleSelect(key: string) {
+        const node = nodeIndex.byKey.get(key)
+        if (!node || disabled || node.item.disabled) return
+        const wasSelected = selectedSet.has(key)
+        if (multiple) handleSelectMultiple(node, wasSelected)
+        else handleSelectSingle(node, wasSelected)
+    }
+
+    function findEnabled(start: number, dir: 1 | -1): string | null {
+        for (let i = start; i >= 0 && i < visibleKeys.length; i += dir) {
+            const key = visibleKeys[i]
+            if (!isNodeDisabled(key)) return key
+        }
+        return null
+    }
+
+    let typeaheadQuery = ''
+    let typeaheadTimer: ReturnType<typeof setTimeout> | undefined
+
+    function handleTypeahead(char: string, currentIndex: number) {
+        clearTimeout(typeaheadTimer)
+        typeaheadQuery += char.toLowerCase()
+        typeaheadTimer = setTimeout(() => {
+            typeaheadQuery = ''
+        }, 500)
+
+        const total = visibleKeys.length
+        const start = typeaheadQuery.length > 1 ? currentIndex : currentIndex + 1
+        for (let offset = 0; offset < total; offset++) {
+            const key = visibleKeys[(start + offset + total) % total]
+            if (isNodeDisabled(key)) continue
+            const node = nodeIndex.byKey.get(key)
+            if (node && getLabel(node).toLowerCase().startsWith(typeaheadQuery)) {
+                moveFocus(key)
+                return
+            }
+        }
+    }
+
+    function moveIntoChildren(node: FlatNode) {
+        if (!node.hasChildren) return
+        if (!expandedSet.has(node.key)) {
+            toggleExpand(node.key)
+        } else {
+            const firstChild = node.childKeys.find((k) => !isNodeDisabled(k))
+            if (firstChild) moveFocus(firstChild)
+        }
+    }
+
+    function moveOutOfChildren(node: FlatNode) {
+        if (node.hasChildren && expandedSet.has(node.key)) {
+            toggleExpand(node.key)
+        } else if (node.parentKey !== null && !isNodeDisabled(node.parentKey)) {
+            moveFocus(node.parentKey)
+        }
+    }
+
+    function expandSiblings(node: FlatNode) {
+        const siblings =
+            node.parentKey !== null
+                ? (nodeIndex.byKey.get(node.parentKey)?.childKeys ?? [])
+                : nodeIndex.topLevelKeys
+        const toExpand = siblings.filter((k) => {
+            const sibling = nodeIndex.byKey.get(k)
+            return sibling?.hasChildren === true && !expandedSet.has(k) && !isNodeDisabled(k)
+        })
+        if (toExpand.length > 0) setExpanded([...(expanded ?? []), ...toExpand])
+    }
+
+    function handleNavigationKey(key: string, currentIndex: number, node: FlatNode): boolean {
+        switch (key) {
+            case 'ArrowDown':
+                moveFocus(findEnabled(currentIndex + 1, 1))
+                return true
+            case 'ArrowUp':
+                moveFocus(findEnabled(currentIndex - 1, -1))
+                return true
+            case 'Home':
+                moveFocus(findEnabled(0, 1))
+                return true
+            case 'End':
+                moveFocus(findEnabled(visibleKeys.length - 1, -1))
+                return true
+            case 'ArrowRight':
+                moveIntoChildren(node)
+                return true
+            case 'ArrowLeft':
+                moveOutOfChildren(node)
+                return true
+            default:
+                return false
+        }
+    }
+
+    function handleActionKey(e: KeyboardEvent, currentIndex: number, node: FlatNode): boolean {
+        switch (e.key) {
+            case 'Enter':
+                handleSelect(node.key)
+                return true
+            case ' ':
+                if (typeaheadQuery.length > 0) handleTypeahead(' ', currentIndex)
+                else handleSelect(node.key)
+                return true
+            case '*':
+                expandSiblings(node)
+                return true
+            default:
+                if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+                    handleTypeahead(e.key, currentIndex)
+                    return true
+                }
+                return false
+        }
+    }
+
+    function handleKeydown(e: KeyboardEvent & { currentTarget: EventTarget & HTMLUListElement }) {
+        onkeydown?.(e)
+        if (e.defaultPrevented || disabled) return
+        const target = (e.target as HTMLElement).closest<HTMLElement>('[data-tree-item]')
+        const currentKey = target?.dataset.key
+        if (!currentKey) return
+        const currentIndex = visibleKeys.indexOf(currentKey)
+        const node = nodeIndex.byKey.get(currentKey)
+        if (currentIndex === -1 || !node) return
+
+        if (
+            handleNavigationKey(e.key, currentIndex, node) ||
+            handleActionKey(e, currentIndex, node)
+        ) {
+            keyboardActive = true
+            e.preventDefault()
+        }
+    }
+
+    function handlePointerdown(
+        e: PointerEvent & { currentTarget: EventTarget & HTMLUListElement }
+    ) {
+        onpointerdown?.(e)
+        keyboardActive = false
+    }
+
+    function handleFocusout(e: FocusEvent & { currentTarget: EventTarget & HTMLUListElement }) {
+        onfocusout?.(e)
+        if (!ref?.contains(e.relatedTarget as Node)) keyboardActive = false
+    }
+
+    const INTERACTIVE_SELECTOR =
+        'input, button, a, select, textarea, [role="checkbox"], [role="switch"], [role="button"]'
+    const TOGGLE_CONTROL_SELECTOR = 'input[type="checkbox"], [role="checkbox"], [role="switch"]'
+
+    function nestedControl(target: HTMLElement, linkEl: HTMLElement): HTMLElement | null {
+        const control = target.closest<HTMLElement>(INTERACTIVE_SELECTOR)
+        return control !== null && linkEl.contains(control) ? control : null
+    }
+
+    interface ClickTarget {
+        node: FlatNode
+        key: string
+        control: HTMLElement | null
+    }
+
+    function resolveClickTarget(e: MouseEvent): ClickTarget | null {
+        if (disabled) return null
+        const target = e.target as HTMLElement
+        const linkEl = target.closest<HTMLElement>('[data-tree-link]')
+        const key = linkEl?.dataset.key
+        if (linkEl === null || key === undefined) return null
+        const node = nodeIndex.byKey.get(key)
+        if (!node || node.item.disabled) return null
+        return { node, key, control: nestedControl(target, linkEl) }
+    }
+
+    function handleClick(e: MouseEvent & { currentTarget: EventTarget & HTMLUListElement }) {
+        onclick?.(e)
+        const hit = resolveClickTarget(e)
+        if (hit === null) return
+        const { node, key, control } = hit
+
+        if (control !== null) {
+            if (control.matches(TOGGLE_CONTROL_SELECTOR)) {
+                moveFocus(key)
+                handleSelect(key)
+            }
+            return
+        }
+
+        moveFocus(key)
+        if (node.hasChildren) toggleExpand(key)
+        handleSelect(key)
+    }
+
+    const apiInstance: TreeApi = {
+        expand(key) {
+            if (!expandedSet.has(key)) toggleExpand(key)
+        },
+        collapse(key) {
+            if (expandedSet.has(key)) toggleExpand(key)
+        },
+        toggle(key) {
+            toggleExpand(key)
+        },
+        expandAll() {
+            setExpanded([...nodeIndex.parentKeys])
+        },
+        collapseAll() {
+            const hadFocus = ref?.contains(document.activeElement) === true
+            setExpanded([])
+            if (hadFocus && focusedKey !== null && !visibleKeys.includes(focusedKey)) {
+                moveFocus(rovingKey)
+            }
+        },
+        select(key) {
+            if (!selectedSet.has(key)) handleSelect(key)
+        },
+        deselect(key) {
+            const node = nodeIndex.byKey.get(key)
+            if (!node || !selectedSet.has(key)) return
+            if (!multiple) {
+                setValue(undefined)
+                return
+            }
+            const next = new SvelteSet(selectedSet)
+            next.delete(key)
+            if (propagateSelect) applyPropagate(node, next, false)
+            if (bubbleSelect) applyBubble(node, next)
+            setValue([...next])
+        },
+        clearSelection() {
+            setValue(multiple ? [] : undefined)
+        },
+        focus(key) {
+            if (visibleKeys.includes(key) && !isNodeDisabled(key)) moveFocus(key)
+        },
+        isExpanded(key) {
+            return expandedSet.has(key)
+        },
+        isSelected(key) {
+            return selectedSet.has(key)
+        },
+        get expanded() {
+            return expanded ?? []
+        },
+        get selected() {
+            return value
+        }
+    }
+
+    api = apiInstance
+
+    const variantSlots = $derived(treeVariants({ color, size }))
+
+    type ItemUi = TreeItem['ui']
+
+    const classes = $derived.by(() => {
+        const c = config.slots
+        const slots = variantSlots
+        const u = ui ?? {}
+
+        const _item = slots.item({ class: [c.item, u.item] })
+        const _itemParent = slots.item({
+            class: [c.item, u.item, c.itemWithChildren, u.itemWithChildren]
+        })
+        const _listWithChildren = slots.listWithChildren({
+            class: [c.listWithChildren, u.listWithChildren]
+        })
+        const _link = slots.link({ class: [c.link, u.link] })
+        const _linkLeadingIcon = slots.linkLeadingIcon({
+            class: [c.linkLeadingIcon, u.linkLeadingIcon]
+        })
+        const _linkLabel = slots.linkLabel({ class: [c.linkLabel, u.linkLabel] })
+        const _linkTrailing = slots.linkTrailing({ class: [c.linkTrailing, u.linkTrailing] })
+        const _linkTrailingIcon = slots.linkTrailingIcon({
+            class: [c.linkTrailingIcon, u.linkTrailingIcon]
+        })
+
+        return {
+            root: slots.root({ class: [c.root, className, u.root] }),
+            item: (hasChildren: boolean, itemClass?: ClassNameValue, itemUi?: ItemUi) =>
+                itemClass || itemUi
+                    ? slots.item({
+                          class: [
+                              c.item,
+                              u.item,
+                              itemUi?.item,
+                              hasChildren
+                                  ? [
+                                        c.itemWithChildren,
+                                        u.itemWithChildren,
+                                        itemUi?.itemWithChildren
+                                    ]
+                                  : undefined,
+                              itemClass
+                          ]
+                      })
+                    : hasChildren
+                      ? _itemParent
+                      : _item,
+            listWithChildren: (itemUi?: ItemUi) =>
+                itemUi
+                    ? slots.listWithChildren({
+                          class: [c.listWithChildren, u.listWithChildren, itemUi.listWithChildren]
+                      })
+                    : _listWithChildren,
+            link: (itemUi?: ItemUi) =>
+                itemUi ? slots.link({ class: [c.link, u.link, itemUi.link] }) : _link,
+            linkLeadingIcon: (itemUi?: ItemUi) =>
+                itemUi
+                    ? slots.linkLeadingIcon({
+                          class: [c.linkLeadingIcon, u.linkLeadingIcon, itemUi.linkLeadingIcon]
+                      })
+                    : _linkLeadingIcon,
+            linkLabel: (itemUi?: ItemUi) =>
+                itemUi
+                    ? slots.linkLabel({ class: [c.linkLabel, u.linkLabel, itemUi.linkLabel] })
+                    : _linkLabel,
+            linkTrailing: (itemUi?: ItemUi) =>
+                itemUi
+                    ? slots.linkTrailing({
+                          class: [c.linkTrailing, u.linkTrailing, itemUi.linkTrailing]
+                      })
+                    : _linkTrailing,
+            linkTrailingIcon: (itemUi?: ItemUi) =>
+                itemUi
+                    ? slots.linkTrailingIcon({
+                          class: [c.linkTrailingIcon, u.linkTrailingIcon, itemUi.linkTrailingIcon]
+                      })
+                    : _linkTrailingIcon
+        }
+    })
+</script>
+
+<ul
+    bind:this={ref}
+    role="tree"
+    aria-multiselectable={multiple ? true : undefined}
+    aria-disabled={disabled ? true : undefined}
+    data-tree=""
+    class={classes.root}
+    onkeydown={handleKeydown}
+    onclick={handleClick}
+    onpointerdown={handlePointerdown}
+    onfocusout={handleFocusout}
+    {...restProps}
+>
+    {@render treeLevel(nodeIndex.topLevelKeys)}
+</ul>
+
+{#snippet treeLevel(keys: string[])}
+    {#each keys as key (key)}
+        {@const node = nodeIndex.byKey.get(key)}
+        {#if node}
+            {@const itemDisabled = disabled || node.item.disabled === true}
+            {@const isExpanded =
+                node.hasChildren && node.item.disabled !== true && expandedSet.has(key)}
+            {@const isSelected = selectedSet.has(key)}
+            {@const isIndeterminate = indeterminateSet.has(key)}
+            {@const slotProps = {
+                item: node.item,
+                key,
+                index: node.index,
+                level: node.level,
+                expanded: isExpanded,
+                selected: isSelected,
+                indeterminate: isIndeterminate,
+                hasChildren: node.hasChildren,
+                select: () => handleSelect(key),
+                toggle: () => toggleExpand(key)
+            }}
+            <li
+                role="treeitem"
+                aria-level={node.level + 1}
+                aria-setsize={node.setsize}
+                aria-posinset={node.posinset}
+                aria-expanded={node.hasChildren ? isExpanded : undefined}
+                aria-selected={checkboxSelection
+                    ? undefined
+                    : multiple
+                      ? isSelected
+                      : isSelected || undefined}
+                aria-checked={checkboxSelection
+                    ? isIndeterminate
+                        ? 'mixed'
+                        : isSelected
+                    : undefined}
+                aria-disabled={itemDisabled ? true : undefined}
+                tabindex={rovingKey === key ? 0 : -1}
+                data-tree-item=""
+                data-key={key}
+                data-level={node.level}
+                data-expanded={node.hasChildren ? isExpanded : undefined}
+                data-selected={isSelected}
+                data-indeterminate={isIndeterminate ? '' : undefined}
+                data-disabled={itemDisabled ? '' : undefined}
+                class={classes.item(node.hasChildren, node.item.class, node.item.ui)}
+                {@attach registerItem(key)}
+                onfocus={() => (focusedKey = key)}
+            >
+                <div
+                    class={classes.link(node.item.ui)}
+                    data-tree-link=""
+                    data-key={key}
+                    data-selected={isSelected}
+                    data-expanded={node.hasChildren ? isExpanded : undefined}
+                    data-disabled={itemDisabled ? '' : undefined}
+                    data-keyboard-focus={keyboardActive && rovingKey === key ? '' : undefined}
+                >
+                    {#if itemSnippet}
+                        {@render itemSnippet(slotProps)}
+                    {:else}
+                        {#if itemLeading}
+                            {@render itemLeading(slotProps)}
+                        {:else}
+                            {@const leadingIcon =
+                                node.item.icon ??
+                                (node.hasChildren
+                                    ? isExpanded
+                                        ? expandedIcon
+                                        : collapsedIcon
+                                    : undefined)}
+                            {#if leadingIcon}
+                                <Icon
+                                    name={leadingIcon}
+                                    class={classes.linkLeadingIcon(node.item.ui)}
+                                />
+                            {/if}
+                        {/if}
+
+                        {#if itemLabel}
+                            {@render itemLabel(slotProps)}
+                        {:else}
+                            <span class={classes.linkLabel(node.item.ui)}>{getLabel(node)}</span>
+                        {/if}
+
+                        {#if itemTrailing}
+                            {@render itemTrailing(slotProps)}
+                        {:else if node.hasChildren}
+                            <span class={classes.linkTrailing(node.item.ui)}>
+                                <Icon
+                                    name={node.item.trailingIcon ?? trailingIcon}
+                                    class={classes.linkTrailingIcon(node.item.ui)}
+                                />
+                            </span>
+                        {/if}
+                    {/if}
+                </div>
+
+                {#if node.hasChildren && isExpanded}
+                    <ul
+                        role="group"
+                        class={classes.listWithChildren(node.item.ui)}
+                        transition:slide={{ duration: 200 }}
+                    >
+                        {@render treeLevel(node.childKeys)}
+                    </ul>
+                {/if}
+            </li>
+        {/if}
+    {/each}
+{/snippet}

--- a/src/lib/components/Tree/Tree.svelte.spec.ts
+++ b/src/lib/components/Tree/Tree.svelte.spec.ts
@@ -1,0 +1,570 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-svelte'
+import Tree from './Tree.svelte'
+import type { TreeApi, TreeItem } from './tree.types.js'
+
+describe('Tree', () => {
+    const sampleItems: TreeItem[] = [
+        {
+            label: 'src',
+            children: [{ label: 'lib', children: [{ label: 'index.ts' }] }, { label: 'app.ts' }]
+        },
+        { label: 'static', children: [{ label: 'favicon.png' }] },
+        { label: 'locked', disabled: true, children: [{ label: 'secret' }] },
+        { label: 'README.md' }
+    ]
+
+    const checkboxItems: TreeItem[] = [
+        {
+            label: 'docs',
+            defaultExpanded: true,
+            children: [{ label: 'read' }, { label: 'write' }]
+        }
+    ]
+
+    const getTree = (container: Element) =>
+        container.querySelector('[data-tree]') as HTMLUListElement
+    const getItems = (container: Element) =>
+        container.querySelectorAll('[data-tree-item]') as NodeListOf<HTMLLIElement>
+    const getItem = (container: Element, key: string) =>
+        container.querySelector(`[data-tree-item][data-key="${key}"]`) as HTMLLIElement | null
+    const getLink = (container: Element, key: string) =>
+        container.querySelector(`[data-tree-link][data-key="${key}"]`) as HTMLElement | null
+
+    const pressKey = (el: Element, key: string) =>
+        el.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }))
+
+    const renderWithApi = (props: Record<string, unknown>) => {
+        let api: TreeApi | undefined
+        const result = render(Tree, {
+            ...props,
+            get api() {
+                return api
+            },
+            set api(v: TreeApi | undefined) {
+                api = v
+            }
+        })
+        return { ...result, getApi: () => api }
+    }
+
+    // ==================== RENDERING ====================
+
+    describe('rendering', () => {
+        it('renders a role=tree root', () => {
+            const { container } = render(Tree, { items: sampleItems })
+            expect(getTree(container).getAttribute('role')).toBe('tree')
+        })
+
+        it('renders only top-level items when collapsed', () => {
+            const { container } = render(Tree, { items: sampleItems })
+            expect(getItems(container).length).toBe(4)
+        })
+
+        it('expands nodes listed in defaultExpanded', () => {
+            const { container } = render(Tree, { items: sampleItems, defaultExpanded: ['src'] })
+            expect(getItems(container).length).toBe(6)
+            expect(getItem(container, 'src')?.getAttribute('aria-expanded')).toBe('true')
+        })
+
+        it('expands nodes marked item.defaultExpanded', () => {
+            const { container } = render(Tree, { items: checkboxItems })
+            expect(getItems(container).length).toBe(3)
+        })
+
+        it('renders labels via custom labelKey', () => {
+            interface NamedItem extends TreeItem {
+                name: string
+            }
+            const items: NamedItem[] = [{ name: 'Custom Node' }]
+            const { container } = render(Tree, { items, labelKey: 'name' } as never)
+            expect(container.textContent).toContain('Custom Node')
+        })
+
+        it('treats leaves and empty children as non-expandable', () => {
+            const { container } = render(Tree, {
+                items: [{ label: 'leaf' }, { label: 'empty', children: [] }]
+            })
+            expect(getItem(container, 'leaf')?.hasAttribute('aria-expanded')).toBe(false)
+            expect(getItem(container, 'empty')?.hasAttribute('aria-expanded')).toBe(false)
+        })
+
+        it('sets aria-level, aria-setsize and aria-posinset on nested items', () => {
+            const { container } = render(Tree, {
+                items: sampleItems,
+                defaultExpanded: ['src', 'lib']
+            })
+            const lib = getItem(container, 'lib')
+            expect(lib?.getAttribute('aria-level')).toBe('2')
+            expect(lib?.getAttribute('aria-setsize')).toBe('2')
+            expect(lib?.getAttribute('aria-posinset')).toBe('1')
+            const index = getItem(container, 'index.ts')
+            expect(index?.getAttribute('aria-level')).toBe('3')
+        })
+
+        it('sets aria-multiselectable only when multiple', () => {
+            const single = render(Tree, { items: sampleItems })
+            expect(getTree(single.container).hasAttribute('aria-multiselectable')).toBe(false)
+            const multi = render(Tree, { items: sampleItems, multiple: true })
+            expect(getTree(multi.container).getAttribute('aria-multiselectable')).toBe('true')
+        })
+
+        it('resolves duplicate keys to index paths', () => {
+            const { container } = render(Tree, {
+                items: [{ label: 'same' }, { label: 'same' }]
+            })
+            expect(getItem(container, 'same')).not.toBeNull()
+            expect(getItem(container, '1')).not.toBeNull()
+        })
+
+        it('keeps keys unique when the index-path fallback also collides', () => {
+            const { container } = render(Tree, {
+                items: [{ label: '1' }, { label: '1' }]
+            })
+            expect(getItems(container).length).toBe(2)
+            expect(getItem(container, '1')).not.toBeNull()
+            expect(getItem(container, '#1')).not.toBeNull()
+        })
+    })
+
+    // ==================== EXPANSION ====================
+
+    describe('expansion', () => {
+        it('toggles a parent on click', async () => {
+            const { container } = render(Tree, { items: sampleItems })
+            await getLink(container, 'src')!.click()
+            await vi.waitFor(() => {
+                expect(getItem(container, 'src')?.getAttribute('aria-expanded')).toBe('true')
+                expect(getItem(container, 'app.ts')).not.toBeNull()
+            })
+            await getLink(container, 'src')!.click()
+            await vi.waitFor(() => {
+                expect(getItem(container, 'src')?.getAttribute('aria-expanded')).toBe('false')
+                expect(getItem(container, 'app.ts')).toBeNull()
+            })
+        })
+
+        it('fires onExpandedChange with the new keys', async () => {
+            const onExpandedChange = vi.fn()
+            const { container } = render(Tree, { items: sampleItems, onExpandedChange })
+            await getLink(container, 'src')!.click()
+            await vi.waitFor(() => {
+                expect(onExpandedChange).toHaveBeenCalledWith(['src'])
+            })
+        })
+
+        it('controlled expanded=[] overrides item.defaultExpanded', () => {
+            const { container } = render(Tree, { items: checkboxItems, expanded: [] })
+            expect(getItems(container).length).toBe(1)
+        })
+
+        it('calls item.onToggle with the new state', async () => {
+            const onToggle = vi.fn()
+            const items: TreeItem[] = [
+                { label: 'parent', onToggle, children: [{ label: 'child' }] }
+            ]
+            const { container } = render(Tree, { items })
+            await getLink(container, 'parent')!.click()
+            await vi.waitFor(() => {
+                expect(onToggle).toHaveBeenCalledWith(true)
+            })
+            await getLink(container, 'parent')!.click()
+            await vi.waitFor(() => {
+                expect(onToggle).toHaveBeenCalledWith(false)
+            })
+        })
+
+        it('does not expand or select disabled parents', async () => {
+            const onValueChange = vi.fn()
+            const { container } = render(Tree, { items: sampleItems, onValueChange })
+            await getLink(container, 'locked')!.click()
+            expect(getItem(container, 'locked')?.getAttribute('aria-expanded')).toBe('false')
+            expect(onValueChange).not.toHaveBeenCalled()
+        })
+
+        it('does not expand disabled parents via keyboard or api', async () => {
+            const { container, getApi } = renderWithApi({ items: sampleItems })
+            await vi.waitFor(() => expect(getApi()).toBeDefined())
+            const locked = getItem(container, 'locked')!
+            locked.focus()
+            pressKey(locked, 'ArrowRight')
+            expect(locked.getAttribute('aria-expanded')).toBe('false')
+            getApi()?.toggle('locked')
+            expect(getApi()?.isExpanded('locked')).toBe(false)
+        })
+
+        it('ignores defaultExpanded on disabled parents', () => {
+            const { container } = render(Tree, {
+                items: [
+                    {
+                        label: 'locked',
+                        disabled: true,
+                        defaultExpanded: true,
+                        children: [{ label: 'secret' }]
+                    }
+                ]
+            })
+            expect(getItems(container).length).toBe(1)
+            expect(getItem(container, 'locked')?.getAttribute('aria-expanded')).toBe('false')
+        })
+
+        it('api.expandAll and api.collapseAll toggle every parent', async () => {
+            const { container, getApi } = renderWithApi({ items: sampleItems })
+            await vi.waitFor(() => expect(getApi()).toBeDefined())
+            getApi()?.expandAll()
+            await vi.waitFor(() => {
+                expect(getItem(container, 'index.ts')).not.toBeNull()
+            })
+            expect(getApi()?.isExpanded('src')).toBe(true)
+            getApi()?.collapseAll()
+            await vi.waitFor(() => {
+                expect(getItem(container, 'src')?.getAttribute('aria-expanded')).toBe('false')
+            })
+        })
+    })
+
+    // ==================== SELECTION ====================
+
+    describe('selection', () => {
+        it('selects a leaf on click and fires onValueChange', async () => {
+            const onValueChange = vi.fn()
+            const { container } = render(Tree, { items: sampleItems, onValueChange })
+            await getLink(container, 'README.md')!.click()
+            await vi.waitFor(() => {
+                expect(getItem(container, 'README.md')?.getAttribute('aria-selected')).toBe('true')
+                expect(onValueChange).toHaveBeenCalledWith('README.md')
+            })
+        })
+
+        it('deselects on second click in single toggle mode', async () => {
+            const onValueChange = vi.fn()
+            const { container } = render(Tree, { items: sampleItems, onValueChange })
+            await getLink(container, 'README.md')!.click()
+            await getLink(container, 'README.md')!.click()
+            await vi.waitFor(() => {
+                expect(onValueChange).toHaveBeenLastCalledWith(undefined)
+                expect(getItem(container, 'README.md')?.hasAttribute('aria-selected')).toBe(false)
+            })
+        })
+
+        it('keeps the selection on re-click with selectionBehavior=replace', async () => {
+            const onValueChange = vi.fn()
+            const { container } = render(Tree, {
+                items: sampleItems,
+                selectionBehavior: 'replace',
+                onValueChange
+            })
+            await getLink(container, 'README.md')!.click()
+            await getLink(container, 'README.md')!.click()
+            await vi.waitFor(() => {
+                expect(getItem(container, 'README.md')?.getAttribute('aria-selected')).toBe('true')
+            })
+            expect(onValueChange).toHaveBeenCalledTimes(1)
+        })
+
+        it('replaces the previous selection in single mode', async () => {
+            const onValueChange = vi.fn()
+            const { container } = render(Tree, { items: sampleItems, onValueChange })
+            await getLink(container, 'README.md')!.click()
+            await getLink(container, 'static')!.click()
+            await vi.waitFor(() => {
+                expect(getItem(container, 'README.md')?.hasAttribute('aria-selected')).toBe(false)
+                expect(getItem(container, 'static')?.getAttribute('aria-selected')).toBe('true')
+            })
+        })
+
+        it('toggles membership in multiple mode', async () => {
+            const onValueChange = vi.fn()
+            const { container } = render(Tree, {
+                items: sampleItems,
+                multiple: true,
+                onValueChange
+            })
+            await getLink(container, 'README.md')!.click()
+            await getLink(container, 'static')!.click()
+            await vi.waitFor(() => {
+                expect(onValueChange).toHaveBeenLastCalledWith(['README.md', 'static'])
+            })
+            await getLink(container, 'README.md')!.click()
+            await vi.waitFor(() => {
+                expect(onValueChange).toHaveBeenLastCalledWith(['static'])
+            })
+        })
+
+        it('replaces the whole set with selectionBehavior=replace in multiple mode', async () => {
+            const onValueChange = vi.fn()
+            const { container } = render(Tree, {
+                items: sampleItems,
+                multiple: true,
+                selectionBehavior: 'replace',
+                onValueChange
+            })
+            await getLink(container, 'README.md')!.click()
+            await getLink(container, 'static')!.click()
+            await vi.waitFor(() => {
+                expect(onValueChange).toHaveBeenLastCalledWith(['static'])
+            })
+        })
+
+        it('propagateSelect selects all selectable descendants', async () => {
+            const onValueChange = vi.fn()
+            const { container } = render(Tree, {
+                items: checkboxItems,
+                multiple: true,
+                propagateSelect: true,
+                onValueChange
+            })
+            await getLink(container, 'docs')!.click()
+            await vi.waitFor(() => {
+                expect(onValueChange).toHaveBeenLastCalledWith(['docs', 'read', 'write'])
+            })
+        })
+
+        it('bubbleSelect selects the parent once all children are selected and marks partial parents indeterminate', async () => {
+            const onValueChange = vi.fn()
+            const { container } = render(Tree, {
+                items: checkboxItems,
+                multiple: true,
+                propagateSelect: true,
+                bubbleSelect: true,
+                onValueChange
+            })
+            await getLink(container, 'read')!.click()
+            await vi.waitFor(() => {
+                expect(getItem(container, 'docs')?.getAttribute('aria-checked')).toBe('mixed')
+                expect(getItem(container, 'docs')?.hasAttribute('data-indeterminate')).toBe(true)
+            })
+            await getLink(container, 'write')!.click()
+            await vi.waitFor(() => {
+                expect(getItem(container, 'docs')?.getAttribute('aria-checked')).toBe('true')
+            })
+            await getLink(container, 'read')!.click()
+            await vi.waitFor(() => {
+                expect(getItem(container, 'docs')?.getAttribute('aria-checked')).toBe('mixed')
+                expect(getItem(container, 'docs')?.hasAttribute('data-indeterminate')).toBe(true)
+            })
+        })
+
+        it('honors defaultValue', () => {
+            const { container } = render(Tree, { items: sampleItems, defaultValue: 'README.md' })
+            expect(getItem(container, 'README.md')?.getAttribute('aria-selected')).toBe('true')
+        })
+    })
+
+    // ==================== KEYBOARD ====================
+
+    describe('keyboard', () => {
+        it('ArrowDown and ArrowUp move focus through visible items, skipping disabled', async () => {
+            const { container } = render(Tree, { items: sampleItems })
+            const src = getItem(container, 'src')!
+            src.focus()
+            pressKey(src, 'ArrowDown')
+            await vi.waitFor(() => {
+                expect(document.activeElement).toBe(getItem(container, 'static'))
+            })
+            pressKey(getItem(container, 'static')!, 'ArrowDown')
+            await vi.waitFor(() => {
+                expect(document.activeElement).toBe(getItem(container, 'README.md'))
+            })
+            pressKey(getItem(container, 'README.md')!, 'ArrowUp')
+            await vi.waitFor(() => {
+                expect(document.activeElement).toBe(getItem(container, 'static'))
+            })
+        })
+
+        it('ArrowRight expands, then moves into the first child', async () => {
+            const { container } = render(Tree, { items: sampleItems })
+            const src = getItem(container, 'src')!
+            src.focus()
+            pressKey(src, 'ArrowRight')
+            await vi.waitFor(() => {
+                expect(getItem(container, 'src')?.getAttribute('aria-expanded')).toBe('true')
+            })
+            pressKey(getItem(container, 'src')!, 'ArrowRight')
+            await vi.waitFor(() => {
+                expect(document.activeElement).toBe(getItem(container, 'lib'))
+            })
+        })
+
+        it('ArrowLeft collapses, then moves to the parent', async () => {
+            const { container } = render(Tree, {
+                items: sampleItems,
+                defaultExpanded: ['src']
+            })
+            const appTs = getItem(container, 'app.ts')!
+            appTs.focus()
+            pressKey(appTs, 'ArrowLeft')
+            await vi.waitFor(() => {
+                expect(document.activeElement).toBe(getItem(container, 'src'))
+            })
+            pressKey(getItem(container, 'src')!, 'ArrowLeft')
+            await vi.waitFor(() => {
+                expect(getItem(container, 'src')?.getAttribute('aria-expanded')).toBe('false')
+            })
+        })
+
+        it('Home and End jump to the first and last visible item', async () => {
+            const { container } = render(Tree, { items: sampleItems })
+            const staticItem = getItem(container, 'static')!
+            staticItem.focus()
+            pressKey(staticItem, 'End')
+            await vi.waitFor(() => {
+                expect(document.activeElement).toBe(getItem(container, 'README.md'))
+            })
+            pressKey(getItem(container, 'README.md')!, 'Home')
+            await vi.waitFor(() => {
+                expect(document.activeElement).toBe(getItem(container, 'src'))
+            })
+        })
+
+        it('Enter and Space select the focused item', async () => {
+            const onValueChange = vi.fn()
+            const { container } = render(Tree, {
+                items: sampleItems,
+                multiple: true,
+                onValueChange
+            })
+            const readme = getItem(container, 'README.md')!
+            readme.focus()
+            pressKey(readme, 'Enter')
+            await vi.waitFor(() => {
+                expect(onValueChange).toHaveBeenLastCalledWith(['README.md'])
+            })
+            const staticItem = getItem(container, 'static')!
+            staticItem.focus()
+            pressKey(staticItem, ' ')
+            await vi.waitFor(() => {
+                expect(onValueChange).toHaveBeenLastCalledWith(['README.md', 'static'])
+            })
+        })
+
+        it('typeahead focuses the next matching label', async () => {
+            const { container } = render(Tree, { items: sampleItems })
+            const src = getItem(container, 'src')!
+            src.focus()
+            pressKey(src, 'r')
+            await vi.waitFor(() => {
+                expect(document.activeElement).toBe(getItem(container, 'README.md'))
+            })
+        })
+
+        it('* expands every sibling parent', async () => {
+            const { container } = render(Tree, { items: sampleItems })
+            const src = getItem(container, 'src')!
+            src.focus()
+            pressKey(src, '*')
+            await vi.waitFor(() => {
+                expect(getItem(container, 'src')?.getAttribute('aria-expanded')).toBe('true')
+                expect(getItem(container, 'static')?.getAttribute('aria-expanded')).toBe('true')
+            })
+            expect(getItem(container, 'locked')?.getAttribute('aria-expanded')).toBe('false')
+        })
+
+        it('keeps exactly one item in the tab order', async () => {
+            const { container } = render(Tree, { items: sampleItems, defaultExpanded: ['src'] })
+            expect(container.querySelectorAll('[data-tree-item][tabindex="0"]').length).toBe(1)
+            const staticItem = getItem(container, 'static')!
+            staticItem.focus()
+            await vi.waitFor(() => {
+                expect(container.querySelectorAll('[data-tree-item][tabindex="0"]').length).toBe(1)
+                expect(staticItem.getAttribute('tabindex')).toBe('0')
+            })
+        })
+    })
+
+    // ==================== API ====================
+
+    describe('api', () => {
+        it('select, deselect and clearSelection update the value', async () => {
+            const onValueChange = vi.fn()
+            const { getApi } = renderWithApi({
+                items: sampleItems,
+                multiple: true,
+                onValueChange
+            })
+            await vi.waitFor(() => expect(getApi()).toBeDefined())
+            getApi()?.select('README.md')
+            await vi.waitFor(() => {
+                expect(onValueChange).toHaveBeenLastCalledWith(['README.md'])
+                expect(getApi()?.isSelected('README.md')).toBe(true)
+            })
+            getApi()?.deselect('README.md')
+            await vi.waitFor(() => {
+                expect(onValueChange).toHaveBeenLastCalledWith([])
+            })
+            getApi()?.select('static')
+            getApi()?.clearSelection()
+            await vi.waitFor(() => {
+                expect(getApi()?.isSelected('static')).toBe(false)
+            })
+        })
+
+        it('exposes expanded and selected getters', async () => {
+            const { getApi } = renderWithApi({
+                items: sampleItems,
+                defaultExpanded: ['src'],
+                defaultValue: 'app.ts'
+            })
+            await vi.waitFor(() => expect(getApi()).toBeDefined())
+            expect(getApi()?.expanded).toEqual(['src'])
+            expect(getApi()?.selected).toBe('app.ts')
+        })
+
+        it('api.deselect keeps propagate/bubble selection consistent', async () => {
+            const onValueChange = vi.fn()
+            const { getApi } = renderWithApi({
+                items: checkboxItems,
+                multiple: true,
+                propagateSelect: true,
+                bubbleSelect: true,
+                onValueChange
+            })
+            await vi.waitFor(() => expect(getApi()).toBeDefined())
+            getApi()?.select('docs')
+            await vi.waitFor(() => {
+                expect(onValueChange).toHaveBeenLastCalledWith(['docs', 'read', 'write'])
+            })
+            getApi()?.deselect('read')
+            await vi.waitFor(() => {
+                expect(onValueChange).toHaveBeenLastCalledWith(['write'])
+            })
+        })
+
+        it('api.focus moves keyboard focus to a visible node', async () => {
+            const { container, getApi } = renderWithApi({ items: sampleItems })
+            await vi.waitFor(() => expect(getApi()).toBeDefined())
+            getApi()?.focus('static')
+            await vi.waitFor(() => {
+                expect(document.activeElement).toBe(getItem(container, 'static'))
+            })
+        })
+    })
+
+    // ==================== STYLING ====================
+
+    describe('styling', () => {
+        it('applies ui overrides and item classes', () => {
+            const items: TreeItem[] = [
+                { label: 'styled', class: 'item-extra', ui: { link: 'link-extra' } }
+            ]
+            const { container } = render(Tree, {
+                items,
+                class: 'root-extra',
+                ui: { root: 'root-ui' }
+            })
+            expect(getTree(container).classList.contains('root-extra')).toBe(true)
+            expect(getTree(container).classList.contains('root-ui')).toBe(true)
+            expect(getItem(container, 'styled')?.classList.contains('item-extra')).toBe(true)
+            expect(getLink(container, 'styled')?.classList.contains('link-extra')).toBe(true)
+        })
+
+        it('marks selected and disabled state via data attributes', async () => {
+            const { container } = render(Tree, {
+                items: sampleItems,
+                defaultValue: 'README.md'
+            })
+            expect(getLink(container, 'README.md')?.getAttribute('data-selected')).toBe('true')
+            expect(getItem(container, 'locked')?.hasAttribute('data-disabled')).toBe(true)
+        })
+    })
+})

--- a/src/lib/components/Tree/index.ts
+++ b/src/lib/components/Tree/index.ts
@@ -1,0 +1,2 @@
+export { default as Tree } from './Tree.svelte'
+export type { TreeProps, TreeItem, TreeValue, TreeSlotProps, TreeApi } from './tree.types.js'

--- a/src/lib/components/Tree/tree.types.ts
+++ b/src/lib/components/Tree/tree.types.ts
@@ -1,0 +1,433 @@
+import type { Snippet } from 'svelte'
+import type { ClassNameValue } from 'tailwind-merge'
+import type { HTMLAttributes } from 'svelte/elements'
+import type { TreeSlots, TreeVariantProps } from './tree.variants.js'
+
+// ============================================================================
+// Value Types
+// ============================================================================
+
+/**
+ * Selected value(s) of the Tree.
+ * A single key when `multiple` is `false`, an array of keys when `true`.
+ */
+export type TreeValue = string | string[]
+
+// ============================================================================
+// Item Types
+// ============================================================================
+
+/**
+ * Configuration for a single node inside the Tree.
+ *
+ * Nodes are identified by a key resolved in this order:
+ * `getKey(item, indexPath)` → `item.value` → `item[labelKey]` → positional
+ * index path (e.g. `'0.2.1'`). When a resolved key collides with an earlier
+ * node's key, the later node falls back to its index path.
+ *
+ * @example
+ * ```ts
+ * const item: TreeItem = {
+ *   label: 'src',
+ *   icon: 'lucide:folder',
+ *   defaultExpanded: true,
+ *   children: [{ label: 'index.ts', icon: 'lucide:file' }]
+ * }
+ * ```
+ */
+export interface TreeItem {
+    /**
+     * Text rendered as the node label (when `labelKey` is `'label'`).
+     */
+    label?: string
+
+    /**
+     * Explicit unique key for this node.
+     * Falls back to the label, then the positional index path.
+     */
+    value?: string
+
+    /**
+     * Iconify icon name rendered before the label.
+     * Overrides the default `collapsedIcon`/`expandedIcon` folder icons
+     * shown on parent nodes.
+     */
+    icon?: string
+
+    /**
+     * Iconify icon name for this node's expand/collapse chevron.
+     * Overrides the tree-level `trailingIcon`.
+     */
+    trailingIcon?: string
+
+    /**
+     * Child nodes. `undefined` or an empty array marks a leaf
+     * (no chevron, no `aria-expanded`).
+     * Typed as `this[]` so interfaces extending `TreeItem` keep their own
+     * item type throughout the subtree.
+     */
+    children?: this[]
+
+    /**
+     * Whether this node cannot be selected, expanded, or reached by
+     * keyboard navigation. Children of a disabled parent stay unreachable.
+     * @default false
+     */
+    disabled?: boolean
+
+    /**
+     * Whether this node starts expanded when the tree is uncontrolled.
+     * Read once on mount; ignored when `expanded` or `defaultExpanded`
+     * is passed on the tree.
+     */
+    defaultExpanded?: boolean
+
+    /**
+     * Fired after this node is expanded or collapsed.
+     */
+    onToggle?: (expanded: boolean) => void
+
+    /**
+     * Fired after this node is selected or deselected.
+     */
+    onSelect?: (selected: boolean) => void
+
+    /**
+     * Additional CSS classes applied to this node's `<li>` element.
+     */
+    class?: ClassNameValue
+
+    /**
+     * Per-node overrides for individual slot classes.
+     */
+    ui?: Partial<
+        Pick<
+            Record<TreeSlots, ClassNameValue>,
+            | 'item'
+            | 'itemWithChildren'
+            | 'listWithChildren'
+            | 'link'
+            | 'linkLeadingIcon'
+            | 'linkLabel'
+            | 'linkTrailing'
+            | 'linkTrailingIcon'
+        >
+    >
+}
+
+// ============================================================================
+// Slot Props
+// ============================================================================
+
+/**
+ * Context passed to every Tree snippet (`item`, `itemLeading`, `itemLabel`,
+ * `itemTrailing`).
+ *
+ * Svelte has no dynamic named slots, so there is no per-item `slot` field
+ * like Nuxt UI's Tree; branch on `item` inside a snippet instead.
+ */
+export interface TreeSlotProps<T extends TreeItem = TreeItem> {
+    /** The node's item data. */
+    item: T
+    /** Resolved unique key of this node. */
+    key: string
+    /** Zero-based position among its siblings. */
+    index: number
+    /** Zero-based depth (top-level nodes are `0`). */
+    level: number
+    /** Whether the node is currently expanded. */
+    expanded: boolean
+    /** Whether the node is currently selected. */
+    selected: boolean
+    /** Whether only some of the node's descendants are selected. */
+    indeterminate: boolean
+    /** Whether the node has children. */
+    hasChildren: boolean
+    /** Select/deselect this node (respects `multiple`, propagate, bubble). */
+    select: () => void
+    /** Toggle this node's expansion. No-op on leaves. */
+    toggle: () => void
+}
+
+// ============================================================================
+// Imperative API
+// ============================================================================
+
+/**
+ * Imperative API exposed via `bind:api`. Useful for external
+ * Expand all / Collapse all buttons or programmatic selection.
+ *
+ * @example
+ * ```svelte
+ * <script>
+ *   let api = $state<TreeApi>()
+ * </script>
+ *
+ * <Tree bind:api items={files} />
+ *
+ * <Button onclick={() => api?.expandAll()}>Expand all</Button>
+ * ```
+ */
+export interface TreeApi {
+    /** Expand the node with the given key. No-op on leaves. */
+    expand: (key: string) => void
+
+    /** Collapse the node with the given key. */
+    collapse: (key: string) => void
+
+    /** Toggle the node's expanded state. No-op on leaves. */
+    toggle: (key: string) => void
+
+    /** Expand every parent node. */
+    expandAll: () => void
+
+    /** Collapse every parent node. */
+    collapseAll: () => void
+
+    /** Select the node with the given key (respects `multiple`). */
+    select: (key: string) => void
+
+    /** Deselect the node with the given key. */
+    deselect: (key: string) => void
+
+    /** Clear the entire selection. */
+    clearSelection: () => void
+
+    /** Move keyboard focus to the node with the given key (if visible). */
+    focus: (key: string) => void
+
+    /** Whether the node with the given key is expanded. */
+    isExpanded: (key: string) => boolean
+
+    /** Whether the node with the given key is selected. */
+    isSelected: (key: string) => boolean
+
+    /** Current expanded keys. */
+    readonly expanded: string[]
+
+    /** Current selection (`string | undefined` single, `string[]` multiple). */
+    readonly selected: TreeValue | undefined
+}
+
+// ============================================================================
+// Component Props
+// ============================================================================
+
+/**
+ * Props for the Tree component.
+ *
+ * Renders an accessible tree view (WAI-ARIA `tree`/`treeitem`/`group`) with
+ * expand/collapse, single or multiple selection, optional parent↔child
+ * selection propagation, and full keyboard navigation (arrows, Home/End,
+ * Enter/Space, `*`, typeahead).
+ *
+ * @example
+ * ```svelte
+ * <Tree
+ *   items={files}
+ *   bind:value={selected}
+ *   bind:expanded
+ *   multiple
+ *   propagateSelect
+ * />
+ * ```
+ */
+export interface TreeProps<T extends TreeItem = TreeItem> extends Omit<
+    HTMLAttributes<HTMLUListElement>,
+    'class'
+> {
+    /**
+     * Bindable reference to the root `<ul>` element.
+     */
+    ref?: HTMLUListElement | null
+
+    // -------------------------------------------------------------------------
+    // Data
+    // -------------------------------------------------------------------------
+
+    /**
+     * Array of root nodes to render.
+     */
+    items?: T[]
+
+    /**
+     * Custom key resolver. Receives the item and its positional index path
+     * (e.g. `'0.2.1'`). Must return a key unique across the whole tree.
+     */
+    getKey?: (item: T, indexPath: string) => string
+
+    /**
+     * Item field used as the node label.
+     * @default 'label'
+     */
+    labelKey?: keyof T & string
+
+    // -------------------------------------------------------------------------
+    // Selection state (controlled / uncontrolled)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Selected key(s). Use `bind:value` for two-way binding.
+     * A single key when `multiple` is `false`, an array when `true`.
+     */
+    value?: TreeValue
+
+    /**
+     * Initial selection when uncontrolled.
+     */
+    defaultValue?: TreeValue
+
+    /**
+     * Fired whenever the selection changes.
+     */
+    onValueChange?: (value: TreeValue | undefined) => void
+
+    // -------------------------------------------------------------------------
+    // Expansion state (controlled / uncontrolled)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Keys of expanded nodes. Use `bind:expanded` for two-way binding.
+     * When passed (even `[]`), `defaultExpanded` and per-item
+     * `defaultExpanded` are ignored.
+     */
+    expanded?: string[]
+
+    /**
+     * Initially expanded keys when uncontrolled. Defaults to the keys of
+     * items marked `defaultExpanded: true`.
+     */
+    defaultExpanded?: string[]
+
+    /**
+     * Fired whenever the expanded keys change.
+     */
+    onExpandedChange?: (expanded: string[]) => void
+
+    // -------------------------------------------------------------------------
+    // Imperative API
+    // -------------------------------------------------------------------------
+
+    /**
+     * Bindable imperative controller for external buttons or
+     * programmatic control.
+     */
+    api?: TreeApi
+
+    // -------------------------------------------------------------------------
+    // Behavior
+    // -------------------------------------------------------------------------
+
+    /**
+     * Allow selecting multiple nodes. Changes `value` to a `string[]` and
+     * sets `aria-multiselectable` on the root.
+     * @default false
+     */
+    multiple?: boolean
+
+    /**
+     * How selecting an unselected node affects the existing selection.
+     * - `'toggle'`: adds/removes the node, keeping other selections
+     * - `'replace'`: the node becomes the only selection
+     * @default 'toggle'
+     */
+    selectionBehavior?: 'toggle' | 'replace'
+
+    /**
+     * When `multiple`, selecting a parent also selects/deselects all its
+     * selectable (non-disabled) descendants, and partially selected parents
+     * report `indeterminate`.
+     * @default false
+     */
+    propagateSelect?: boolean
+
+    /**
+     * When `multiple`, a parent is automatically added to the selection
+     * once all its selectable children are selected (and removed when
+     * any child is deselected).
+     * @default false
+     */
+    bubbleSelect?: boolean
+
+    /**
+     * Whether the whole tree is disabled.
+     * @default false
+     */
+    disabled?: boolean
+
+    // -------------------------------------------------------------------------
+    // Display
+    // -------------------------------------------------------------------------
+
+    /**
+     * Color used for selection highlight and focus ring.
+     * @default 'primary'
+     */
+    color?: NonNullable<TreeVariantProps['color']>
+
+    /**
+     * Size variant controlling row padding, text, and icon sizes.
+     * @default 'md'
+     */
+    size?: NonNullable<TreeVariantProps['size']>
+
+    /**
+     * Iconify icon name for the expand/collapse chevron on parent nodes.
+     * @default icons.chevronDown ('lucide:chevron-down')
+     */
+    trailingIcon?: string
+
+    /**
+     * Iconify icon name shown before the label of expanded parent nodes
+     * without an explicit `item.icon`.
+     * @default icons.folderOpen ('lucide:folder-open')
+     */
+    expandedIcon?: string
+
+    /**
+     * Iconify icon name shown before the label of collapsed parent nodes
+     * without an explicit `item.icon`.
+     * @default icons.folder ('lucide:folder')
+     */
+    collapsedIcon?: string
+
+    // -------------------------------------------------------------------------
+    // Styling
+    // -------------------------------------------------------------------------
+
+    /**
+     * Additional CSS classes for the root element.
+     */
+    class?: ClassNameValue
+
+    /**
+     * Override classes for component slots.
+     */
+    ui?: Partial<Record<TreeSlots, ClassNameValue>>
+
+    // -------------------------------------------------------------------------
+    // Snippets
+    // -------------------------------------------------------------------------
+
+    /**
+     * Full custom row renderer. Replaces the default leading icon, label,
+     * and trailing chevron entirely (children still render below).
+     */
+    item?: Snippet<[TreeSlotProps<T>]>
+
+    /**
+     * Custom content before the label. Falls back to the item/folder icon.
+     */
+    itemLeading?: Snippet<[TreeSlotProps<T>]>
+
+    /**
+     * Custom label renderer. Falls back to `item[labelKey]`.
+     */
+    itemLabel?: Snippet<[TreeSlotProps<T>]>
+
+    /**
+     * Custom content after the label. Falls back to the expand chevron on
+     * parent nodes.
+     */
+    itemTrailing?: Snippet<[TreeSlotProps<T>]>
+}

--- a/src/lib/components/Tree/tree.variants.ts
+++ b/src/lib/components/Tree/tree.variants.ts
@@ -1,0 +1,124 @@
+import { tv, type VariantProps } from 'tailwind-variants'
+
+export const treeVariants = tv({
+    slots: {
+        root: 'relative isolate w-full list-none p-0 m-0 space-y-0.5',
+        item: 'group/item space-y-0.5 focus:outline-none focus-visible:outline-none',
+        listWithChildren:
+            'list-none p-0 m-0 ms-4.5 ps-1.5 border-s border-outline-variant space-y-0.5',
+        itemWithChildren: '',
+        link: [
+            'group/link relative w-full flex items-center text-start rounded-md select-none',
+            'text-on-surface transition-colors',
+            'cursor-pointer hover:not-data-[selected=true]:not-data-disabled:bg-surface-container',
+            'data-[keyboard-focus]:ring-2 data-[keyboard-focus]:ring-inset',
+            'data-disabled:cursor-not-allowed data-disabled:opacity-60'
+        ],
+        linkLeadingIcon: 'shrink-0 text-on-surface-variant',
+        linkLabel: 'truncate',
+        linkTrailing: 'ms-auto inline-flex items-center',
+        linkTrailingIcon: [
+            'shrink-0 text-on-surface-variant transition-transform duration-200',
+            'group-data-[expanded=true]/link:rotate-180'
+        ]
+    },
+    variants: {
+        color: {
+            primary: {
+                link: [
+                    'data-[keyboard-focus]:ring-primary',
+                    'data-[selected=true]:bg-primary/10 data-[selected=true]:text-primary'
+                ],
+                linkLeadingIcon: 'group-data-[selected=true]/link:text-primary'
+            },
+            secondary: {
+                link: [
+                    'data-[keyboard-focus]:ring-secondary',
+                    'data-[selected=true]:bg-secondary/10 data-[selected=true]:text-secondary'
+                ],
+                linkLeadingIcon: 'group-data-[selected=true]/link:text-secondary'
+            },
+            tertiary: {
+                link: [
+                    'data-[keyboard-focus]:ring-tertiary',
+                    'data-[selected=true]:bg-tertiary/10 data-[selected=true]:text-tertiary'
+                ],
+                linkLeadingIcon: 'group-data-[selected=true]/link:text-tertiary'
+            },
+            success: {
+                link: [
+                    'data-[keyboard-focus]:ring-success',
+                    'data-[selected=true]:bg-success/10 data-[selected=true]:text-success'
+                ],
+                linkLeadingIcon: 'group-data-[selected=true]/link:text-success'
+            },
+            warning: {
+                link: [
+                    'data-[keyboard-focus]:ring-warning',
+                    'data-[selected=true]:bg-warning/10 data-[selected=true]:text-warning'
+                ],
+                linkLeadingIcon: 'group-data-[selected=true]/link:text-warning'
+            },
+            error: {
+                link: [
+                    'data-[keyboard-focus]:ring-error',
+                    'data-[selected=true]:bg-error/10 data-[selected=true]:text-error'
+                ],
+                linkLeadingIcon: 'group-data-[selected=true]/link:text-error'
+            },
+            info: {
+                link: [
+                    'data-[keyboard-focus]:ring-info',
+                    'data-[selected=true]:bg-info/10 data-[selected=true]:text-info'
+                ],
+                linkLeadingIcon: 'group-data-[selected=true]/link:text-info'
+            },
+            surface: {
+                link: [
+                    'data-[keyboard-focus]:ring-outline',
+                    'data-[selected=true]:bg-surface-container-highest data-[selected=true]:text-on-surface'
+                ],
+                linkLeadingIcon: 'group-data-[selected=true]/link:text-on-surface'
+            }
+        },
+        size: {
+            xs: {
+                link: 'px-2 py-1 text-xs gap-1',
+                linkLeadingIcon: 'size-3.5',
+                linkTrailingIcon: 'size-3.5'
+            },
+            sm: {
+                link: 'px-2 py-1.5 text-xs gap-1.5',
+                linkLeadingIcon: 'size-4',
+                linkTrailingIcon: 'size-4'
+            },
+            md: {
+                link: 'px-2.5 py-1.5 text-sm gap-1.5',
+                linkLeadingIcon: 'size-5',
+                linkTrailingIcon: 'size-5'
+            },
+            lg: {
+                link: 'px-3 py-2 text-sm gap-2',
+                linkLeadingIcon: 'size-5',
+                linkTrailingIcon: 'size-5'
+            },
+            xl: {
+                link: 'px-3 py-2 text-base gap-2',
+                linkLeadingIcon: 'size-6',
+                linkTrailingIcon: 'size-6'
+            }
+        }
+    },
+    defaultVariants: {
+        color: 'primary',
+        size: 'md'
+    }
+})
+
+export type TreeVariantProps = VariantProps<typeof treeVariants>
+export type TreeSlots = keyof ReturnType<typeof treeVariants>
+
+export const treeDefaults = {
+    defaultVariants: treeVariants.defaultVariants,
+    slots: {} as Partial<Record<TreeSlots, string>>
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -44,6 +44,8 @@ export const iconsDefaults = {
     trash: 'lucide:trash-2',
     search: 'lucide:search',
     star: 'lucide:star',
+    folder: 'lucide:folder',
+    folderOpen: 'lucide:folder-open',
     sortAsc: 'lucide:chevron-up',
     sortDesc: 'lucide:chevron-down',
     sortDefault: 'lucide:chevrons-up-down'

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -63,6 +63,7 @@ export * from './components/Carousel/index.js'
 export * from './components/Banner/index.js'
 export * from './components/Stepper/index.js'
 export * from './components/Tour/index.js'
+export * from './components/Tree/index.js'
 
 // Composables
 export * from './hooks/index.js'

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -73,7 +73,8 @@
         { href: '/editor', label: 'Editor', icon: 'lucide:pen-tool' },
         { href: '/banner', label: 'Banner', icon: 'lucide:megaphone' },
         { href: '/stepper', label: 'Stepper', icon: 'lucide:list-ordered' },
-        { href: '/tour', label: 'Tour', icon: 'lucide:route' }
+        { href: '/tour', label: 'Tour', icon: 'lucide:route' },
+        { href: '/tree', label: 'Tree', icon: 'lucide:folder-tree' }
     ]
 
     const hookItems = [

--- a/src/routes/tree/+page.svelte
+++ b/src/routes/tree/+page.svelte
@@ -1,0 +1,690 @@
+<script lang="ts">
+    import {
+        Tree,
+        Button,
+        Badge,
+        Checkbox,
+        Input,
+        Avatar,
+        Icon,
+        type TreeApi,
+        type TreeItem
+    } from '$lib/index.js'
+
+    const colors = [
+        'primary',
+        'secondary',
+        'tertiary',
+        'success',
+        'warning',
+        'error',
+        'info',
+        'surface'
+    ] as const
+    const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const
+
+    const files: TreeItem[] = [
+        {
+            label: 'app',
+            defaultExpanded: true,
+            children: [
+                {
+                    label: 'composables',
+                    children: [
+                        { label: 'useAuth.ts', icon: 'lucide:file-code' },
+                        { label: 'useUser.ts', icon: 'lucide:file-code' }
+                    ]
+                },
+                {
+                    label: 'components',
+                    defaultExpanded: true,
+                    children: [
+                        { label: 'Card.svelte', icon: 'lucide:file-code' },
+                        { label: 'Button.svelte', icon: 'lucide:file-code' }
+                    ]
+                }
+            ]
+        },
+        { label: 'app.config.ts', icon: 'lucide:file-cog' },
+        { label: 'package.json', icon: 'lucide:file-json' }
+    ]
+
+    const plainFiles: TreeItem[] = [
+        {
+            label: 'src',
+            children: [
+                {
+                    label: 'lib',
+                    children: [
+                        { label: 'index.ts', icon: 'lucide:file-code' },
+                        { label: 'utils.ts', icon: 'lucide:file-code' }
+                    ]
+                },
+                { label: 'routes', children: [{ label: '+page.svelte', icon: 'lucide:file-code' }] }
+            ]
+        },
+        { label: 'static', children: [{ label: 'favicon.png', icon: 'lucide:image' }] },
+        { label: 'README.md', icon: 'lucide:file-text' }
+    ]
+
+    const permissionItems: TreeItem[] = [
+        {
+            label: 'Documents',
+            value: 'documents',
+            defaultExpanded: true,
+            children: [
+                { label: 'Read', value: 'documents.read' },
+                { label: 'Write', value: 'documents.write' },
+                { label: 'Delete', value: 'documents.delete' }
+            ]
+        },
+        {
+            label: 'Users',
+            value: 'users',
+            defaultExpanded: true,
+            children: [
+                { label: 'Invite', value: 'users.invite' },
+                { label: 'Remove', value: 'users.remove' }
+            ]
+        }
+    ]
+
+    const disabledItems: TreeItem[] = [
+        {
+            label: 'public',
+            children: [{ label: 'index.html', icon: 'lucide:file-code' }]
+        },
+        {
+            label: 'node_modules',
+            disabled: true,
+            children: [{ label: 'lots-of-packages' }]
+        },
+        { label: '.env', icon: 'lucide:file-lock', disabled: true },
+        { label: 'vite.config.ts', icon: 'lucide:file-cog' }
+    ]
+
+    interface FileItem extends TreeItem {
+        size?: string
+    }
+
+    const sizedItems: FileItem[] = [
+        {
+            label: 'assets',
+            defaultExpanded: true,
+            children: [
+                { label: 'logo.svg', icon: 'lucide:image', size: '4.2 KB' },
+                { label: 'hero.png', icon: 'lucide:image', size: '1.8 MB' }
+            ]
+        },
+        { label: 'index.html', icon: 'lucide:file-code', size: '2.1 KB' }
+    ]
+
+    let api = $state<TreeApi>()
+    let expandedKeys = $state<string[]>(['src'])
+    let singleValue = $state<string | string[]>()
+    let multiValue = $state<string | string[]>(['documents.read'])
+    let checkboxValue = $state<string | string[]>([])
+
+    // ---- Search / filter demo ----
+    const projectTree: TreeItem[] = [
+        {
+            label: 'src',
+            children: [
+                {
+                    label: 'components',
+                    children: [
+                        { label: 'Tree.svelte', icon: 'lucide:file-code' },
+                        { label: 'Button.svelte', icon: 'lucide:file-code' },
+                        { label: 'Modal.svelte', icon: 'lucide:file-code' }
+                    ]
+                },
+                {
+                    label: 'hooks',
+                    children: [
+                        { label: 'useMediaQuery.ts', icon: 'lucide:file-code' },
+                        { label: 'useClipboard.ts', icon: 'lucide:file-code' }
+                    ]
+                },
+                { label: 'index.ts', icon: 'lucide:file-code' }
+            ]
+        },
+        {
+            label: 'tests',
+            children: [
+                { label: 'tree.spec.ts', icon: 'lucide:flask-conical' },
+                { label: 'button.spec.ts', icon: 'lucide:flask-conical' }
+            ]
+        },
+        { label: 'package.json', icon: 'lucide:file-json' }
+    ]
+
+    function filterTree(nodes: TreeItem[], query: string): TreeItem[] {
+        const out: TreeItem[] = []
+        for (const node of nodes) {
+            const selfMatch = (node.label ?? '').toLowerCase().includes(query)
+            const matchedChildren = node.children ? filterTree(node.children, query) : []
+            if (selfMatch || matchedChildren.length > 0) {
+                out.push({
+                    ...node,
+                    children: node.children
+                        ? selfMatch
+                            ? node.children
+                            : matchedChildren
+                        : undefined
+                })
+            }
+        }
+        return out
+    }
+
+    function folderKeys(nodes: TreeItem[]): string[] {
+        const keys: string[] = []
+        for (const node of nodes) {
+            if (node.children?.length) {
+                keys.push(node.label ?? '')
+                keys.push(...folderKeys(node.children))
+            }
+        }
+        return keys
+    }
+
+    let query = $state('')
+    const filteredTree = $derived(
+        query.trim() ? filterTree(projectTree, query.toLowerCase()) : projectTree
+    )
+    const searchExpanded = $derived(query.trim() ? folderKeys(filteredTree) : ['src'])
+
+    // ---- Programmatic selection demo ----
+    let progApi = $state<TreeApi>()
+    let progValue = $state<string | string[]>([])
+
+    // ---- File explorer with row actions ----
+    interface ExplorerItem extends TreeItem {
+        value: string
+    }
+
+    const initialExplorer: ExplorerItem[] = [
+        {
+            label: 'app',
+            value: 'app',
+            defaultExpanded: true,
+            children: [
+                { label: 'layout.svelte', value: 'app/layout', icon: 'lucide:file-code' },
+                { label: 'page.svelte', value: 'app/page', icon: 'lucide:file-code' }
+            ]
+        },
+        {
+            label: 'lib',
+            value: 'lib',
+            children: [{ label: 'utils.ts', value: 'lib/utils', icon: 'lucide:file-code' }]
+        },
+        { label: 'README.md', value: 'readme', icon: 'lucide:file-text' }
+    ]
+
+    let explorerItems = $state<ExplorerItem[]>(structuredClone(initialExplorer))
+    let newFileCount = $state(1)
+
+    function removeNode(nodes: ExplorerItem[], value: string): ExplorerItem[] {
+        return nodes
+            .filter((node) => node.value !== value)
+            .map((node) =>
+                node.children ? { ...node, children: removeNode(node.children, value) } : node
+            )
+    }
+
+    function deleteNode(value: string) {
+        explorerItems = removeNode(explorerItems, value)
+    }
+
+    function addFile() {
+        explorerItems = [
+            ...explorerItems,
+            {
+                label: `untitled-${newFileCount}.ts`,
+                value: `untitled-${newFileCount}`,
+                icon: 'lucide:file-plus'
+            }
+        ]
+        newFileCount += 1
+    }
+
+    function resetExplorer() {
+        explorerItems = structuredClone(initialExplorer)
+        newFileCount = 1
+    }
+
+    // ---- People / org tree ----
+    interface PersonItem extends TreeItem {
+        initials: string
+        role: string
+        avatar?: string
+    }
+
+    const people: PersonItem[] = [
+        {
+            label: 'Ada Lovelace',
+            initials: 'AL',
+            role: 'CTO',
+            defaultExpanded: true,
+            children: [
+                {
+                    label: 'Grace Hopper',
+                    initials: 'GH',
+                    role: 'Eng Lead',
+                    children: [
+                        { label: 'Linus Torvalds', initials: 'LT', role: 'Engineer' },
+                        { label: 'Margaret Hamilton', initials: 'MH', role: 'Engineer' }
+                    ]
+                },
+                { label: 'Alan Turing', initials: 'AT', role: 'Research' }
+            ]
+        }
+    ]
+    let peopleValue = $state<string | string[]>()
+</script>
+
+<div class="space-y-8">
+    <h1 class="text-2xl font-bold text-on-surface">Tree</h1>
+
+    <!-- Basic Usage -->
+    <section class="space-y-4">
+        <h2 class="text-lg font-semibold text-on-surface">Basic Usage</h2>
+        <p class="text-sm text-on-surface-variant">
+            An accessible tree view. Parent nodes get folder icons and a chevron by default; use
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">items</code>
+            with nested
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">children</code>
+            and mark nodes
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >defaultExpanded</code
+            >. Navigate with the arrow keys, Home/End, Enter/Space,
+            <kbd class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">*</kbd> to expand
+            siblings, or just type a label (typeahead).
+        </p>
+        <Tree items={files} class="max-w-xs" />
+    </section>
+
+    <!-- Controlled Expansion -->
+    <section class="space-y-4">
+        <h2 class="text-lg font-semibold text-on-surface">Controlled Expansion & API</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >bind:expanded</code
+            >
+            for two-way expansion state, and
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">bind:api</code>
+            for imperative control from external buttons.
+        </p>
+        <div class="flex flex-wrap items-center gap-2">
+            <Button size="sm" variant="outline" onclick={() => api?.expandAll()}>Expand all</Button>
+            <Button size="sm" variant="outline" onclick={() => api?.collapseAll()}>
+                Collapse all
+            </Button>
+        </div>
+        <Tree items={plainFiles} bind:expanded={expandedKeys} bind:api class="max-w-xs" />
+        <p class="text-sm text-on-surface-variant">
+            Expanded: <span class="font-mono text-on-surface"
+                >[{expandedKeys.map((key) => `'${key}'`).join(', ')}]</span
+            >
+        </p>
+    </section>
+
+    <!-- Single Selection -->
+    <section class="space-y-4">
+        <h2 class="text-lg font-semibold text-on-surface">Single Selection</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >bind:value</code
+            >
+            to track the selected node. Clicking a selected node deselects it (<code
+                class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >selectionBehavior="toggle"</code
+            >, the default).
+        </p>
+        <Tree items={files} bind:value={singleValue} class="max-w-xs" />
+        <p class="text-sm text-on-surface-variant">
+            Selected: <span class="font-mono text-on-surface">{singleValue ?? 'none'}</span>
+        </p>
+    </section>
+
+    <!-- Multiple Selection -->
+    <section class="space-y-4">
+        <h2 class="text-lg font-semibold text-on-surface">Multiple Selection</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >multiple</code
+            >
+            to select several nodes;
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">value</code>
+            becomes an array of keys.
+        </p>
+        <Tree items={permissionItems} multiple bind:value={multiValue} class="max-w-xs" />
+        <p class="text-sm text-on-surface-variant">
+            Selected: <span class="font-mono text-on-surface"
+                >{Array.isArray(multiValue) ? JSON.stringify(multiValue) : 'none'}</span
+            >
+        </p>
+    </section>
+
+    <!-- Checkbox Tree -->
+    <section class="space-y-4">
+        <h2 class="text-lg font-semibold text-on-surface">Checkbox Tree</h2>
+        <p class="text-sm text-on-surface-variant">
+            Combine <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >propagateSelect</code
+            >
+            (selecting a parent selects its descendants),
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >bubbleSelect</code
+            >
+            (a parent is selected once all children are) and an
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >itemLeading</code
+            > snippet rendering a tri-state Checkbox.
+        </p>
+        <Tree
+            items={permissionItems}
+            multiple
+            propagateSelect
+            bubbleSelect
+            bind:value={checkboxValue}
+            class="max-w-xs"
+        >
+            {#snippet itemLeading({ selected, indeterminate })}
+                <Checkbox checked={selected} {indeterminate} tabindex={-1} />
+            {/snippet}
+        </Tree>
+        <p class="text-sm text-on-surface-variant">
+            Selected: <span class="font-mono text-on-surface"
+                >{Array.isArray(checkboxValue) ? JSON.stringify(checkboxValue) : 'none'}</span
+            >
+        </p>
+    </section>
+
+    <!-- Colors -->
+    <section class="space-y-4">
+        <h2 class="text-lg font-semibold text-on-surface">Colors</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">color</code
+            > to change the selection highlight and focus ring.
+        </p>
+        <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {#each colors as color (color)}
+                <div class="space-y-2">
+                    <span class="text-sm text-on-surface-variant">{color}</span>
+                    <Tree
+                        {color}
+                        items={[
+                            {
+                                label: 'components',
+                                defaultExpanded: true,
+                                children: [
+                                    { label: 'Tree.svelte', icon: 'lucide:file-code' },
+                                    { label: 'index.ts', icon: 'lucide:file-code' }
+                                ]
+                            }
+                        ]}
+                        defaultValue="Tree.svelte"
+                    />
+                </div>
+            {/each}
+        </div>
+    </section>
+
+    <!-- Sizes -->
+    <section class="space-y-4">
+        <h2 class="text-lg font-semibold text-on-surface">Sizes</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">size</code>
+            to control row padding, text and icon sizes.
+        </p>
+        <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {#each sizes as size (size)}
+                <div class="space-y-2">
+                    <span class="text-sm text-on-surface-variant">{size}</span>
+                    <Tree
+                        {size}
+                        items={[
+                            {
+                                label: 'src',
+                                defaultExpanded: true,
+                                children: [{ label: 'main.ts', icon: 'lucide:file-code' }]
+                            }
+                        ]}
+                    />
+                </div>
+            {/each}
+        </div>
+    </section>
+
+    <!-- Disabled -->
+    <section class="space-y-4">
+        <h2 class="text-lg font-semibold text-on-surface">Disabled</h2>
+        <p class="text-sm text-on-surface-variant">
+            Disable individual nodes with <code
+                class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >item.disabled</code
+            >
+            (skipped by keyboard navigation, not selectable or expandable) or the whole tree with the
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">disabled</code>
+            prop.
+        </p>
+        <div class="flex flex-wrap gap-10">
+            <Tree items={disabledItems} class="max-w-xs" />
+            <Tree items={plainFiles} disabled class="max-w-xs" />
+        </div>
+    </section>
+
+    <!-- Custom Icons -->
+    <section class="space-y-4">
+        <h2 class="text-lg font-semibold text-on-surface">Custom Icons</h2>
+        <p class="text-sm text-on-surface-variant">
+            Override the chevron with <code
+                class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >trailingIcon</code
+            >
+            and the parent icons with
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >expandedIcon</code
+            >
+            /
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >collapsedIcon</code
+            >. Per-item
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">icon</code>
+            always wins.
+        </p>
+        <Tree
+            items={plainFiles}
+            trailingIcon="lucide:chevron-right"
+            expandedIcon="lucide:folder-minus"
+            collapsedIcon="lucide:folder-plus"
+            ui={{ linkTrailingIcon: 'group-data-[expanded=true]/link:rotate-90' }}
+            class="max-w-xs"
+        />
+    </section>
+
+    <!-- Custom Snippets -->
+    <section class="space-y-4">
+        <h2 class="text-lg font-semibold text-on-surface">Custom Snippets</h2>
+        <p class="text-sm text-on-surface-variant">
+            Use the <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >itemTrailing</code
+            >
+            snippet (or
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">item</code>,
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >itemLeading</code
+            >,
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">itemLabel</code
+            >) to customize row content. Extra item fields are available on
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">item</code>.
+        </p>
+        <Tree items={sizedItems} class="max-w-xs">
+            {#snippet itemTrailing({ item, hasChildren })}
+                {#if !hasChildren && item.size}
+                    <Badge size="sm" color="surface" variant="soft" class="ms-auto">
+                        {item.size}
+                    </Badge>
+                {/if}
+            {/snippet}
+        </Tree>
+    </section>
+
+    <!-- Search / Filter -->
+    <section class="space-y-4">
+        <h2 class="text-lg font-semibold text-on-surface">Search &amp; Filter</h2>
+        <p class="text-sm text-on-surface-variant">
+            Derive a filtered <code
+                class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">items</code
+            >
+            tree from a query (keeping matched nodes and their ancestors) and pass matched folder keys
+            to a controlled
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">expanded</code>
+            so results auto-expand.
+        </p>
+        <div class="max-w-xs space-y-3">
+            <Input bind:value={query} leadingIcon="lucide:search" placeholder="Filter files..." />
+            {#if filteredTree.length > 0}
+                <Tree items={filteredTree} expanded={searchExpanded} size="sm" />
+            {:else}
+                <p class="px-2 py-1.5 text-sm text-on-surface-variant">
+                    No files match &ldquo;{query}&rdquo;.
+                </p>
+            {/if}
+        </div>
+    </section>
+
+    <!-- Programmatic Selection -->
+    <section class="space-y-4">
+        <h2 class="text-lg font-semibold text-on-surface">Programmatic Selection</h2>
+        <p class="text-sm text-on-surface-variant">
+            Drive selection from outside via <code
+                class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">bind:api</code
+            >
+            &mdash;
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >api.select</code
+            >,
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >api.deselect</code
+            >,
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >api.clearSelection</code
+            >. With
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >propagateSelect</code
+            > these stay consistent across descendants.
+        </p>
+        <div class="flex flex-wrap items-center gap-2">
+            <Button size="sm" variant="soft" onclick={() => progApi?.select('documents')}>
+                Select all Documents
+            </Button>
+            <Button size="sm" variant="soft" onclick={() => progApi?.deselect('documents.delete')}>
+                Revoke Delete
+            </Button>
+            <Button size="sm" variant="outline" onclick={() => progApi?.clearSelection()}>
+                Clear
+            </Button>
+        </div>
+        <Tree
+            items={permissionItems}
+            multiple
+            propagateSelect
+            bubbleSelect
+            bind:api={progApi}
+            bind:value={progValue}
+            class="max-w-xs"
+        />
+        <p class="text-sm text-on-surface-variant">
+            Selected: <span class="font-mono text-on-surface"
+                >{Array.isArray(progValue) && progValue.length
+                    ? JSON.stringify(progValue)
+                    : 'none'}</span
+            >
+        </p>
+    </section>
+
+    <!-- File Explorer with row actions -->
+    <section class="space-y-4">
+        <h2 class="text-lg font-semibold text-on-surface">File Explorer with Row Actions</h2>
+        <p class="text-sm text-on-surface-variant">
+            An <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >itemTrailing</code
+            >
+            snippet renders a delete button next to each row. Clicking a button (or any non-checkbox control)
+            never selects or toggles the row, so actions and navigation stay independent. The
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">items</code>
+            array is
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">$state</code>,
+            so edits render immediately.
+        </p>
+        <div class="flex flex-wrap items-center gap-2">
+            <Button size="sm" variant="soft" leadingIcon="lucide:plus" onclick={addFile}>
+                Add file
+            </Button>
+            <Button size="sm" variant="outline" onclick={resetExplorer}>Reset</Button>
+        </div>
+        <Tree items={explorerItems} class="max-w-sm">
+            {#snippet itemTrailing({ item, hasChildren, expanded })}
+                <span class="ms-auto flex items-center gap-1">
+                    <Button
+                        icon="lucide:trash-2"
+                        size="xs"
+                        variant="ghost"
+                        color="error"
+                        aria-label="Delete {item.label}"
+                        onclick={() => deleteNode(item.value as string)}
+                    />
+                    {#if hasChildren}
+                        <Icon
+                            name="lucide:chevron-down"
+                            class="size-4 text-on-surface-variant transition-transform duration-200 {expanded
+                                ? 'rotate-180'
+                                : ''}"
+                        />
+                    {/if}
+                </span>
+            {/snippet}
+        </Tree>
+    </section>
+
+    <!-- People / Org tree -->
+    <section class="space-y-4">
+        <h2 class="text-lg font-semibold text-on-surface">Org Chart</h2>
+        <p class="text-sm text-on-surface-variant">
+            Rich rows via an <code
+                class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">itemLeading</code
+            >
+            snippet (an Avatar) and an
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs"
+                >itemTrailing</code
+            > snippet (a role badge, plus the chevron re-added for managers).
+        </p>
+        <Tree items={people} bind:value={peopleValue} color="tertiary" size="lg" class="max-w-md">
+            {#snippet itemLeading({ item })}
+                <Avatar text={(item as PersonItem).initials} size="xs" />
+            {/snippet}
+            {#snippet itemTrailing({ item, hasChildren, expanded })}
+                <span class="ms-auto flex items-center gap-2">
+                    <Badge size="sm" variant="soft" color="surface">
+                        {(item as PersonItem).role}
+                    </Badge>
+                    {#if hasChildren}
+                        <Icon
+                            name="lucide:chevron-down"
+                            class="size-5 text-on-surface-variant transition-transform duration-200 {expanded
+                                ? 'rotate-180'
+                                : ''}"
+                        />
+                    {/if}
+                </span>
+            {/snippet}
+        </Tree>
+    </section>
+
+    <p class="text-sm text-on-surface-variant">
+        Future work: virtualization for very large trees, Shift+Arrow range selection, and async
+        (lazy-loaded) children.
+    </p>
+</div>


### PR DESCRIPTION
## Summary

Adds the **Tree** component: a hierarchical tree view with multi-select, checkbox propagation and full keyboard navigation.

Closes #171

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature / component
- [ ] 📖 Documentation
- [ ] ♻️ Refactor / chore
- [ ] ⚠️ Breaking change

## Changes

- **Tree** component (`Tree.svelte`, types, variants, index)
- Generic data-driven `items` with `getKey` and `labelKey`, recursive `children`, per-item `icon`/`trailingIcon`/`disabled`/`defaultExpanded` and per-item `class`/`ui` overrides
- Selection: bindable `value` plus `defaultValue`/`onValueChange`, `multiple`, `selectionBehavior` `toggle` or `replace`, `propagateSelect` down to descendants and `bubbleSelect` up to ancestors with indeterminate state
- Expansion: bindable `expanded` plus `defaultExpanded`/`onExpandedChange`, customizable `expandedIcon`/`collapsedIcon`/`trailingIcon`
- `api` imperative handle: `expand`, `collapse`, `toggle`, `expandAll`, `collapseAll`, `select`, `deselect`, `clearSelection`, `focus`, `isExpanded`, `isSelected`
- Full keyboard navigation and `color`/`size` variants
- Snippets: `item`, `itemLeading`, `itemLabel`, `itemTrailing`, each receiving level, expanded, selected, indeterminate and imperative helpers
- Demo route `/tree` and docs nav entry

## Checklist

- [x] Linked the related issue (`Closes #…`)
- [ ] `pnpm check` passes (0 errors, 0 warnings)
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [x] Added or updated tests for the change
- [ ] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] Followed component conventions (no comments outside `*.types.ts`, Material 3 design tokens)

## Screenshots / notes

- 41 browser specs in `Tree.svelte.spec.ts`.
- Gate boxes are left unchecked because the branch was not re-verified locally in this pass; CI on this PR is the authority.
- CHANGELOG entry under `[Unreleased]` is still to be written on this branch.
