### PR TITLE
fix(image-cropper): review findings from the 2.7.0 documentation pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,23 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Editor** — `imageCrop` puts the cropper in front of `onImageUpload`, so what leaves the browser is the crop rather than the original. It covers every route that produces a file: the toolbar picker, a paste and a drop. Pass an object to set the aspect, shape, mode, dialog wording and output limits; cancelling uploads nothing, and images inserted by URL are left alone.
-- **ImageCropper** — client-side image cropper with two interaction models: `mode="fixed"` pans and zooms the image behind a centred frame, `mode="box"` gives a draggable frame with eight resize handles. Drag, pinch, wheel and keyboard control, rotate and flip, `aspect` ratios (including `'free'`), `shape="circle"` and a rule-of-thirds `grid`. `src` takes a URL, `File` or `Blob`; `crop()` renders the selection on a canvas and returns a `Blob` and a `File` at the source resolution, with `output` size and format limits, `autoCrop` for live results, and two-way `bind:area` to reopen a stored crop. 5 sizes, 8 colors, 16 `ui` slots, plus `labels` and `icons` overrides.
-- **useSessionStorage** — the storage hook backed by `sessionStorage`, for state that should live for the life of the tab.
-- **usePointerDrag** — pointer dragging with the parts every component gets wrong: pointer capture with a `window` fallback, moves coalesced to one update per frame, and the final position always flushed on release so the result matches the pointer. Reports `dx`/`dy` measured from the start of the gesture, locks to one `axis`, lets `onStart` return `false` to decline a drag, and ends the gesture if the component becomes disabled while it runs. `axis` and `disabled` accept a getter, so a component whose orientation or state changes at runtime stays correct.
-- **Resizable** — split a layout into draggable panes, horizontally or vertically, nested freely. Sizes are percentages that always add up to 100 so a split survives a window resize, while `minSize` and `maxSize` also accept pixels; a drag cascades into the next pane once a neighbour hits its minimum, and a `collapsible` pane snaps shut and springs back. Each handle is a `role="separator"` driven by arrows, Home, End and Enter. `storageKey` remembers the split, `bind:sizes` and an `api` (`collapse`, `expand`, `toggle`, `resize`, `setSizes`, `reset`) drive it from outside, `resizable: false` pins a pane, plus a `handle` snippet, 8 colors, 5 thicknesses and `ui` overrides.
+- **ImageCropper** — client-side image cropper: `mode="fixed"` pans and zooms behind a centred frame, `mode="box"` drags a frame with eight handles. Rotate, flip, `aspect` ratios, `shape="circle"`, wheel and keyboard control; `crop()` returns a `Blob` and a `File` at source resolution. 5 sizes, 8 colors, 16 `ui` slots. ([#202](https://github.com/ndlabdev/sv5ui/pull/202))
+- **Resizable** — draggable panes, horizontal or vertical, nestable. Percentage sizes that survive a window resize, `minSize`/`maxSize` in px or %, collapsible panes, keyboard-driven separators, `storageKey` persistence, `bind:sizes` and an imperative `api`. ([#205](https://github.com/ndlabdev/sv5ui/pull/205))
+- **usePointerDrag** — shared drag hook: pointer capture with a `window` fallback, one update per frame, the final position flushed on release, optional `axis` lock. ([#204](https://github.com/ndlabdev/sv5ui/pull/204))
+- **useSessionStorage** — the storage hook backed by `sessionStorage`. ([#203](https://github.com/ndlabdev/sv5ui/pull/203))
+- **Editor** — `imageCrop` opens the cropper before `onImageUpload`, for the toolbar picker, a paste and a drop alike. ([#210](https://github.com/ndlabdev/sv5ui/pull/210))
 
 ### Changed
 
-- **useLocalStorage** — the key may now be a getter, and a `null` key turns the hook inert, so a component can offer opt-in persistence without branching. Adds `storage: 'local' | 'session'`, a `remove()` that deletes the entry instead of writing the initial value back, and an `enabled` flag. Existing calls are unchanged.
-- **ColorPicker** — the saturation area now drags through `usePointerDrag` instead of its own pointer handling. Behaviour is unchanged.
-- **Form** — `validateOn: 'focus'` now waits for the first blur before it reports an error, the same rule `input` already followed. Focusing a field, whether by tabbing through a form or because a dialog focused it on open, no longer paints untouched fields red; coming back to a field the user already left wrong still re-checks it. A field can opt back into validating on its very first focus with `eagerValidation`.
-- **Editor** — the link, image and YouTube dialogs now read as forms: a labelled, required URL field with a matching icon and help text, and, for links, an optional **Display text** field prefilled from the selection. Inserting with a display text replaces the selected text, and inserting with nothing selected now uses the URL as its own label instead of leaving the document unchanged. The dialog says "Edit link" and "Update" when the cursor sits inside an existing link.
+- **useLocalStorage** — the key may be a getter, and a `null` key turns the hook inert. Adds `storage`, `remove()` and `enabled`; existing calls are unchanged. ([#203](https://github.com/ndlabdev/sv5ui/pull/203))
+- **ColorPicker** — the saturation area drags through `usePointerDrag`. Behaviour is unchanged. ([#204](https://github.com/ndlabdev/sv5ui/pull/204))
+- **Form** — `validateOn: 'focus'` waits for the first blur before reporting an error, the rule `input` already followed. `eagerValidation` opts a field back in. ([#207](https://github.com/ndlabdev/sv5ui/pull/207))
+- **Editor** — the link, image and YouTube dialogs read as forms: labelled required URL field with help text, plus an optional **Display text** for links. ([#208](https://github.com/ndlabdev/sv5ui/pull/208))
 
 ### Fixed
 
-- **Editor** — the Insert link dialog no longer opens with "URL is required" already showing. The prompt focused the url field itself while the dialog was moving focus to its first element, and the resulting blur made the form validate a field the user had never touched. The prompt now takes over the dialog's own opening focus instead of racing it.
-- **Editor** — pasting or dropping an image file now calls `onImageUpload`, which the props documented but nothing implemented: the handler was only ever reached through the toolbar's file picker. Every image in one paste is uploaded, a drop inserts at the position it was released, a paste without image files is left to the editor, and failures still go through `onImageUploadError`.
+- **Editor** — the Insert link dialog no longer opens with "URL is required" already showing. ([#206](https://github.com/ndlabdev/sv5ui/pull/206))
+- **Editor** — pasting or dropping an image now calls `onImageUpload`; only the toolbar picker did before. ([#209](https://github.com/ndlabdev/sv5ui/pull/209))
 
 ## [2.6.1] - 2026-08-26
 

--- a/src/lib/components/Editor/Editor.svelte.spec.ts
+++ b/src/lib/components/Editor/Editor.svelte.spec.ts
@@ -1183,6 +1183,27 @@ describe('Editor', () => {
             expect(uploaded.type).toBe('image/png')
         })
 
+        it('keeps the whole image when the user confirms without dragging', async () => {
+            const onImageUpload = vi.fn().mockResolvedValue('https://cdn.test/a.png')
+            const { container } = render(Editor, { image: true, imageCrop: true, onImageUpload })
+            await vi.waitFor(() => expect(getProseMirror(container)).not.toBeNull())
+
+            pasteFile(container, await pngFile())
+            await vi.waitFor(() => expect(cropDialog()).not.toBeNull())
+            await vi.waitFor(() =>
+                expect(document.querySelector('[role="dialog"] img')).not.toBeNull()
+            )
+            await vi.waitFor(() => expect(dialogButton('Insert')).toBeDefined())
+            dialogButton('Insert')!.click()
+
+            await vi.waitFor(() => expect(onImageUpload).toHaveBeenCalledTimes(1))
+            const uploaded = onImageUpload.mock.calls[0][0] as File
+            const bitmap = await createImageBitmap(uploaded)
+
+            expect(bitmap.width).toBe(48)
+            expect(bitmap.height).toBe(32)
+        })
+
         it('uploads nothing when the user cancels the crop', async () => {
             const onImageUpload = vi.fn()
             const { container } = render(Editor, { image: true, imageCrop: true, onImageUpload })

--- a/src/lib/components/Editor/EditorImageCropDialog.svelte
+++ b/src/lib/components/Editor/EditorImageCropDialog.svelte
@@ -71,6 +71,7 @@
                 src={file}
                 mode={options?.mode ?? 'box'}
                 aspect={options?.aspect ?? 'free'}
+                initialFrame="full"
                 shape={options?.shape ?? 'rect'}
                 grid
                 output={{ ...options?.output, type: outputType }}

--- a/src/lib/components/ImageCropper/ImageCropper.svelte
+++ b/src/lib/components/ImageCropper/ImageCropper.svelte
@@ -20,6 +20,7 @@
         areaEquals,
         centerForArea,
         centerFrameWithin,
+        FREE_FRAME_SCALE,
         clamp,
         computeFrame,
         constrainCenter,
@@ -114,6 +115,7 @@
         disabled = false,
         icons,
         label = 'Image cropper',
+        initialFrame = 'inset',
         labels,
         placeholder,
         toolbarSlot,
@@ -259,7 +261,13 @@
         })
     )
 
-    const boxFrame: Rect = $derived(centerFrameWithin(cropBounds, resolvedAspect))
+    const boxFrame: Rect = $derived(
+        centerFrameWithin(
+            cropBounds,
+            resolvedAspect,
+            initialFrame === 'full' ? 1 : FREE_FRAME_SCALE
+        )
+    )
     const cropRect: Rect = $derived(mode === 'box' ? (boxRect ?? boxFrame) : fixedFrame)
 
     let sliderRotation = $state(0)
@@ -414,10 +422,27 @@
         applyNatural(event.currentTarget as HTMLImageElement)
     }
 
+    function isCrossOrigin(value: string): boolean {
+        try {
+            const url = new URL(value, window.location.href)
+            if (url.protocol !== 'http:' && url.protocol !== 'https:') return false
+
+            return url.origin !== window.location.origin
+        } catch {
+            return false
+        }
+    }
+
     function handleImageError() {
         natural = { width: 0, height: 0 }
         failed = true
-        onError?.({ code: 'load', message: 'The image failed to load' })
+
+        const needsCors = crossorigin !== null && !!resolvedSrc && isCrossOrigin(resolvedSrc)
+        const hint = needsCors
+            ? ' A cross-origin image needs an Access-Control-Allow-Origin header.'
+            : ''
+
+        onError?.({ code: 'load', message: `The image failed to load.${hint}` })
     }
 
     let seenSrc: string | null = null

--- a/src/lib/components/ImageCropper/ImageCropper.svelte.spec.ts
+++ b/src/lib/components/ImageCropper/ImageCropper.svelte.spec.ts
@@ -380,6 +380,21 @@ describe('ImageCropper', () => {
             expect(api().area.x).toBeGreaterThan(before.x)
         })
 
+        it('should open a free frame inset from the image', async () => {
+            const api = await renderLoaded({ mode: 'box', aspect: 'free' })
+
+            expect(api().area.width).toBeLessThan(60)
+            expect(api().area.height).toBeLessThan(40)
+            expect(api().area.x).toBeGreaterThan(0)
+        })
+
+        it('should open on the whole image when initialFrame is full', async () => {
+            const api = await renderLoaded({ mode: 'box', aspect: 'free', initialFrame: 'full' })
+
+            expect(api().area.width).toBeCloseTo(60, 0)
+            expect(api().area.height).toBeCloseTo(40, 0)
+        })
+
         it('should resize the crop frame from a handle', async () => {
             const api = await renderLoaded({ mode: 'box', aspect: 'free' })
             const before = { ...api().area }
@@ -1077,6 +1092,28 @@ describe('ImageCropper', () => {
 
             await vi.waitFor(() =>
                 expect(onError).toHaveBeenCalledWith(expect.objectContaining({ code: 'load' }))
+            )
+        })
+
+        it('should not blame CORS for a same-origin failure', async () => {
+            const onError = vi.fn()
+            render(ImageCropper, { props: { src: 'data:image/png;base64,not-an-image', onError } })
+
+            await vi.waitFor(() => expect(onError).toHaveBeenCalled())
+            expect(onError.mock.calls[0][0].message).not.toContain('Access-Control-Allow-Origin')
+        })
+
+        it('should point at CORS when a cross-origin image fails to load', async () => {
+            const onError = vi.fn()
+            render(ImageCropper, { props: { src: 'http://127.0.0.1:1/missing.png', onError } })
+
+            await vi.waitFor(() =>
+                expect(onError).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        code: 'load',
+                        message: expect.stringContaining('Access-Control-Allow-Origin')
+                    })
+                )
             )
         })
     })

--- a/src/lib/components/ImageCropper/image-cropper.types.ts
+++ b/src/lib/components/ImageCropper/image-cropper.types.ts
@@ -55,6 +55,12 @@ export interface ImageCropperError {
 export interface ImageCropperOutput {
     /**
      * MIME type of the produced blob.
+     *
+     * PNG is the default so a circular crop, or any source with an alpha
+     * channel, survives the export. The crop is written at the source
+     * resolution, so a large photo produces a multi-megabyte file: for avatars
+     * and covers, pair this with `maxWidth` or switch to `image/jpeg`.
+     *
      * @default 'image/png'
      */
     type?: 'image/png' | 'image/jpeg' | 'image/webp'
@@ -168,7 +174,8 @@ export type ImageCropperProps = Omit<
 
     /**
      * Aspect ratio of the crop frame as `width / height`, or `'free'` to let the
-     * user resize both axes independently (`box` mode only).
+     * user resize both axes independently (`box` mode only). A `'free'` frame
+     * opens inset from the image, so the crop region is visible from the start.
      *
      * Ignored when `shape` is `'circle'`, which always crops 1:1.
      *
@@ -279,6 +286,21 @@ export type ImageCropperProps = Omit<
     padding?: number
 
     /**
+     * Where the crop frame starts in `box` mode with a free `aspect`.
+     *
+     * - `inset`: slightly smaller than the image, so the crop region reads as a
+     *   frame the moment the cropper opens
+     * - `full`: the whole image, so confirming without dragging keeps
+     *   everything. Use it when the cropper sits in an upload flow where a
+     *   silent crop would be surprising.
+     *
+     * A fixed `aspect` always opens at the largest frame that fits.
+     *
+     * @default 'inset'
+     */
+    initialFrame?: 'inset' | 'full'
+
+    /**
      * Smallest allowed crop frame size in pixels (`box` mode only).
      * @default 48
      */
@@ -314,7 +336,13 @@ export type ImageCropperProps = Omit<
 
     /**
      * `crossorigin` attribute for the underlying `<img>`. Required when cropping
-     * a remote image, otherwise the canvas is tainted and the export fails.
+     * a remote image.
+     *
+     * With the default, a host that sends no `Access-Control-Allow-Origin`
+     * header fails the image request itself: the image never appears and
+     * `onError` reports `load`. With `null` the image displays, but the canvas
+     * is tainted and the export fails with `tainted`.
+     *
      * @default 'anonymous'
      */
     crossorigin?: 'anonymous' | 'use-credentials' | null

--- a/src/lib/components/ImageCropper/image-cropper.utils.spec.ts
+++ b/src/lib/components/ImageCropper/image-cropper.utils.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
     applyTransform,
+    centerFrameWithin,
     clamp,
     clampRectWithin,
     computeFrame,
@@ -204,6 +205,23 @@ describe('image cropper frame', () => {
             width: 360,
             height: 160
         })
+    })
+
+    it('insets a free box frame so the image shows around it', () => {
+        const bounds = { x: 10, y: 20, width: 400, height: 200 }
+
+        expect(centerFrameWithin(bounds, 'free')).toEqual({
+            x: 50,
+            y: 40,
+            width: 320,
+            height: 160
+        })
+    })
+
+    it('keeps a fixed aspect box frame centred inside the image', () => {
+        const bounds = { x: 0, y: 0, width: 400, height: 200 }
+
+        expect(centerFrameWithin(bounds, 1)).toEqual({ x: 100, y: 0, width: 200, height: 200 })
     })
 
     it('clamps a rect inside its bounds', () => {

--- a/src/lib/components/ImageCropper/image-cropper.utils.ts
+++ b/src/lib/components/ImageCropper/image-cropper.utils.ts
@@ -65,6 +65,8 @@ export function containScale(natural: Size, area: Size, rotation: number): numbe
 
 export const EDGE_MARGIN = 1
 
+export const FREE_FRAME_SCALE = 0.8
+
 function inflate(size: Size, margin: number): Size {
     return { width: size.width + margin * 2, height: size.height + margin * 2 }
 }
@@ -262,8 +264,22 @@ export function clampRectWithin(rect: Rect, bounds: Rect): Rect {
     }
 }
 
-export function centerFrameWithin(bounds: Rect, aspect: number | 'free'): Rect {
-    if (aspect === 'free' || aspect <= 0) return { ...bounds }
+export function centerFrameWithin(
+    bounds: Rect,
+    aspect: number | 'free',
+    freeScale: number = FREE_FRAME_SCALE
+): Rect {
+    if (aspect === 'free' || aspect <= 0) {
+        const freeWidth = bounds.width * freeScale
+        const freeHeight = bounds.height * freeScale
+
+        return {
+            x: bounds.x + (bounds.width - freeWidth) / 2,
+            y: bounds.y + (bounds.height - freeHeight) / 2,
+            width: freeWidth,
+            height: freeHeight
+        }
+    }
 
     let width = bounds.width
     let height = width / aspect

--- a/src/lib/components/Resizable/Resizable.svelte
+++ b/src/lib/components/Resizable/Resizable.svelte
@@ -62,7 +62,7 @@
         )
     )
     let activeHandle = $state<number | null>(null)
-    const paneEls: (HTMLElement | null)[] = []
+    let paneEls = $state<(HTMLElement | null)[]>([])
 
     const resolvedDirection = $derived<'horizontal' | 'vertical'>(direction ?? 'horizontal')
 

--- a/src/routes/image-cropper/+page.svelte
+++ b/src/routes/image-cropper/+page.svelte
@@ -199,7 +199,9 @@
         <div class="flex items-baseline justify-between gap-2">
             <h2 class="text-lg font-semibold">Crop box</h2>
             <p class="text-xs text-on-surface-variant">
-                mode="box" · drag the frame, resize the handles, drag outside to pan
+                mode="box" · drag the frame, resize the handles, drag outside to pan. A free aspect
+                opens inset from the image; pass initialFrame="full" to start on the whole image
+                instead.
             </p>
         </div>
         <div


### PR DESCRIPTION
## Summary

Three defects found while writing the 2.7.0 documentation, plus the CHANGELOG tidy-up for the same release. All of them are in code that has not shipped yet, so nothing here changes behaviour for an installed version.

The second finding turned out to hide a worse one: insetting the free crop frame makes the Editor upload dialog crop every image by default, so the frame origin is now an explicit prop and the Editor opts out of it.

Closes #211

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature / component
- [x] 📖 Documentation
- [ ] ♻️ Refactor / chore
- [ ] ⚠️ Breaking change

## Changes

- **Resizable**: `paneEls` is reactive state, so `bind:this` no longer logs `binding_property_non_reactive` once per pane on every render. The spec alone printed 258 warning lines.
- **ImageCropper**: with `mode="box"` and `aspect="free"` the crop frame opened on the image bounds, so nothing read as a frame and the arrow keys had nowhere to move. It now opens inset.
- **ImageCropper**: new `initialFrame` prop, `'inset'` by default, `'full'` to select the whole image from the start.
- **Editor**: the crop dialog passes `initialFrame="full"`. Without it, confirming without dragging would quietly upload 64% of the image.
- **ImageCropper**: a `load` error on a cross-origin http(s) source now names the missing Access-Control-Allow-Origin header. `data:` and `blob:` sources are untouched.
- **Docs**: JSDoc for `initialFrame`, `output.type`, `crossorigin` and `aspect`, plus a note on the crop box demo page.
- **CHANGELOG**: unreleased entries cut to one or two sentences each with their PR links, Added list led by the new components.

## Checklist

- [x] Linked the related issue (`Closes #…`)
- [x] `pnpm check` passes (0 errors, 0 warnings)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added or updated tests for the change
- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] Followed component conventions (no comments outside `*.types.ts`, Material 3 design tokens)

## Screenshots / notes

**Tests:** 3812 passing across 106 files, 6 new.

- 2 for `centerFrameWithin`: a free frame is inset, a fixed aspect stays centred at full size
- 2 for `initialFrame`: `'inset'` reports an area smaller than the source, `'full'` reports the source size
- 1 for the CORS hint, 1 asserting a same-origin `data:` failure is not blamed on CORS
- 1 for the Editor: pasting a 48x32 image and confirming the dialog uploads 48x32

**Verification:** every fix was proven by reverting it first.

- Resizable warning: 258 lines before, 0 after, 60/60 spec tests unchanged
- Editor crop: without `initialFrame="full"` the uploaded file is 38x26 instead of 48x32
- The CORS hint test caught a bug in the first version of the fix: `new URL('data:...').origin` is `"null"`, so `data:` sources were being flagged as cross-origin. The check is now limited to http and https.

**Decision recorded, no change made:** `output` still defaults to PNG at source resolution, which can reach about 2 MB for an avatar. PNG is the only default that keeps a circular crop and an alpha channel intact, and following the source format instead would turn a size trap into a rendering one, since a circular JPEG comes out with filled corners. Documented in the `output.type` JSDoc. If it is ever revisited, the safe shape is "follow the source format unless `shape` is `circle`".

**Not covered:** Chromium only, no real touch device, and the paste path builds its `DataTransfer` directly rather than going through the operating system clipboard.
