### PR TITLE
chore(release): 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.1] - 2026-08-26
+
+### Fixed
+
+- **DropdownMenu**, **Popover** — the arrow now carries its own outline, so the ring flows around it instead of stopping at a borderless triangle with the ring line cutting across its base. New `arrowBorder` `ui` slot on both for overriding the stroke. Tooltip is unaffected: its surface has no ring.
+
+### Changed
+
+- **DropdownMenu docs** — added an Arrow section covering the four sides and custom `width`/`height`, aligned to `center` so the arrow sits under the middle of the menu.
+
 ## [2.6.0] - 2026-08-25
 
 ### Added
@@ -415,7 +425,8 @@ New SSR-safe Svelte 5 hooks:
 - Tailwind CSS 4 + Tailwind Variants integration
 - bits-ui and Vaul Svelte headless primitives
 
-[Unreleased]: https://github.com/ndlabdev/sv5ui/compare/v2.6.0...HEAD
+[Unreleased]: https://github.com/ndlabdev/sv5ui/compare/v2.6.1...HEAD
+[2.6.1]: https://github.com/ndlabdev/sv5ui/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/ndlabdev/sv5ui/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/ndlabdev/sv5ui/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/ndlabdev/sv5ui/compare/v2.3.0...v2.4.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sv5ui",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "description": "A modern Svelte 5 UI component library with Tailwind CSS",
     "author": "ndlabdev",
     "license": "MIT",

--- a/src/lib/components/DropdownMenu/DropdownMenu.svelte
+++ b/src/lib/components/DropdownMenu/DropdownMenu.svelte
@@ -88,12 +88,23 @@
         subTriggerIcon: variantSlots.subTriggerIcon({
             class: [config.slots.subTriggerIcon, ui?.subTriggerIcon]
         }),
-        subContent: variantSlots.subContent({ class: [config.slots.subContent, ui?.subContent] })
+        subContent: variantSlots.subContent({ class: [config.slots.subContent, ui?.subContent] }),
+        arrowBorder: variantSlots.arrowBorder({
+            class: [config.slots.arrowBorder, ui?.arrowBorder]
+        })
     })
 
     const arrowProps = $derived.by(() => {
         if (typeof arrow === 'object') return { width: 12, height: 6, ...arrow }
         return { width: 12, height: 6 }
+    })
+
+    const arrowPaths = $derived.by(() => {
+        const { width: w, height: h } = arrowProps
+        return {
+            fill: `M0 -1H${w}V1H0Z M0 0H${w}L${w / 2} ${h}Z`,
+            border: `M0 0L${w / 2} ${h}L${w} 0`
+        }
     })
 
     function close() {
@@ -343,7 +354,26 @@
                 width={arrowProps.width}
                 height={arrowProps.height}
                 class={classes.arrow}
-            />
+            >
+                <svg
+                    width={arrowProps.width}
+                    height={arrowProps.height}
+                    viewBox="0 0 {arrowProps.width} {arrowProps.height}"
+                    class="block overflow-visible"
+                    aria-hidden="true"
+                    data-arrow=""
+                >
+                    <path d={arrowPaths.fill} fill="currentColor" stroke="none" />
+                    <path
+                        d={arrowPaths.border}
+                        fill="none"
+                        stroke-width="1"
+                        stroke-linejoin="round"
+                        vector-effect="non-scaling-stroke"
+                        class={classes.arrowBorder}
+                    />
+                </svg>
+            </DropdownMenu.Arrow>
         {/if}
     </DropdownMenu.Content>
 {/snippet}

--- a/src/lib/components/DropdownMenu/DropdownMenu.svelte.spec.ts
+++ b/src/lib/components/DropdownMenu/DropdownMenu.svelte.spec.ts
@@ -237,6 +237,31 @@ describe('DropdownMenu', () => {
                 expect(svg!.getAttribute('height')).toBe('8')
             })
         })
