### PR TITLE
fix(icon): bundle default icons so they render during SSR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
 
             - run: pnpm install --frozen-lockfile
 
+            - name: Verify generated icons are current
+              run: |
+                  pnpm generate:icons
+                  git diff --exit-code src/lib/components/Icon/bundled.ts
+
             - name: Lint
               run: pnpm lint
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **NavigationMenu** — navigation menu (bits-ui): horizontal mega-menu or vertical disclosures, nested `items` with icons/avatars/badges and active-route detection, `collapsed` icon rail with tooltips and flyouts, `highlight` bar, `pill`/`link` variants, `stacked` tab bar, and an optional mobile drawer. ([#175](https://github.com/ndlabdev/sv5ui/pull/175))
 - **Sidebar** — collapsible dashboard sidebar rendering its navigation through NavigationMenu: `variant` `sidebar`/`floating`/`inset`, `side` left/right, `collapsible` `icon`/`offcanvas`/`none` with bindable `collapsed`/`open`, composable header, edge `rail` toggle, localStorage `persist`, and a `slideover`/`drawer` mobile menu. Header height follows `--ui-header-height` so it aligns with a sibling Header. ([#176](https://github.com/ndlabdev/sv5ui/pull/176))
 - **SidebarTrigger** — viewport-aware toggle button for the app header: collapses the sidebar on desktop, opens the mobile menu below `breakpoint`. ([#176](https://github.com/ndlabdev/sv5ui/pull/176))
+- `npm run generate:icons` regenerates `src/lib/components/Icon/bundled.ts` from `iconsDefaults`. It runs automatically in `prepack`, so the bundled set can never drift from the defaults.
 
 ### Fixed
 
 - **Sidebar** — `collapsible="offcanvas"` now marks the collapsed sidebar `inert` and `aria-hidden`, so its links no longer take keyboard focus or reach assistive tech while off screen. ([#180](https://github.com/ndlabdev/sv5ui/pull/180))
 - **Sidebar** — the edge rail, footer toggle and `SidebarTrigger` expose `aria-expanded`. ([#180](https://github.com/ndlabdev/sv5ui/pull/180))
+- **Icon** — the 24 icons referenced by `iconsDefaults` are now bundled and registered with Iconify at module load, so built-in chrome (chevrons, close, loading spinner, check, sort arrows) renders inline during SSR instead of being fetched from the Iconify API after hydration. This removes the first-paint layout shift and the network round-trip, and makes the defaults work offline or behind a CSP that blocks `api.iconify.design`. Costs ~1.2KB gzip; icons outside `iconsDefaults` are unaffected and still load on demand.
 
 ### Changed
 
 - **Sidebar** — added a bindable `api` handle (`collapsed`, `open`, `below`, `state`, `toggle`, `expand`, `collapse`) that `SidebarTrigger` accepts, so a trigger rendered outside the sidebar no longer repeats `breakpoint` or the bindable state. ([#180](https://github.com/ndlabdev/sv5ui/pull/180))
+- **Icon** — the default loading icon is now `lucide:loader-circle` instead of `lucide:loader-2`. `loader-2` is a deprecated alias in `@iconify-json/lucide` that resolves to the same artwork, so the rendered spinner is pixel-identical. Only the name in `iconsDefaults` changed.
 
 ## [2.4.0] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,18 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **NavigationMenu** — navigation menu (bits-ui): horizontal mega-menu or vertical disclosures, nested `items` with icons/avatars/badges and active-route detection, `collapsed` icon rail with tooltips and flyouts, `highlight` bar, `pill`/`link` variants, `stacked` tab bar, and an optional mobile drawer. ([#175](https://github.com/ndlabdev/sv5ui/pull/175))
 - **Sidebar** — collapsible dashboard sidebar rendering its navigation through NavigationMenu: `variant` `sidebar`/`floating`/`inset`, `side` left/right, `collapsible` `icon`/`offcanvas`/`none` with bindable `collapsed`/`open`, composable header, edge `rail` toggle, localStorage `persist`, and a `slideover`/`drawer` mobile menu. Header height follows `--ui-header-height` so it aligns with a sibling Header. ([#176](https://github.com/ndlabdev/sv5ui/pull/176))
 - **SidebarTrigger** — viewport-aware toggle button for the app header: collapses the sidebar on desktop, opens the mobile menu below `breakpoint`. ([#176](https://github.com/ndlabdev/sv5ui/pull/176))
-- `npm run generate:icons` regenerates `src/lib/components/Icon/bundled.ts` from `iconsDefaults`. It runs automatically in `prepack`, so the bundled set can never drift from the defaults.
+- `npm run generate:icons` regenerates `src/lib/components/Icon/bundled.ts` from `iconsDefaults`. It runs automatically in `prepack`, so the bundled set can never drift from the defaults. ([#181](https://github.com/ndlabdev/sv5ui/pull/181))
 
 ### Fixed
 
 - **Sidebar** — `collapsible="offcanvas"` now marks the collapsed sidebar `inert` and `aria-hidden`, so its links no longer take keyboard focus or reach assistive tech while off screen. ([#180](https://github.com/ndlabdev/sv5ui/pull/180))
 - **Sidebar** — the edge rail, footer toggle and `SidebarTrigger` expose `aria-expanded`. ([#180](https://github.com/ndlabdev/sv5ui/pull/180))
-- **Icon** — the 24 icons referenced by `iconsDefaults` are now bundled and registered with Iconify at module load, so built-in chrome (chevrons, close, loading spinner, check, sort arrows) renders inline during SSR instead of being fetched from the Iconify API after hydration. This removes the first-paint layout shift and the network round-trip, and makes the defaults work offline or behind a CSP that blocks `api.iconify.design`. Costs ~1.2KB gzip; icons outside `iconsDefaults` are unaffected and still load on demand.
+- **Icon** — the 24 icons referenced by `iconsDefaults` are now bundled and registered with Iconify at module load, so built-in chrome (chevrons, close, loading spinner, check, sort arrows) renders inline during SSR instead of being fetched from the Iconify API after hydration. This removes the first-paint layout shift and the network round-trip, and makes the defaults work offline or behind a CSP that blocks `api.iconify.design`. Costs ~1.2KB gzip; icons outside `iconsDefaults` are unaffected and still load on demand. ([#181](https://github.com/ndlabdev/sv5ui/pull/181))
 
 ### Changed
 
 - **Sidebar** — added a bindable `api` handle (`collapsed`, `open`, `below`, `state`, `toggle`, `expand`, `collapse`) that `SidebarTrigger` accepts, so a trigger rendered outside the sidebar no longer repeats `breakpoint` or the bindable state. ([#180](https://github.com/ndlabdev/sv5ui/pull/180))
-- **Icon** — the default loading icon is now `lucide:loader-circle` instead of `lucide:loader-2`. `loader-2` is a deprecated alias in `@iconify-json/lucide` that resolves to the same artwork, so the rendered spinner is pixel-identical. Only the name in `iconsDefaults` changed.
+- **Icon** — the default loading icon is now `lucide:loader-circle` instead of `lucide:loader-2`. `loader-2` is a deprecated alias in `@iconify-json/lucide` that resolves to the same artwork, so the rendered spinner is pixel-identical. Only the name in `iconsDefaults` changed. ([#181](https://github.com/ndlabdev/sv5ui/pull/181))
 
 ## [2.4.0] - 2026-07-19
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,6 +37,13 @@ export default defineConfig(
         }
     },
     {
+        files: ['scripts/**/*.js'],
+
+        rules: {
+            'no-console': 'off'
+        }
+    },
+    {
         files: ['**/*.svelte', '**/*.svelte.ts', '**/*.svelte.js'],
 
         languageOptions: {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
         "build": "vite build && npm run prepack",
         "preview": "vite preview",
         "prepare": "svelte-kit sync || echo ''",
-        "prepack": "svelte-kit sync && svelte-package && publint",
+        "generate:icons": "node scripts/generate-icons.js && prettier --write --log-level warn src/lib/components/Icon/bundled.ts",
+        "prepack": "npm run generate:icons && svelte-kit sync && svelte-package && publint",
         "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
         "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
         "lint": "prettier --check . && eslint .",
@@ -150,6 +151,8 @@
     "devDependencies": {
         "@eslint/compat": "^1.4.0",
         "@eslint/js": "^9.39.1",
+        "@iconify-json/lucide": "^1.2.117",
+        "@iconify/utils": "^3.1.4",
         "@sveltejs/adapter-auto": "^7.0.0",
         "@sveltejs/kit": "^2.49.1",
         "@sveltejs/package": "^2.5.7",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "preview": "vite preview",
         "prepare": "svelte-kit sync || echo ''",
         "generate:icons": "node --experimental-strip-types --no-warnings scripts/generate-icons.js && prettier --write --log-level warn src/lib/components/Icon/bundled.ts",
-        "prepack": "npm run generate:icons && svelte-kit sync && svelte-package && publint",
+        "prepack": "svelte-kit sync && svelte-package && publint",
         "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
         "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
         "lint": "prettier --check . && eslint .",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "build": "vite build && npm run prepack",
         "preview": "vite preview",
         "prepare": "svelte-kit sync || echo ''",
-        "generate:icons": "node scripts/generate-icons.js && prettier --write --log-level warn src/lib/components/Icon/bundled.ts",
+        "generate:icons": "node --experimental-strip-types --no-warnings scripts/generate-icons.js && prettier --write --log-level warn src/lib/components/Icon/bundled.ts",
         "prepack": "npm run generate:icons && svelte-kit sync && svelte-package && publint",
         "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
         "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,12 @@ importers:
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.2
+      '@iconify-json/lucide':
+        specifier: ^1.2.117
+        version: 1.2.121
+      '@iconify/utils':
+        specifier: ^3.1.4
+        version: 3.1.4
       '@sveltejs/adapter-auto':
         specifier: ^7.0.0
         version: 7.0.0(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.48.2)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)))(svelte@5.48.2)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)))
@@ -203,6 +209,9 @@ importers:
         version: 4.3.6
 
 packages:
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -452,6 +461,9 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@iconify-json/lucide@1.2.121':
+    resolution: {integrity: sha512-zSoQQSmsyFaeTpSwURHJ9PIrsDcGFpDNhGlpiTrs+Ua4uFeH5UsE26L4OEBLrgLWoSK0UO+JhsO8yehSw0403g==}
+
   '@iconify/svelte@5.2.1':
     resolution: {integrity: sha512-zHmsIPmnIhGd5gc95bNN5FL+GifwMZv7M2rlZEpa7IXYGFJm/XGHdWf6PWQa6OBoC+R69WyiPO9NAj5wjfjbow==}
     peerDependencies:
@@ -459,6 +471,9 @@ packages:
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.4':
+    resolution: {integrity: sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==}
 
   '@internationalized/date@3.11.0':
     resolution: {integrity: sha512-BOx5huLAWhicM9/ZFs84CzP+V3gBW6vlpM02yzsdYC7TGlZJX1OJiEEHcSayF00Z+3jLlm4w79amvSt6RqKN3Q==}
@@ -1446,6 +1461,9 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -2259,6 +2277,11 @@ packages:
 
 snapshots:
 
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.0.2
+
   '@esbuild/aix-ppc64@0.27.2':
     optional: true
 
@@ -2427,12 +2450,22 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@iconify-json/lucide@1.2.121':
+    dependencies:
+      '@iconify/types': 2.0.0
+
   '@iconify/svelte@5.2.1(svelte@5.48.2)':
     dependencies:
       '@iconify/types': 2.0.0
       svelte: 5.48.2
 
   '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.4':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
 
   '@internationalized/date@3.11.0':
     dependencies:
@@ -3418,6 +3451,8 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+
+  import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
 

--- a/scripts/generate-icons.js
+++ b/scripts/generate-icons.js
@@ -1,0 +1,105 @@
+import { writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { getIconData } from '@iconify/utils'
+import lucide from '@iconify-json/lucide/icons.json' with { type: 'json' }
+import { iconsDefaults } from '../src/lib/config.ts'
+
+const sources = { lucide }
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const output = resolve(root, 'src/lib/components/Icon/bundled.ts')
+
+const transformDefaults = { left: 0, top: 0, rotate: 0, hFlip: false, vFlip: false }
+
+const namesByPrefix = new Map()
+
+for (const [key, value] of Object.entries(iconsDefaults)) {
+    const [prefix, name, ...rest] = value.split(':')
+
+    if (!prefix || !name || rest.length > 0) {
+        throw new Error(`iconsDefaults.${key} is not a valid icon name: "${value}"`)
+    }
+
+    if (!namesByPrefix.has(prefix)) namesByPrefix.set(prefix, new Set())
+    namesByPrefix.get(prefix).add(name)
+}
+
+const collections = []
+
+for (const prefix of [...namesByPrefix.keys()].sort()) {
+    const source = sources[prefix]
+
+    if (!source) {
+        throw new Error(
+            `iconsDefaults uses the "${prefix}" collection, which this script does not load. ` +
+                `Install "@iconify-json/${prefix}" and add it to the "sources" map above.`
+        )
+    }
+
+    const width = source.width ?? 16
+    const height = source.height ?? 16
+    const icons = {}
+
+    for (const name of [...namesByPrefix.get(prefix)].sort()) {
+        const data = getIconData(source, name)
+
+        if (!data)
+            throw new Error(`Icon "${prefix}:${name}" does not exist in @iconify-json/${prefix}`)
+
+        const icon = { body: data.body }
+
+        if (data.width !== width) icon.width = data.width
+        if (data.height !== height) icon.height = data.height
+
+        for (const [prop, fallback] of Object.entries(transformDefaults)) {
+            if (data[prop] !== undefined && data[prop] !== fallback) icon[prop] = data[prop]
+        }
+
+        icons[name] = icon
+    }
+
+    collections.push({ prefix, width, height, icons })
+}
+
+const body = collections
+    .map((collection) => {
+        const icons = Object.entries(collection.icons)
+            .map(([name, icon]) => {
+                const props = Object.entries(icon)
+                    .map(([prop, value]) => `${prop}: ${JSON.stringify(value)}`)
+                    .join(', ')
+
+                return `            ${JSON.stringify(name)}: { ${props} }`
+            })
+            .join(',\n')
+
+        return [
+            '    {',
+            `        prefix: ${JSON.stringify(collection.prefix)},`,
+            `        width: ${collection.width},`,
+            `        height: ${collection.height},`,
+            '        icons: {',
+            icons,
+            '        }',
+            '    }'
+        ].join('\n')
+    })
+    .join(',\n')
+
+const contents = `import type { BundledIconCollection } from './icon.types.js'
+
+export const bundledIcons: BundledIconCollection[] = [
+${body}
+]
+`
+
+writeFileSync(output, contents)
+
+const total = collections.reduce((sum, { icons }) => sum + Object.keys(icons).length, 0)
+
+console.log(
+    `Generated ${output.replace(`${root}/`, '')} — ` +
+        `${total} icons across ${collections.length} collection(s), ` +
+        `${(Buffer.byteLength(contents) / 1024).toFixed(1)}KB`
+)

--- a/src/lib/components/Icon/Icon.svelte
+++ b/src/lib/components/Icon/Icon.svelte
@@ -1,5 +1,9 @@
 <script lang="ts" module>
     import type { IconProps } from './icon.types.js'
+    import { addCollection } from '@iconify/svelte'
+    import { bundledIcons } from './bundled.js'
+
+    for (const collection of bundledIcons) addCollection(collection)
 
     export type Props = IconProps
 </script>

--- a/src/lib/components/Icon/Icon.svelte.spec.ts
+++ b/src/lib/components/Icon/Icon.svelte.spec.ts
@@ -2,6 +2,7 @@ import { page } from 'vitest/browser'
 import { describe, expect, it } from 'vitest'
 import { render } from 'vitest-browser-svelte'
 import Icon from './Icon.svelte'
+import { iconsDefaults } from '../../config.js'
 
 /** Helper: wait for SVG to render (iconify loads async) then return a locator */
 async function getSvg(container: HTMLElement) {
@@ -163,6 +164,19 @@ describe('Icon', () => {
             const svgHtml = container.querySelector('svg')!.innerHTML
             expect(svgHtml).toMatch(/rotate\(-90\b/)
         })
+    })
+
+    describe('bundled defaults', () => {
+        it.each(Object.entries(iconsDefaults))(
+            'renders %s synchronously without polling',
+            (_key, name) => {
+                const { container } = render(Icon, { name })
+                const svg = container.querySelector('svg')
+
+                expect(svg).toBeTruthy()
+                expect(svg!.innerHTML).not.toBe('')
+            }
+        )
     })
 
     // ==================== DIFFERENT ICONS ====================

--- a/src/lib/components/Icon/bundled.ts
+++ b/src/lib/components/Icon/bundled.ts
@@ -1,0 +1,83 @@
+import type { BundledIconCollection } from './icon.types.js'
+
+export const bundledIcons: BundledIconCollection[] = [
+    {
+        prefix: 'lucide',
+        width: 24,
+        height: 24,
+        icons: {
+            'arrow-up-right': {
+                body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h10v10M7 17L17 7"/>'
+            },
+            check: {
+                body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 6L9 17l-5-5"/>'
+            },
+            'chevron-down': {
+                body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"/>'
+            },
+            'chevron-left': {
+                body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m15 18l-6-6l6-6"/>'
+            },
+            'chevron-right': {
+                body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m9 18l6-6l-6-6"/>'
+            },
+            'chevron-up': {
+                body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m18 15l-6-6l-6 6"/>'
+            },
+            'chevrons-left': {
+                body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m11 17l-5-5l5-5m7 10l-5-5l5-5"/>'
+            },
+            'chevrons-right': {
+                body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 17l5-5l-5-5m7 10l5-5l-5-5"/>'
+            },
+            'chevrons-up-down': {
+                body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m7 15l5 5l5-5M7 9l5-5l5 5"/>'
+            },
+            ellipsis: {
+                body: '<g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></g>'
+            },
+            file: {
+                body: '<g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/></g>'
+            },
+            folder: {
+                body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/>'
+            },
+            'folder-open': {
+                body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 14l1.5-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.54 6a2 2 0 0 1-1.95 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H18a2 2 0 0 1 2 2v2"/>'
+            },
+            'loader-circle': {
+                body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 1 1-6.219-8.56"/>'
+            },
+            menu: {
+                body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5h16M4 12h16M4 19h16"/>'
+            },
+            moon: {
+                body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.985 12.486a9 9 0 1 1-9.473-9.472c.405-.022.617.46.402.803a6 6 0 0 0 8.268 8.268c.344-.215.825-.004.803.401"/>'
+            },
+            'panel-left': {
+                body: '<g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/></g>'
+            },
+            search: {
+                body: '<g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="m21 21l-4.34-4.34"/><circle cx="11" cy="11" r="8"/></g>'
+            },
+            star: {
+                body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.12 2.12 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.12 2.12 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.12 2.12 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.12 2.12 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.12 2.12 0 0 0 1.597-1.16z"/>'
+            },
+            sun: {
+                body: '<g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.93 4.93l1.41 1.41m11.32 11.32l1.41 1.41M2 12h2m16 0h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></g>'
+            },
+            'trash-2': {
+                body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 11v6m4-6v6m5-11v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>'
+            },
+            upload: {
+                body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v12m5-7l-5-5l-5 5m14 7v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>'
+            },
+            x: {
+                body: '<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 6L6 18M6 6l12 12"/>'
+            },
+            'zoom-in': {
+                body: '<g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21l-4.35-4.35M11 8v6m-3-3h6"/></g>'
+            }
+        }
+    }
+]

--- a/src/lib/components/Icon/icon-ssr.spec.ts
+++ b/src/lib/components/Icon/icon-ssr.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { render } from 'svelte/server'
+import Icon from './Icon.svelte'
+import { bundledIcons } from './bundled.js'
+import { iconsDefaults } from '../../config.js'
+
+const bundledNames = bundledIcons.flatMap((collection) =>
+    Object.keys(collection.icons).map((name) => `${collection.prefix}:${name}`)
+)
+
+describe('Icon SSR', () => {
+    describe('bundled defaults', () => {
+        it('covers every icon in iconsDefaults', () => {
+            const missing = [...new Set(Object.values(iconsDefaults))].filter(
+                (name) => !bundledNames.includes(name)
+            )
+
+            expect(missing).toEqual([])
+        })
+
+        it.each(bundledNames)('renders %s inline during SSR', (name) => {
+            const { body } = render(Icon, { props: { name } })
+
+            expect(body).toContain('<svg')
+            expect(body).toMatch(/<(path|circle|rect|g|line|polyline|polygon|ellipse)\b/)
+        })
+
+        it('resolves without any network request', () => {
+            const fetchSpy = () => {
+                throw new Error('Icon triggered a network request during SSR')
+            }
+            const original = globalThis.fetch
+
+            globalThis.fetch = fetchSpy as unknown as typeof fetch
+
+            try {
+                const { body } = render(Icon, { props: { name: iconsDefaults.loading } })
+
+                expect(body).toContain('<svg')
+            } finally {
+                globalThis.fetch = original
+            }
+        })
+    })
+
+    describe('non-bundled icons', () => {
+        it('renders nothing during SSR and defers to the Iconify API on the client', () => {
+            const { body } = render(Icon, { props: { name: 'lucide:this-icon-does-not-exist' } })
+
+            expect(body).not.toContain('<svg')
+        })
+    })
+})

--- a/src/lib/components/Icon/icon.types.ts
+++ b/src/lib/components/Icon/icon.types.ts
@@ -2,6 +2,36 @@ import type { IconProps as IconifyProps } from '@iconify/svelte'
 import type { SVGAttributes } from 'svelte/elements'
 import type { ClassNameValue } from 'tailwind-merge'
 
+/**
+ * A single icon inside a bundled collection.
+ * Mirrors Iconify's `IconifyIcon`, narrowed to the fields the generator emits.
+ * `width`/`height` are omitted when they match the collection defaults.
+ */
+export interface BundledIcon {
+    body: string
+    width?: number
+    height?: number
+    left?: number
+    top?: number
+    rotate?: number
+    hFlip?: boolean
+    vFlip?: boolean
+}
+
+/**
+ * An icon collection pre-registered with Iconify at module load, so the icons in
+ * `iconsDefaults` render synchronously during SSR instead of being fetched from
+ * the Iconify API after hydration.
+ *
+ * Generated into `bundled.ts` by `npm run generate:icons`.
+ */
+export interface BundledIconCollection {
+    prefix: string
+    width: number
+    height: number
+    icons: Record<string, BundledIcon>
+}
+
 export interface IconProps
     extends
         Omit<IconifyProps, 'icon' | 'width' | 'height' | 'rotate' | 'flip' | 'class'>,

--- a/src/lib/components/PinInput/PinInput.svelte.spec.ts
+++ b/src/lib/components/PinInput/PinInput.svelte.spec.ts
@@ -396,7 +396,7 @@ describe('PinInput', () => {
         })
 
         it('should accept custom loadingIcon', async () => {
-            render(PinInput, { loading: true, loadingIcon: 'lucide:loader-2' })
+            render(PinInput, { loading: true, loadingIcon: 'lucide:refresh-cw' })
             await vi.waitFor(() => {
                 const overlay = document.querySelector(
                     'span[aria-hidden="true"].pointer-events-none'

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -25,7 +25,7 @@
  * Default icons used across components
  */
 export const iconsDefaults = {
-    loading: 'lucide:loader-2',
+    loading: 'lucide:loader-circle',
     chevronDown: 'lucide:chevron-down',
     chevronLeft: 'lucide:chevron-left',
     chevronRight: 'lucide:chevron-right',

--- a/src/routes/button/+page.svelte
+++ b/src/routes/button/+page.svelte
@@ -241,7 +241,7 @@
         <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface-container-high p-4">
             <Button loading label="Loading..." />
             <Button variant="outline" color="secondary" loading label="Processing" />
-            <Button variant="soft" color="success" loading icon="lucide:loader-2" square />
+            <Button variant="soft" color="success" loading icon="lucide:loader-circle" square />
             <Button variant="solid" color="info" loading trailing label="Uploading" />
         </div>
     </section>

--- a/src/routes/icon/+page.svelte
+++ b/src/routes/icon/+page.svelte
@@ -275,7 +275,7 @@
             <p class="text-xs font-medium text-on-surface-variant uppercase">Loading states</p>
             <div class="flex items-center gap-6">
                 <div class="flex flex-col items-center gap-2">
-                    <Icon name="lucide:loader-2" class="animate-spin text-primary" />
+                    <Icon name="lucide:loader-circle" class="animate-spin text-primary" />
                     <span class="text-xs text-on-surface-variant">Spinner</span>
                 </div>
                 <div class="flex flex-col items-center gap-2">

--- a/src/routes/table/+page.svelte
+++ b/src/routes/table/+page.svelte
@@ -851,7 +851,7 @@
         >
             {#snippet loadingSlot()}
                 <div class="flex items-center justify-center gap-2">
-                    <Icon name="lucide:loader-2" class="size-5 animate-spin text-primary" />
+                    <Icon name="lucide:loader-circle" class="size-5 animate-spin text-primary" />
                     <span class="text-sm text-on-surface-variant">Loading data...</span>
                 </div>
             {/snippet}


### PR DESCRIPTION
## Problem

`@iconify/svelte` renders nothing until icon data arrives, and it fetches that data from `api.iconify.design` after hydration. Its component ends with `{#if data}`, so during SSR every icon collapses to an empty node with no placeholder holding space.

That covers the 24 icons in `iconsDefaults`, which are the chrome of nearly every component: Select and Accordion chevrons, the Dialog close button, the loading spinner, Table sort arrows. On first paint they are missing, then pop in and shift the surrounding layout. The browser test suite shows the cost directly: a non bundled icon takes roughly 1s to appear.

It also leaves every consumer app depending on a third party CDN at runtime, which breaks offline installs and any CSP that blocks `api.iconify.design`.

## Approach

Iconify already ships an offline path: `addCollection()` fills a registry that `checkIconState` reads synchronously. No Vite plugin or source scanner is required.

- `scripts/generate-icons.js` reads `iconsDefaults`, resolves each name against `@iconify-json/lucide` with `getIconData` (which follows aliases), groups by prefix, and writes `src/lib/components/Icon/bundled.ts`.
- `Icon.svelte` registers those collections in module scope, so the registry is populated before any render.
- `generate:icons` is wired into `prepack`, so the bundled set cannot drift from the defaults.

Icons outside `iconsDefaults` are untouched and still resolve through the Iconify API exactly as before.

## Also in here

Renames the `loading` default from `lucide:loader-2` to `lucide:loader-circle`. `loader-2` is a deprecated alias in `@iconify-json/lucide`; both resolve to byte identical data, so the spinner does not change visually. An audit of all 24 defaults found this was the only stale alias.

`PinInput.svelte.spec.ts` passed `lucide:loader-2` to exercise a custom `loadingIcon`, which was the same value as the default at the time, so the test could not fail. It now uses a genuinely different icon.

## Cost

`dist/components/Icon/bundled.js`: 6231 B raw, 1241 B gzip, 1122 B brotli.

## Verification

- `npm run check`: 0 errors, 0 warnings
- `npm run lint`: clean
- `npm test`: 3334 passed across 95 files
- `npm run build`: exit 0, publint reports "All good!"
- New `icon-ssr.spec.ts` renders all 24 defaults through `svelte/server` and asserts inline `<svg>` output, including a case that fails if `fetch` is called during SSR
- New browser tests assert every default renders synchronously, with no polling

## Not included

No version bump. That is handled separately.
