### PR TITLE
fix(sidebar): make offcanvas inert, expose aria-expanded, add api handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Sidebar** — collapsible dashboard sidebar rendering its navigation through NavigationMenu: `variant` `sidebar`/`floating`/`inset`, `side` left/right, `collapsible` `icon`/`offcanvas`/`none` with bindable `collapsed`/`open`, composable header, edge `rail` toggle, localStorage `persist`, and a `slideover`/`drawer` mobile menu. Header height follows `--ui-header-height` so it aligns with a sibling Header. ([#176](https://github.com/ndlabdev/sv5ui/pull/176))
 - **SidebarTrigger** — viewport-aware toggle button for the app header: collapses the sidebar on desktop, opens the mobile menu below `breakpoint`. ([#176](https://github.com/ndlabdev/sv5ui/pull/176))
 
+### Fixed
+
+- **Sidebar** — `collapsible="offcanvas"` now marks the collapsed sidebar `inert` and `aria-hidden`, so its links no longer take keyboard focus or reach assistive tech while off screen. ([#180](https://github.com/ndlabdev/sv5ui/pull/180))
+- **Sidebar** — the edge rail, footer toggle and `SidebarTrigger` expose `aria-expanded`. ([#180](https://github.com/ndlabdev/sv5ui/pull/180))
+
+### Changed
+
+- **Sidebar** — added a bindable `api` handle (`collapsed`, `open`, `below`, `state`, `toggle`, `expand`, `collapse`) that `SidebarTrigger` accepts, so a trigger rendered outside the sidebar no longer repeats `breakpoint` or the bindable state. ([#180](https://github.com/ndlabdev/sv5ui/pull/180))
+
 ## [2.4.0] - 2026-07-19
 
 ### Added

--- a/src/lib/components/Sidebar/Sidebar.svelte
+++ b/src/lib/components/Sidebar/Sidebar.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <script lang="ts">
-    import type { SidebarState } from './sidebar.types.js'
+    import type { SidebarApi, SidebarState } from './sidebar.types.js'
     import type { ButtonProps } from '../Button/button.types.js'
     import type { NavigationMenuItem } from '../NavigationMenu/navigation-menu.types.js'
     import { sidebarVariants, sidebarDefaults } from './sidebar.variants.js'
@@ -15,6 +15,7 @@
     import Slideover from '../Slideover/Slideover.svelte'
     import Drawer from '../Drawer/Drawer.svelte'
     import NavigationMenu from '../NavigationMenu/NavigationMenu.svelte'
+    import { useMediaQuery } from '../../hooks/useMediaQuery/index.js'
 
     const config = getComponentConfig('sidebar', sidebarDefaults)
     const icons = getComponentConfig('icons', iconsDefaults)
@@ -26,6 +27,7 @@
         side = config.defaultVariants.side ?? 'left',
         collapsible = 'icon',
         breakpoint = config.defaultVariants.breakpoint ?? 'lg',
+        api = $bindable(),
         collapsed = $bindable(false),
         open = $bindable(false),
         mode = 'slideover',
@@ -59,10 +61,23 @@
         ...restProps
     }: Props = $props()
 
-    const offcanvasHidden = $derived(collapsible === 'offcanvas' && collapsed)
+    const BREAKPOINT_PX = { sm: 640, md: 768, lg: 1024, xl: 1280 }
+
+    const collapsedValue = $derived(collapsed)
+    const openValue = $derived(open)
+    const activeBreakpoint = $derived(breakpoint)
+
+    const media = useMediaQuery(() => `(max-width: ${BREAKPOINT_PX[activeBreakpoint] - 0.02}px)`)
+
+    const offcanvasHidden = $derived(collapsible === 'offcanvas' && collapsedValue)
 
     const classes = $derived.by(() => {
-        const slots = sidebarVariants({ variant, side, breakpoint, transition })
+        const slots = sidebarVariants({
+            variant,
+            side,
+            breakpoint: activeBreakpoint,
+            transition
+        })
         const c = config.slots
         const u = ui ?? {}
         return {
@@ -83,8 +98,8 @@
     })
 
     const canCollapse = $derived(collapsible !== 'none')
-    const isCollapsed = $derived(canCollapse && collapsed)
-    const isRail = $derived(collapsible === 'icon' && collapsed)
+    const isCollapsed = $derived(canCollapse && collapsedValue)
+    const isRail = $derived(collapsible === 'icon' && collapsedValue)
 
     const currentWidth = $derived.by(() => {
         if (!isCollapsed) return width
@@ -107,7 +122,7 @@
     const userToggle: ButtonProps = $derived(typeof toggle === 'object' ? toggle : {})
 
     const toggleIcon = $derived.by(() => {
-        const expand = collapsed
+        const expand = collapsedValue
         if (side === 'left') return expand ? icons.chevronsRight : icons.chevronsLeft
         return expand ? icons.chevronsLeft : icons.chevronsRight
     })
@@ -117,7 +132,8 @@
         variant: 'ghost',
         block: true,
         icon: toggleIcon,
-        'aria-label': collapsed ? 'Expand sidebar' : 'Collapse sidebar',
+        'aria-label': collapsedValue ? 'Expand sidebar' : 'Collapse sidebar',
+        'aria-expanded': !collapsedValue,
         ...userToggle
     })
 
@@ -162,12 +178,16 @@
         return list.filter((entry) => entry.type !== 'label')
     }
 
-    function visibleItems(collapsedView: boolean) {
-        if (!collapsedView || !items) return items
+    const railItems = $derived.by(() => {
+        if (!items) return items
         if (Array.isArray(items[0])) {
             return (items as NavigationMenuItem[][]).map(stripLabels)
         }
         return stripLabels(items as NavigationMenuItem[])
+    })
+
+    function visibleItems(collapsedView: boolean) {
+        return collapsedView ? railItems : items
     }
 
     function setCollapsed(value: boolean) {
@@ -183,14 +203,43 @@
     function handleToggle(event: MouseEvent & { currentTarget: EventTarget & HTMLElement }) {
         userToggle.onclick?.(event)
         if (!event.defaultPrevented) {
-            setCollapsed(!collapsed)
+            setCollapsed(!collapsedValue)
         }
     }
+
+    const apiInstance: SidebarApi = {
+        get collapsed() {
+            return collapsed
+        },
+        get open() {
+            return open
+        },
+        get below() {
+            return media.matches
+        },
+        get state() {
+            return collapsed ? 'collapsed' : 'expanded'
+        },
+        toggle() {
+            if (media.matches) setOpen(!open)
+            else setCollapsed(!collapsed)
+        },
+        expand() {
+            if (media.matches) setOpen(true)
+            else setCollapsed(false)
+        },
+        collapse() {
+            if (media.matches) setOpen(false)
+            else setCollapsed(true)
+        }
+    }
+
+    api = apiInstance
 
     let hydrated = false
     $effect(() => {
         const key = storageKey
-        const value = collapsed
+        const value = collapsedValue
         if (typeof localStorage === 'undefined' || !key) return
         if (!hydrated) {
             hydrated = true
@@ -298,6 +347,8 @@
     data-side={side}
     data-collapsible={collapsible}
     data-collapsed={isCollapsed}
+    inert={offcanvasHidden || undefined}
+    aria-hidden={offcanvasHidden || undefined}
 >
     {@render inner(isRail, true)}
 
@@ -307,8 +358,9 @@
         {:else}
             <button
                 type="button"
-                aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-                onclick={() => setCollapsed(!collapsed)}
+                aria-label={collapsedValue ? 'Expand sidebar' : 'Collapse sidebar'}
+                aria-expanded={!collapsedValue}
+                onclick={() => setCollapsed(!collapsedValue)}
                 class={classes.rail}
             >
                 <span class={classes.railHandle}></span>
@@ -319,7 +371,7 @@
 
 {#if mode === 'slideover'}
     <Slideover
-        {open}
+        open={openValue}
         onOpenChange={setOpen}
         {side}
         title="Navigation"
@@ -335,7 +387,7 @@
     </Slideover>
 {:else}
     <Drawer
-        {open}
+        open={openValue}
         onOpenChange={setOpen}
         direction={side}
         title="Navigation"

--- a/src/lib/components/Sidebar/Sidebar.svelte.spec.ts
+++ b/src/lib/components/Sidebar/Sidebar.svelte.spec.ts
@@ -144,6 +144,34 @@ describe('Sidebar', () => {
             const root = container.firstElementChild as HTMLElement
             expect(root.style.width).toBe('0px')
         })
+
+        it('should make offcanvas-collapsed content inert and hidden from assistive tech', async () => {
+            const { container } = render(Sidebar, {
+                items,
+                collapsible: 'offcanvas',
+                collapsed: true
+            })
+            const root = container.firstElementChild as HTMLElement
+            expect(root.hasAttribute('inert')).toBe(true)
+            expect(root.getAttribute('aria-hidden')).toBe('true')
+
+            const link = container.querySelector('a') as HTMLAnchorElement
+            link.focus()
+            expect(document.activeElement).not.toBe(link)
+        })
+
+        it('should not be inert while expanded', async () => {
+            const { container } = render(Sidebar, { items, collapsible: 'offcanvas' })
+            const root = container.firstElementChild as HTMLElement
+            expect(root.hasAttribute('inert')).toBe(false)
+            expect(root.getAttribute('aria-hidden')).toBeNull()
+        })
+
+        it('should expose aria-expanded on the footer toggle', async () => {
+            const { container } = render(Sidebar, { items, toggle: true })
+            const toggle = container.querySelector('button[aria-label="Collapse sidebar"]')
+            expect(toggle!.getAttribute('aria-expanded')).toBe('true')
+        })
     })
 
     // ==================== VARIANT ====================
@@ -211,9 +239,11 @@ describe('Sidebar', () => {
             const root = container.firstElementChild as HTMLElement
             const rail = container.querySelector('button.cursor-col-resize') as HTMLButtonElement
             expect(rail).not.toBeNull()
+            expect(rail.getAttribute('aria-expanded')).toBe('true')
             rail.click()
             await tick()
             expect(root.dataset.collapsed).toBe('true')
+            expect(rail.getAttribute('aria-expanded')).toBe('false')
         })
     })
 })

--- a/src/lib/components/Sidebar/SidebarTrigger.svelte
+++ b/src/lib/components/Sidebar/SidebarTrigger.svelte
@@ -7,10 +7,14 @@
 <script lang="ts">
     import Button from '../Button/Button.svelte'
     import { getComponentConfig, iconsDefaults } from '../../config.js'
+    import { useMediaQuery } from '../../hooks/useMediaQuery/index.js'
 
     const icons = getComponentConfig('icons', iconsDefaults)
 
+    const BREAKPOINT_PX = { sm: 640, md: 768, lg: 1024, xl: 1280 }
+
     let {
+        api,
         collapsed = $bindable(undefined),
         open = $bindable(undefined),
         breakpoint = 'lg',
@@ -21,19 +25,23 @@
         ...restProps
     }: Props = $props()
 
-    const breakpointPx = { sm: 640, md: 768, lg: 1024, xl: 1280 } as const
+    const media = useMediaQuery(() => `(max-width: ${BREAKPOINT_PX[breakpoint] - 0.02}px)`)
 
-    let below = $state(false)
-    $effect(() => {
-        if (typeof window === 'undefined' || !window.matchMedia) return
-        const mq = window.matchMedia(`(max-width: ${breakpointPx[breakpoint] - 0.02}px)`)
-        const update = () => (below = mq.matches)
-        update()
-        mq.addEventListener('change', update)
-        return () => mq.removeEventListener('change', update)
+    const below = $derived(api ? api.below : media.matches)
+
+    const expanded = $derived.by(() => {
+        if (api) return below ? api.open : !api.collapsed
+        if (below && open !== undefined) return open
+        if (collapsed !== undefined) return !collapsed
+        if (open !== undefined) return open
+        return undefined
     })
 
     function toggle() {
+        if (api) {
+            api.toggle()
+            return
+        }
         if (below && open !== undefined) {
             open = !open
             return
@@ -60,6 +68,7 @@
     {variant}
     icon={icon ?? icons.panelLeft}
     aria-label="Toggle sidebar"
+    aria-expanded={expanded}
     {...restProps}
     onclick={handleClick}
 />

--- a/src/lib/components/Sidebar/SidebarTrigger.svelte.spec.ts
+++ b/src/lib/components/Sidebar/SidebarTrigger.svelte.spec.ts
@@ -22,4 +22,29 @@ describe('SidebarTrigger', () => {
         const { container } = render(SidebarTrigger, { color: 'primary', variant: 'solid' })
         expect(container.querySelector('button')).not.toBeNull()
     })
+
+    it('should expose aria-expanded from the collapsed prop', async () => {
+        const { container } = render(SidebarTrigger, { collapsed: false })
+        expect(container.querySelector('button')!.getAttribute('aria-expanded')).toBe('true')
+    })
+
+    it('should delegate to the sidebar api when given one', async () => {
+        let toggled = 0
+        const api = {
+            collapsed: false,
+            open: false,
+            below: false,
+            state: 'expanded' as const,
+            toggle: () => {
+                toggled += 1
+            },
+            expand: () => {},
+            collapse: () => {}
+        }
+        const { container } = render(SidebarTrigger, { api })
+        const button = container.querySelector('button') as HTMLButtonElement
+        expect(button.getAttribute('aria-expanded')).toBe('true')
+        button.click()
+        expect(toggled).toBe(1)
+    })
 })

--- a/src/lib/components/Sidebar/index.ts
+++ b/src/lib/components/Sidebar/index.ts
@@ -1,4 +1,4 @@
 export { default as Sidebar } from './Sidebar.svelte'
 export { default as SidebarTrigger } from './SidebarTrigger.svelte'
 export type { SidebarTriggerProps } from './sidebar-trigger.types.js'
-export type { SidebarProps, SidebarMode } from './sidebar.types.js'
+export type { SidebarProps, SidebarMode, SidebarApi } from './sidebar.types.js'

--- a/src/lib/components/Sidebar/sidebar-trigger.types.ts
+++ b/src/lib/components/Sidebar/sidebar-trigger.types.ts
@@ -1,22 +1,28 @@
 import type { ButtonProps } from '../Button/button.types.js'
-import type { SidebarBreakpoint } from './sidebar.types.js'
+import type { SidebarApi, SidebarBreakpoint } from './sidebar.types.js'
 
 export type SidebarTriggerProps = ButtonProps & {
     /**
-     * Bindable desktop collapsed state to toggle. Toggled when the viewport is at
-     * or above `breakpoint`.
+     * The Sidebar's `bind:api` handle. Preferred over the individual props
+     * below: it already knows the breakpoint, so nothing is repeated.
+     */
+    api?: SidebarApi
+
+    /**
+     * Bindable desktop collapsed state to toggle. Toggled when the viewport is
+     * at or above `breakpoint`. Ignored when `api` is provided.
      */
     collapsed?: boolean
 
     /**
-     * Bindable mobile overlay open state to toggle. Toggled when the viewport is
-     * below `breakpoint`.
+     * Bindable mobile overlay open state to toggle. Toggled when the viewport
+     * is below `breakpoint`. Ignored when `api` is provided.
      */
     open?: boolean
 
     /**
      * Breakpoint deciding whether the trigger toggles `open` (below) or
-     * `collapsed` (at or above). Should match the Sidebar's `breakpoint`.
+     * `collapsed` (at or above). Ignored when `api` is provided.
      * @default 'lg'
      */
     breakpoint?: SidebarBreakpoint

--- a/src/lib/components/Sidebar/sidebar.types.ts
+++ b/src/lib/components/Sidebar/sidebar.types.ts
@@ -15,6 +15,29 @@ export type SidebarCollapsible = 'icon' | 'offcanvas' | 'none'
 export type SidebarMode = 'slideover' | 'drawer'
 export type SidebarState = 'expanded' | 'collapsed'
 
+export interface SidebarApi {
+    /** Desktop collapsed state. */
+    readonly collapsed: boolean
+
+    /** Mobile menu open state. */
+    readonly open: boolean
+
+    /** Whether the viewport is below `breakpoint`, so the mobile menu is in play. */
+    readonly below: boolean
+
+    /** `'collapsed'` when the desktop sidebar is collapsed, otherwise `'expanded'`. */
+    readonly state: SidebarState
+
+    /** Toggles the mobile menu below `breakpoint`, the collapsed rail above it. */
+    toggle: () => void
+
+    /** Opens the mobile menu below `breakpoint`, expands the sidebar above it. */
+    expand: () => void
+
+    /** Closes the mobile menu below `breakpoint`, collapses the sidebar above it. */
+    collapse: () => void
+}
+
 export type SidebarPersist =
     | boolean
     | {
@@ -66,6 +89,13 @@ export type SidebarProps = Omit<HTMLAttributes<HTMLElement>, 'class'> & {
      * @default 'lg'
      */
     breakpoint?: SidebarBreakpoint
+
+    /**
+     * Bindable imperative controller, for external buttons such as a
+     * `SidebarTrigger` rendered in a Header. Carries the viewport awareness so
+     * the breakpoint only has to be declared here.
+     */
+    api?: SidebarApi
 
     /**
      * Bindable desktop collapsed state.

--- a/src/routes/sidebar/+page.svelte
+++ b/src/routes/sidebar/+page.svelte
@@ -10,7 +10,7 @@
         Avatar,
         Link
     } from '$lib/index.js'
-    import type { NavigationMenuItem, SidebarProps, SidebarMode } from '$lib/index.js'
+    import type { NavigationMenuItem, SidebarProps, SidebarMode, SidebarApi } from '$lib/index.js'
 
     const items: NavigationMenuItem[][] = [
         [
@@ -87,8 +87,7 @@
     let mode = $state<SidebarMode>('slideover')
     let mobileSide = $state<'left' | 'right'>('left')
 
-    let appCollapsed = $state(false)
-    let appOpen = $state(false)
+    let appApi = $state<SidebarApi>()
 
     const stats = [
         { label: 'Revenue', value: '$48.2k', delta: '+12.5%', icon: 'lucide:dollar-sign' },
@@ -168,11 +167,10 @@
         <div class="flex h-168 overflow-hidden rounded-xl bg-surface ring ring-outline-variant">
             <Sidebar
                 {items}
-                bind:collapsed={appCollapsed}
-                bind:open={appOpen}
+                bind:api={appApi}
+                breakpoint="md"
                 collapsible="icon"
                 rail
-                breakpoint="md"
                 mode="slideover"
                 header={brand}
                 footer={person}
@@ -187,11 +185,7 @@
                 >
                     {#snippet titleSlot()}
                         <div class="flex items-center gap-1">
-                            <SidebarTrigger
-                                bind:collapsed={appCollapsed}
-                                bind:open={appOpen}
-                                breakpoint="md"
-                            />
+                            <SidebarTrigger api={appApi} />
                             <span class="text-sm font-semibold text-on-surface">Dashboard</span>
                         </div>
                     {/snippet}
@@ -353,7 +347,7 @@
             {/if}
             <div class="flex min-w-0 flex-1 flex-col">
                 <div
-                    class="flex h-14 shrink-0 items-center gap-2 border-b border-outline-variant bg-surface px-3"
+                    class="flex h-(--ui-header-height) shrink-0 items-center gap-2 border-b border-outline-variant bg-surface px-3"
                 >
                     <SidebarTrigger bind:collapsed breakpoint="sm" />
                     <span class="text-sm font-semibold text-on-surface">Dashboard</span>


### PR DESCRIPTION
## Summary

Follow-up review of the Sidebar family after #176: one accessibility bug, two accessibility gaps, two small performance issues, and the wiring for a trigger rendered outside the sidebar.

Closes #179

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature / component
- [ ] 📖 Documentation
- [ ] ♻️ Refactor / chore
- [ ] ⚠️ Breaking change

## Changes

**Accessibility**

- `collapsible="offcanvas"` only set `width: 0`, so the sidebar's links stayed in the DOM, kept receiving focus and were still exposed to assistive tech. A probe confirmed focus landed on a hidden link. The root is now `inert` and `aria-hidden` while collapsed off screen.
- The edge rail, the footer toggle and `SidebarTrigger` expose `aria-expanded`.

**External trigger wiring**

- New bindable `api` handle on Sidebar: `collapsed`, `open`, `below`, `state`, `toggle()`, `expand()`, `collapse()`.
- `SidebarTrigger` accepts `api` and delegates to it. The trigger no longer repeats `breakpoint` or the bindable state, which previously could drift and silently toggle the wrong thing between the two breakpoints.
- The individual props (`collapsed`, `open`, `breakpoint`) still work when no `api` is passed.

**Performance**

- `SidebarTrigger` only creates its media query when it has no `api` to read from.
- The collapsed rail derives its filtered items instead of rebuilding the array on every render, so the `items` identity handed to NavigationMenu stays stable.

**Demo**

- The header trigger is wired through `bind:api`.
- The playground navbar is sized from `--ui-header-height` instead of a hardcoded height, so its divider lines up with the sidebar header.

## Checklist

- [x] Linked the related issue (`Closes #…`)
- [x] `pnpm check` passes (0 errors, 0 warnings)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added or updated tests for the change
- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] Followed component conventions (no comments outside `*.types.ts`, Material 3 design tokens)

## Screenshots / notes

**Why a bindable handle.** A trigger in a Header is a sibling of the sidebar, so it cannot read anything the sidebar sets on its own subtree. A wrapper component providing context would work but forces every consumer to nest their layout in an extra component; module-level shared state would leak across server requests and across multiple sidebars on one page. The bindable `api` handle is already the convention here, used by Carousel, Editor, Form, Lightbox, Tree, Stepper and Tour, and Tree documents it as being "for external buttons".

Merging `collapsed` and `open` into one value was considered and rejected: the desktop default is expanded while the mobile default is closed, so a single boolean cannot carry both without the mobile menu opening itself on load.

**Not a defect.** A suspected stray divider when a collapsed group holds only a label was probed and rendered identically to the control, so nothing was changed there.

New regression tests cover the inert behaviour (including that focus no longer lands on a hidden link), `aria-expanded` on the rail and footer toggle, and the trigger delegating to the `api` handle.