+
+        it('should outline the arrow edges with the content ring color', async () => {
+            render(DropdownMenu, { open: true, items: basicItems, arrow: true })
+            await vi.waitFor(() => {
+                const border = getArrow()!.querySelectorAll('path')[1]
+                expect(border).not.toBeUndefined()
+                expect(border.getAttribute('d')).toBe('M0 0L6 6L12 0')
+                expect(border.getAttribute('class')).toContain('stroke-outline-variant/50')
+                expect(getContent()!.className).toContain('ring-outline-variant/50')
+            })
+        })
+
+        it('should mask the content ring across the arrow base', async () => {
+            render(DropdownMenu, {
+                open: true,
+                items: basicItems,
+                arrow: { width: 20, height: 10 }
+            })
+            await vi.waitFor(() => {
+                const fill = getArrow()!.querySelector('path')
+                expect(fill).not.toBeNull()
+                expect(fill!.getAttribute('d')).toBe('M0 -1H20V1H0Z M0 0H20L10 10Z')
+                expect(fill!.getAttribute('fill')).toBe('currentColor')
+            })
+        })
     })
 
     // ==================== ITEM TYPES ====================

--- a/src/lib/components/DropdownMenu/dropdown-menu.variants.ts
+++ b/src/lib/components/DropdownMenu/dropdown-menu.variants.ts
@@ -53,6 +53,7 @@ export const dropdownMenuVariants = tv({
             'overflow-hidden'
         ],
         arrow: 'fill-surface-container-low text-surface-container-low',
+        arrowBorder: 'stroke-outline-variant/50',
         group: 'p-1',
         separator: '-mx-1 my-1 h-px bg-outline-variant',
         label: 'px-2 py-1.5 text-xs font-semibold text-on-surface-variant',

--- a/src/lib/components/Popover/Popover.svelte
+++ b/src/lib/components/Popover/Popover.svelte
@@ -46,7 +46,10 @@
     const variantSlots = $derived(popoverVariants({ transition }))
     const classes = $derived({
         content: variantSlots.content({ class: [config.slots.content, ui?.content] }),
-        arrow: variantSlots.arrow({ class: [config.slots.arrow, ui?.arrow] })
+        arrow: variantSlots.arrow({ class: [config.slots.arrow, ui?.arrow] }),
+        arrowBorder: variantSlots.arrowBorder({
+            class: [config.slots.arrowBorder, ui?.arrowBorder]
+        })
     })
 
     const arrowProps = $derived.by(() => {
@@ -54,6 +57,14 @@
             return { width: 12, height: 6, ...arrow }
         }
         return { width: 12, height: 6 }
+    })
+
+    const arrowPaths = $derived.by(() => {
+        const { width: w, height: h } = arrowProps
+        return {
+            fill: `M0 -1H${w}V1H0Z M0 0H${w}L${w / 2} ${h}Z`,
+            border: `M0 0L${w / 2} ${h}L${w} 0`
+        }
     })
 
     const dismissBehavior = $derived(dismissible ? ('close' as const) : ('ignore' as const))
@@ -96,7 +107,26 @@
                 width={arrowProps.width}
                 height={arrowProps.height}
                 class={classes.arrow}
-            />
+            >
+                <svg
+                    width={arrowProps.width}
+                    height={arrowProps.height}
+                    viewBox="0 0 {arrowProps.width} {arrowProps.height}"
+                    class="block overflow-visible"
+                    aria-hidden="true"
+                    data-arrow=""
+                >
+                    <path d={arrowPaths.fill} fill="currentColor" stroke="none" />
+                    <path
+                        d={arrowPaths.border}
+                        fill="none"
+                        stroke-width="1"
+                        stroke-linejoin="round"
+                        vector-effect="non-scaling-stroke"
+                        class={classes.arrowBorder}
+                    />
+                </svg>
+            </Popover.Arrow>
         {/if}
     </Popover.Content>
 {/snippet}

--- a/src/lib/components/Popover/Popover.svelte.spec.ts
+++ b/src/lib/components/Popover/Popover.svelte.spec.ts
@@ -127,6 +127,27 @@ describe('Popover', () => {
                 expect(svg!.getAttribute('height')).toBe('8')
             })
         })
+
+        it('should outline the arrow edges with the content ring color', async () => {
+            render(Popover, { open: true, arrow: true })
+            await vi.waitFor(() => {
+                const border = getArrow()!.querySelectorAll('path')[1]
+                expect(border).not.toBeUndefined()
+                expect(border.getAttribute('d')).toBe('M0 0L6 6L12 0')
+                expect(border.getAttribute('class')).toContain('stroke-surface-container-highest')
+                expect(getContent()!.className).toContain('ring-surface-container-highest')
+            })
+        })
+
+        it('should mask the content ring across the arrow base', async () => {
+            render(Popover, { open: true, arrow: { width: 20, height: 10 } })
+            await vi.waitFor(() => {
+                const fill = getArrow()!.querySelector('path')
+                expect(fill).not.toBeNull()
+                expect(fill!.getAttribute('d')).toBe('M0 -1H20V1H0Z M0 0H20L10 10Z')
+                expect(fill!.getAttribute('fill')).toBe('currentColor')
+            })
+        })
     })
 
     // ==================== DISMISSIBLE ====================

