### PR TITLE
test(editor): wait for the cropper to decode before confirming

### DIFF
--- a/src/lib/components/Editor/Editor.svelte.spec.ts
+++ b/src/lib/components/Editor/Editor.svelte.spec.ts
@@ -1135,6 +1135,9 @@ describe('Editor', () => {
                 '[role="dialog"] [aria-label="Image cropper"]'
             ) as HTMLElement | null
 
+        const cropperReady = () =>
+            document.querySelector('[role="dialog"] [data-handle="se"]') as HTMLElement | null
+
         const dialogButton = (label: string) =>
             Array.from(document.querySelectorAll('[role="dialog"] button')).find(
                 (button) => button.textContent?.trim() === label
@@ -1169,11 +1172,9 @@ describe('Editor', () => {
 
             pasteFile(container, await pngFile())
             await vi.waitFor(() => expect(cropDialog()).not.toBeNull())
-            // wait for the cropper to decode the image, otherwise there is
-            // nothing to crop and the dialog stays open
-            await vi.waitFor(() =>
-                expect(document.querySelector('[role="dialog"] img')).not.toBeNull()
-            )
+            // the resize handles only render once the image is decoded, so this
+            // is the point where there is something to crop
+            await vi.waitFor(() => expect(cropperReady()).not.toBeNull())
             await vi.waitFor(() => expect(dialogButton('Insert')).toBeDefined())
             dialogButton('Insert')!.click()
 
@@ -1190,9 +1191,7 @@ describe('Editor', () => {
 
             pasteFile(container, await pngFile())
             await vi.waitFor(() => expect(cropDialog()).not.toBeNull())
-            await vi.waitFor(() =>
-                expect(document.querySelector('[role="dialog"] img')).not.toBeNull()
-            )
+            await vi.waitFor(() => expect(cropperReady()).not.toBeNull())
             await vi.waitFor(() => expect(dialogButton('Insert')).toBeDefined())
             dialogButton('Insert')!.click()
 


### PR DESCRIPTION
## Summary

`dev` went red right after #212 merged, on a test that #212 added. The library is fine: the tests confirmed the crop dialog before the browser had decoded the image.

The Insert click was gated on an `<img>` existing inside the dialog, but that element appears as soon as `src` is assigned. On a slower machine the click landed while the cropper still reported nothing loaded, so `crop()` resolved to `null`, the dialog stayed open and no upload happened.

Closes #213

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature / component
- [ ] 📖 Documentation
- [ ] ♻️ Refactor / chore
- [ ] ⚠️ Breaking change

## Changes

- Both crop tests wait for a resize handle inside the dialog instead of an `<img>`. `showHandles` requires `loaded`, so the handle cannot exist before there is something to crop.
- The same wait is applied to `uploads the cropped file once the user confirms`, which had the identical latent race and simply won the coin toss on every run so far.

## Checklist

- [x] Linked the related issue (`Closes #…`)
- [x] `pnpm check` passes (0 errors, 0 warnings)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Added or updated tests for the change
- [ ] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] Followed component conventions (no comments outside `*.types.ts`, Material 3 design tokens)

No CHANGELOG entry: this is a test-only change to code that has not shipped, so there is nothing for a reader of the release notes to learn.

## Screenshots / notes

**Why this is a real fix and not a longer timeout:** the old marker could be true before the condition the test depends on. The new one cannot: `showHandles` is `mode === 'box' && shape === 'rect' && loaded && !disabled`, so a handle in the DOM means the image is decoded and the crop frame exists.

**Verification:** the `crop before upload` group ran 5 times in a row, 6 of 6 passing each time; the full Editor suite passes 89 of 89.

**Failure this fixes:** run 33950995803 on `dev`, 3811 of 3812 passing, `keeps the whole image when the user confirms without dragging` reporting `onImageUpload` called 0 times.