--- a/src/lib/components/Popover/popover.variants.ts
+++ b/src/lib/components/Popover/popover.variants.ts
@@ -8,7 +8,8 @@ export const popoverVariants = tv({
             'rounded-md shadow-lg',
             'focus:outline-none pointer-events-auto'
         ],
-        arrow: 'fill-surface-container-lowest text-surface-container-lowest'
+        arrow: 'fill-surface-container-lowest text-surface-container-lowest',
+        arrowBorder: 'stroke-surface-container-highest'
     },
     variants: {
         transition: {

--- a/src/routes/dropdown-menu/+page.svelte
+++ b/src/routes/dropdown-menu/+page.svelte
@@ -210,6 +210,46 @@
         </div>
     </section>
 
+    <!-- Arrow -->
+    <section class="space-y-3">
+        <h2 class="text-lg font-semibold">Arrow</h2>
+        <p class="text-sm text-on-surface-variant">
+            Add a pointer to the trigger with the
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">arrow</code>
+            prop. Pass an object to customize its
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">width</code>
+            and
+            <code class="rounded bg-surface-container-highest px-1.5 py-0.5 text-xs">height</code>.
+        </p>
+        <div class="grid gap-4 sm:grid-cols-2">
+            {#each [{ side: 'top' as const, label: 'Top' }, { side: 'right' as const, label: 'Right' }, { side: 'bottom' as const, label: 'Bottom' }, { side: 'left' as const, label: 'Left' }] as item (item.side)}
+                <div
+                    class="flex items-center justify-center rounded-lg bg-surface-container-high p-6"
+                >
+                    <DropdownMenu
+                        items={basicItems.slice(0, 4)}
+                        arrow
+                        align="center"
+                        side={item.side}
+                    >
+                        {#snippet children({ props })}
+                            <Button {...props} variant="soft">{item.label}</Button>
+                        {/snippet}
+                    </DropdownMenu>
+                </div>
+            {/each}
+        </div>
+        <div class="flex flex-wrap items-center gap-4 rounded-lg bg-surface-container-high p-6">
+            {#each [{ label: 'Small', size: { width: 8, height: 4 } }, { label: 'Default', size: { width: 12, height: 6 } }, { label: 'Large', size: { width: 20, height: 10 } }] as item (item.label)}
+                <DropdownMenu items={basicItems.slice(0, 4)} arrow={item.size} align="center">
+                    {#snippet children({ props })}
+                        <Button {...props} variant="outline">{item.label}</Button>
+                    {/snippet}
+                </DropdownMenu>
+            {/each}
+        </div>
+    </section>
+
     <!-- Sizes -->
     <section class="space-y-3">
         <h2 class="text-lg font-semibold">Sizes</h2>


### PR DESCRIPTION
Patch release fixing the arrow outline on DropdownMenu and Popover.

## Fixed

- **DropdownMenu**, **Popover**: the arrow now carries its own outline. Previously the arrow was a borderless filled triangle, so the content ring stopped dead at the arrow and the ring line ran straight across the arrow's base. The arrow now renders two paths: a fill that masks the ring across its base, and a stroked path along the two slanted edges in the same color as the content ring, so the outline flows continuously around the arrow.
- New `arrowBorder` `ui` slot on both components for overriding that stroke.
- Tooltip is unaffected: its surface has no ring, so a solid arrow is correct there.

## Docs

- **DropdownMenu**: new Arrow section covering the four sides and custom `width`/`height`, aligned to `center` so the arrow sits under the middle of the menu.

## Verification

- 3521 tests pass across 99 files, including 4 new tests covering the border path geometry and the ring mask on both components
- `svelte-check`: 0 errors, 0 warnings; `eslint`: clean
- `npm run build` + `publint`: clean, and the fix is present in the packaged `dist` output
- Automated DOM geometry sweep over 22 cases (2 themes x 4 sides x 3 arrow sizes, both components) asserting: arrow centered on the trigger within 1.5px, base flush to the content edge within 0.6px, stroke color matching the content ring, arrow not hidden
- Collision behavior checked on a 420px viewport where the menu flips side: the arrow still renders correctly